### PR TITLE
Support service dependencies (starting services via .travis.yml)

### DIFF
--- a/features/support/step_definitions.rb
+++ b/features/support/step_definitions.rb
@@ -119,6 +119,10 @@ Then /^it enables a service named "(.+)"$/ do |name|
     in_sequence($sequence)
 end
 
+Then /^it gives services a moment to start$/ do
+  $shell.expects(:execute).with("sleep 3").outputs("sleep 3").in_sequence($sequence)
+end
+
 Then /^it silently disables interactive git auth$/ do
   $shell.expects(:export).
     with('GIT_ASKPASS', 'echo', :echo => false).

--- a/features/test_services.feature
+++ b/features/test_services.feature
@@ -10,6 +10,7 @@ Feature: service dependencies
     When it starts a job
     Then it exports the given environment variables
     And it enables a service named "rabbitmq-server"
+    And it gives services a moment to start
     And it successfully clones the repository to the build dir with git
     And it successfully checks out the commit with git to the repository directory
     And it exports the line TRAVIS_JDK_VERSION=openjdk6
@@ -30,6 +31,7 @@ Feature: service dependencies
        | job:test:log    | log: export TRAVIS_JOB_ID=10              |
        | job:test:log    | log: export FOO=foo                       |
        | job:test:log    | log: sudo service rabbitmq-server start   |
+       | job:test:log    | log: sleep 3                              |
        | job:test:log    | log: git clone                            |
        | job:test:log    | log: cd travis-ci/travis-ci               |
        | job:test:log    | log: git checkout                         |

--- a/lib/travis/build/job/test.rb
+++ b/lib/travis/build/job/test.rb
@@ -109,9 +109,14 @@ module Travis
         end
 
         def start_services
-          Array(config.services || []).
-            map { |s| normalize_service(s) }.
-            each { |s| start_service(s) }
+          xs = Array(config.services || []).
+            map { |s| normalize_service(s) }
+
+          if xs.any?
+            xs.each { |s| start_service(s) }
+            # give services a moment to start
+            shell.execute "sleep 3"
+          end
         end
 
         def normalize_service(name)


### PR DESCRIPTION
## Background

Historically, projects that need various services (PostgreSQL, MySQL, RabbitMQ, etc) running either
relied on the fact that CI env had them started on boot or `before_install` steps (or similar).

This is about to change.
## The Change

As the number of services grows and more and more large-ish projects join Travis, it becomes more
and more obvious that we cannot have all those services started on boot and have enough RAM for
large test suites.

So we have a few options:
- Add more RAM to each VM
- Tune services to use less RAM
- Disable some services from being started on boot

We have been doing #2 and #3 for some time now but did not touch services that have always been
started on boot (e.g. MongoDB or RabbitMQ). #1 will also happen thanks to our next gen (BlueBox) VM infrastructure.

However, with BB we also move to 64 bit VMs and that largely eliminates some of the gains. The only
realistic scenario seems to be disabling more services on boot, leaving only MySQL and PostgreSQL running
by default.

When we do that, projects will have to tweak .travis.yml to enable those services. Using `sudo service ... start` is straightforward
but has some downsides
- You need to know exact service names. Apparently some developers do not know them and some services have irregular names.
- This makes hundreds if not thousands of .travis.yml files out there contain even more Linux/Debianoids-specific code.

In the end Josh and I settled on providing a way to list services in .travis.yml in a way that will let travis-build
handle irregular service names and (at some future point) OS differences.
## How It Works

``` yaml
services:
  - riak     # will start a service named riak
  - rabbimq  # will start a service named rabbitmq-server
  - memcache # will start a service named memcached
```

That's about it.
