### PR TITLE
Make sure that dependencies for Haskell test suites are installed

### DIFF
--- a/lib/travis/build/job/test/haskell.rb
+++ b/lib/travis/build/job/test/haskell.rb
@@ -13,20 +13,11 @@ module Travis
           end
 
           def install
-
-            # Ideally we would use:
-            #
-            # "cabal update && cabal install --only-dependencies --enable-tests"
-            #
-            # But this does not properly work with cabal-install 0.10.2.
-            #
-            # http://www.haskell.org/pipermail/cabal-devel/2012-January/008428.html
-            #
-            "cabal update && cabal install"
+            "cabal update && cabal install --enable-tests"
           end
 
           def script
-            "cabal configure --enable-tests && cabal build && cabal test"
+            "cabal test"
           end
 
           protected

--- a/spec/build/job/test/haskell_spec.rb
+++ b/spec/build/job/test/haskell_spec.rb
@@ -10,14 +10,14 @@ describe Travis::Build::Job::Test::Haskell do
 
   describe 'install' do
     it "uses cabal" do
-      job.install.should == "cabal update && cabal install"
+      job.install.should == "cabal update && cabal install --enable-tests"
     end
   end
 
 
   describe 'script' do
     it "uses cabal" do
-      job.script.should == "cabal configure --enable-tests && cabal build && cabal test"
+      job.script.should == "cabal test"
     end
   end
 end


### PR DESCRIPTION
Now that we use Cabal 0.14.0, this finally works.
