### PR TITLE
Add a way to switch between virtualenvs with and without SSP

### DIFF
--- a/spec/build/job/test/python_spec.rb
+++ b/spec/build/job/test/python_spec.rb
@@ -35,6 +35,34 @@ describe Travis::Build::Job::Test::Python do
   end
 
 
+  describe 'setup with PyPy and virtualenv.system_site_packages enabled' do
+    let(:config) { Travis::Build::Job::Test::Python::Config.new(:python => "pypy", :virtualenv => {:system_site_packages => true}) }
+
+    it 'is treated as a special case' do
+      shell.expects(:export_line).with("TRAVIS_PYTHON_VERSION=pypy").returns(true)
+      shell.expects(:execute).with("source ~/virtualenv/pypy_with_system_site_packages/bin/activate").returns(true)
+      shell.expects(:execute).with("python --version").returns(true)
+      shell.expects(:execute).with("pip --version").returns(true)
+
+      job.setup
+    end
+  end
+
+
+  describe 'setup with 2.7 and virtualenv.system_site_packages enabled' do
+    let(:config) { Travis::Build::Job::Test::Python::Config.new(:python => "2.7", :virtualenv => {:system_site_packages => true}) }
+
+    it 'is treated as a special case' do
+      shell.expects(:export_line).with("TRAVIS_PYTHON_VERSION=2.7").returns(true)
+      shell.expects(:execute).with("source ~/virtualenv/python2.7_with_system_site_packages/bin/activate").returns(true)
+      shell.expects(:execute).with("python --version").returns(true)
+      shell.expects(:execute).with("pip --version").returns(true)
+
+      job.setup
+    end
+  end
+
+
   describe 'install' do
     context "when Requirements.txt is found in the repository root" do
       it "returns pip install -r Requirements.txt" do


### PR DESCRIPTION
We previously created only one virtualenv per Python, without --system-site-packages. However,
some dependencies cannot be installed via pip. So in the end we settled on having two sets
of virtualenvs and the way to alternate between them.

Depends on travis-cookbooks@54f5ad4f0e43438fee83efc08b30d88bc558839d being deployed (will be later today). 
