### PR TITLE
[Scala] By default, use Scala version configured by SBT (unless a build matrix is defined in .travis.yml)

### DIFF
--- a/features/test_scala.feature
+++ b/features/test_scala.feature
@@ -2,16 +2,45 @@ Feature: Testing a Scala project
 
   Background:
    Given the following test payload
-     | repository | travis-ci/travis-ci             |
-     | commit     | 1234567                         |
+     | repository | travis-ci/travis-ci                         |
+     | commit     | 1234567                                     |
      | config     | language: scala, scala: 2.9.1, env: FOO=foo |
 
+  Scenario: A successful SBT build without forcing Scala version 
+   Given the following test payload
+     | repository | travis-ci/travis-ci                         |
+     | commit     | 1234567                                     |
+     | config     | language: scala, env: FOO=foo               |
+
+    When it starts a job
+    Then it exports the given environment variables
+     And it successfully clones the repository to the build dir with git 
+     And it successfully checks out the commit with git to the repository directory
+     And it exports the line TRAVIS_SCALA_VERSION=undefined
+     # think ./project          
+     And it finds directory project
+     And it successfully runs the script: sbt test
+     And it closes the ssh session
+     And it returns the status 0
+     And it has captured the following events
+       | name            | data                                | 
+       | job:test:start  | started_at: [now]                   |
+       | job:test:log    | log: /Using worker/                 | 
+       | job:test:log    | log: cd ~/builds                    |
+       | job:test:log    | log: export FOO=foo                 | 
+       | job:test:log    | log: git clone                      |
+       | job:test:log    | log: cd travis-ci/travis-ci         |
+       | job:test:log    | log: git checkout                   |
+       | job:test:log    | log: /export TRAVIS_SCALA_VERSION=/ |
+       | job:test:log    | log: sbt test                       |
+       | job:test:log    | log: /Done.* 0/                     |
+       | job:test:finish | finished_at: [now], status: 0       |
+  
   Scenario: A successful build with ./project directory in the repository root
     When it starts a job
     Then it exports the given environment variables
      And it successfully clones the repository to the build dir with git
      And it successfully checks out the commit with git to the repository directory
-     And it exports the line SCALA_VERSION=2.9.1
      And it exports the line TRAVIS_SCALA_VERSION=2.9.1
      # think ./project
      And it finds directory project
@@ -27,7 +56,6 @@ Feature: Testing a Scala project
        | job:test:log    | log: git clone                      |
        | job:test:log    | log: cd travis-ci/travis-ci         |
        | job:test:log    | log: git checkout                   |
-       | job:test:log    | log: /export SCALA_VERSION=/        |
        | job:test:log    | log: /export TRAVIS_SCALA_VERSION=/ |
        | job:test:log    | log: sbt ++2.9.1 test               |
        | job:test:log    | log: /Done.* 0/                     |
@@ -38,7 +66,6 @@ Feature: Testing a Scala project
     Then it exports the given environment variables
      And it successfully clones the repository to the build dir with git
      And it successfully checks out the commit with git to the repository directory
-     And it exports the line SCALA_VERSION=2.9.1
      And it exports the line TRAVIS_SCALA_VERSION=2.9.1
      And it does not find directory project
      And it finds the file build.sbt
@@ -54,12 +81,10 @@ Feature: Testing a Scala project
        | job:test:log    | log: git clone                      |
        | job:test:log    | log: cd travis-ci/travis-ci         |
        | job:test:log    | log: git checkout                   |
-       | job:test:log    | log: /export SCALA_VERSION=/        |
        | job:test:log    | log: /export TRAVIS_SCALA_VERSION=/ |
        | job:test:log    | log: sbt ++2.9.1 test               |
        | job:test:log    | log: /Done.* 0/                     |
        | job:test:finish | finished_at: [now], status: 0       |
-
 
   Scenario: The repository can not be cloned
     When it starts a job
@@ -81,7 +106,6 @@ Feature: Testing a Scala project
     Then it exports the given environment variables
      And it successfully clones the repository to the build dir with git
      And it successfully checks out the commit with git to the repository directory
-     And it exports the line SCALA_VERSION=2.9.1
      And it exports the line TRAVIS_SCALA_VERSION=2.9.1
      # think ./project
      And it finds directory project

--- a/spec/build/job/test/scala_spec.rb
+++ b/spec/build/job/test/scala_spec.rb
@@ -7,23 +7,22 @@ describe Travis::Build::Job::Test::Scala do
   let(:job)    { described_class.new(shell, nil, config) }
 
   describe 'config' do
-    it 'defaults :scala to "2.9.1"' do
-      config.scala.should == '2.9.1'
+    it 'defaults :scala to "undefined"' do
+      config.scala.should == 'undefined'
     end
   end
 
   describe 'setup' do
     it 'exports the Scala version to use for the build and announces it, without any validation' do
       config.scala = '0.0.7' # version validity is not verified
-      shell.expects(:export_line).with('SCALA_VERSION=0.0.7')
       shell.expects(:export_line).with('TRAVIS_SCALA_VERSION=0.0.7')
-      shell.expects(:echo).with('Using Scala 0.0.7')
+      shell.expects(:echo).with("Expect to run tests with Scala version '0.0.7'")
       job.setup
     end
   end
 
   describe 'script' do
-    context "when configured to use SBT 2.8.2" do
+    context "when configured to use Scala 2.8.2 with SBT" do
       it 'returns "sbt ++2.8.2 test"' do
         config.scala = '2.8.2'
         job.expects(:uses_sbt?).returns(true)
@@ -31,7 +30,15 @@ describe Travis::Build::Job::Test::Scala do
       end
     end
 
-    context "when SBT is not used by the project" do
+    context "when configured to use SBT without precising any Scala version" do
+      it 'returns "sbt test"' do
+        config.scala = 'undefined'
+        job.expects(:uses_sbt?).returns(true)
+        job.send(:script).should == 'sbt test'
+      end
+    end    
+
+    context "when sbt is not used by the project" do
       it 'falls back to Maven' do
         job.expects(:uses_sbt?).returns(false)
         job.send(:script).should == 'mvn test'


### PR DESCRIPTION
Since Scala projects are growing on Travis, I would like to propose following changes
- major: project built with SBT that does not explicitly require a specific Scala version in .travis.yml should be built according to SBT settings (build.sbt and /project/*)
- minor: Try to make clearer that **Using Scala x.y.z** message is more an expectation, rather than a fact
- minor: remove duplicated environment variable SCALA_VERSION
### Details about the changes:
- For SBT: don't force the Scala 2.9.1 by default, but use the version
  defined in SBT own settings. 
  - I think it's definitively better to rely on sbt settings, unless we explicitly require a build-matrix in .travis.yml.
  - Since sbt can automatically download and use any Scala release (e.g. 2.9.2, 2.10.0-M2,...), it will save us the painful administration task to upgrade the default version of the travis-scala builder.
  - Maybe it breaks the convention, that Travis builder always set a **default version**. In this case **undefined** means **scala-version-managed-by-build-tool-own-configuration**.
  - Maybe there is a better keyword rather 'undefined', like _automatic_, _dynamic_, _unmanaged_,... (or even empty string "" ?)
- By the way, I also removed the export of SCALA_VERSION variable (duplicated by TRAVIS_SCALA_VERSION). This variable was designed before all builders were refactored to export TRAVIS_language_VERSION variable. The original variable is thus useless...
