### PR TITLE
Make sure that dependencies for Haskell test suites are installed

### DIFF
--- a/lib/travis/build/job/test/haskell.rb
+++ b/lib/travis/build/job/test/haskell.rb
@@ -13,11 +13,11 @@ module Travis
           end
 
           def install
-            "cabal update && cabal install"
+            "cabal update && cabal install --enable-tests"
           end
 
           def script
-            "cabal configure --enable-tests && cabal build && cabal test"
+            "cabal test"
           end
 
           protected

--- a/spec/build/job/test/haskell_spec.rb
+++ b/spec/build/job/test/haskell_spec.rb
@@ -8,14 +8,14 @@ describe Travis::Build::Job::Test::Haskell do
 
   describe 'install' do
     it "uses cabal" do
-      job.install.should == "cabal update && cabal install"
+      job.install.should == "cabal update && cabal install --enable-tests"
     end
   end
 
 
   describe 'script' do
     it "uses cabal" do
-      job.script.should == "cabal configure --enable-tests && cabal build && cabal test"
+      job.script.should == "cabal test"
     end
   end
 end


### PR DESCRIPTION
That way the test suite is already build on install, so we only run it
on script (this should also be somewhat faster).
