### PR TITLE
Convert 'go get .' method to 'go get -d && go build'

### DIFF
--- a/lib/travis/build/job/test/go.rb
+++ b/lib/travis/build/job/test/go.rb
@@ -7,24 +7,18 @@ module Travis
           end
 
           def setup
-            # Here we set up GOPATH + subdirectories structure Go build tool expects
+            # Here we set up GOPATH + subdirectories structure Go build tool expects.
+            # We will just put dependencies here, as source only, via 'go get -d'.
+            # The 'go build' step will look for them here, and build them.
             shell.execute "mkdir -p #{gopath}/src"
-            # For example, cp -r ~/builds/peterbourgon/g2g ~/gopath/src/g2g. Unfortunately, go build
-            # tool does not like symlinks. MK.
-            shell.execute "cp -r #{home_directory}/builds/#{repository_slug} #{package_path_under_gopath}"
             shell.export_line "GOPATH=#{gopath}"
-            # this is not how we do it for all other languages but an experienced Go developer suggests
-            # this makes sense for Go projects. We still end up in the same directory as with other
-            # builders (in the local git repository root) but with `pwd` reporting a path under
-            # GOPATH. MK.
-            shell.execute "cd #{package_path_under_gopath}"
           end
 
           def install
             if uses_make?
               # no-op
             else
-              "go get -v ."
+              "go get -d -v && go build -v"
             end
           end
 
@@ -32,7 +26,7 @@ module Travis
             if uses_make?
               "make"
             else
-              "go test -v ."
+              "go test -v"
             end
           end
 
@@ -44,11 +38,6 @@ module Travis
 
             def gopath
               "#{home_directory}/gopath"
-            end
-
-            # GOPATH/src/[package] location
-            def package_path_under_gopath
-              "#{gopath}/src/#{repository_name}"
             end
         end
       end

--- a/spec/build/job/test/go_spec.rb
+++ b/spec/build/job/test/go_spec.rb
@@ -19,7 +19,7 @@ describe Travis::Build::Job::Test::Go do
     context "when Makefile DOES NOT exist" do
       it 'uses go get' do
         job.expects(:uses_make?).returns(false)
-        job.install.should == "go get -v ."
+        job.install.should == "go get -d -v && go build -v"
       end
     end
   end
@@ -33,9 +33,9 @@ describe Travis::Build::Job::Test::Go do
     end
 
     context "when Makefile DOES NOT exist" do
-      it 'returns "go test -v ."' do
+      it 'returns "go test -v"' do
         job.expects(:uses_make?).returns(false)
-        job.send(:script).should == 'go test -v .'
+        job.send(:script).should == 'go test -v'
       end
     end
   end


### PR DESCRIPTION
After some discussion on the mailing list and with some colleagues, I think this method is a lot more robust.

We still establish a GOPATH at an arbitrary location, but we no longer need to put the checked-out code in a specific location within it. Instead, we use GOPATH simply as a place to store downloaded dependencies (via `go get -d`) and, later, to look for them during the build step (via `go build`).

`go build` makes no demands on the location of the folder it's called in. It simply uses GOPATH to find referenced imports, and builds whatever artifacts it will build in-place.

I think this is a robust building method that should work well for any Go 1.x.x project. It closely tracks what happens when someone would `go get` a repo remotely, which is the canonical use-case for Go code and something Travis should take care not to conflict with.
