### PR TITLE
Make the git clone depth configurable

### DIFF
--- a/lib/travis/build/scm/git.rb
+++ b/lib/travis/build/scm/git.rb
@@ -8,7 +8,7 @@ module Travis
         extend Assertions
 
         class Config < Hashr
-          define :git => { :submodules => true }
+          define :git => { :submodules => true, :depth => 100 }
         end
 
         attr_reader :shell, :config
@@ -37,7 +37,7 @@ module Travis
           assert :clone
 
           def clone_args(branch, ref)
-            args = ["--depth=100", "--quiet"]
+            args = ["--depth=#{config[:git][:depth]}", "--quiet"]
             args.unshift("--branch=#{branch}") unless ref
             args.join(' ')
           end

--- a/spec/build/scm/git_spec.rb
+++ b/spec/build/scm/git_spec.rb
@@ -62,5 +62,14 @@ describe Travis::Build::Scm::Git do
         scm.fetch(source, target, sha, branch, ref)
       end
     end
+
+    context 'with a custom --depth set in the configuration' do
+      let(:scm) { described_class.new(shell, :git => { :depth => 20 }) }
+
+      it 'clones with the set depth' do
+        shell.expects(:execute).with('git clone --branch=master --depth=20 --quiet git://example.com/travis-ci.git travis-ci').returns(true)
+        scm.fetch(source, target, sha, branch, ref)
+      end
+    end
   end
 end


### PR DESCRIPTION
@joshk suggested this in IRC. In many cases, a clone depth of 100
is not necessary. Reducing the clone depth may decrease the time it
takes to clone a repository.

The option can be set by adding the following to the .travis.yml
file:

``` YAML
git:
  depth: 20
```

Since we added `--branch` to the clone, I think we can safely turn the default down from 100, but that should probably be tested first.
