### PR TITLE
Add after_failure and after_success, references #33

### DIFF
--- a/lib/travis/build/job/test.rb
+++ b/lib/travis/build/job/test.rb
@@ -223,7 +223,7 @@ module Travis
         log :run_command, :only => :before
 
         def commands_for(stage)
-          Array(config[stage] || (respond_to?(stage, true) ? __send__(stage) : nil))
+          Array(config[stage] || (respond_to?(stage, true) ? send(stage) : nil))
         end
 
         def run_after_success


### PR DESCRIPTION
after_failure covers any possible failure. Separating failures by stages sounds like too much
effort to very little gain. See #33.
