### PR TITLE
Add a config option to disable checking out submodules

### DIFF
--- a/lib/travis/build/factory.rb
+++ b/lib/travis/build/factory.rb
@@ -57,7 +57,7 @@ module Travis
         end
 
         def scm
-          @scm ||= Scm::Git.new(shell, payload.config)
+          @scm ||= Scm::Git.new(shell, Scm::Git::Config.new(payload.config))
         end
     end
   end

--- a/lib/travis/build/scm/git.rb
+++ b/lib/travis/build/scm/git.rb
@@ -7,9 +7,13 @@ module Travis
       class Git
         extend Assertions
 
+        class Config < Hashr
+          define :git => { :submodules => true }
+        end
+
         attr_reader :shell, :config
 
-        def initialize(shell, config = {})
+        def initialize(shell, config = Config.new)
           @shell = shell
           @config = config
         end
@@ -18,7 +22,7 @@ module Travis
           clone(source, target, branch, ref)
           chdir(target)
           checkout(sha, ref)
-          submodules if shell.file_exists?('.gitmodules')
+          submodules if checkout_submodules?
           true
         end
 
@@ -40,6 +44,10 @@ module Travis
 
           def chdir(target)
             shell.chdir(target)
+          end
+
+          def checkout_submodules?
+            shell.file_exists?('.gitmodules') && config[:git][:submodules]
           end
 
           def submodules

--- a/spec/build/scm/git_spec.rb
+++ b/spec/build/scm/git_spec.rb
@@ -50,5 +50,17 @@ describe Travis::Build::Scm::Git do
       shell.expects(:execute).with('git submodule update').returns(true)
       scm.fetch(source, target, sha, branch, ref)
     end
+
+    context 'submodules are turned off in the configuration' do
+      let(:scm) { described_class.new(shell, :git => { :submodules => false }) }
+
+      it 'does not set up submodules' do
+        shell.expects(:file_exists?).with('.gitmodules').returns(true)
+        shell.unstub(:execute)
+        shell.stubs(:execute).with { |command, *args| command !~ /submodule/ }.returns(true)
+
+        scm.fetch(source, target, sha, branch, ref)
+      end
+    end
   end
 end


### PR DESCRIPTION
By adding the following to the .travis.yml file, submodules will not be checked out:

``` YAML
git:
  submodules: false
```

This was discussed/requested in #19.
