### PR TITLE
Update Haskell support

### DIFF
--- a/lib/travis/build/job/test/haskell.rb
+++ b/lib/travis/build/job/test/haskell.rb
@@ -16,11 +16,11 @@ module Travis
           end
 
           def install
-            "cabal install --enable-tests"
+            "cabal install --only-dependencies --enable-tests"
           end
 
           def script
-            "cabal test"
+            "cabal configure --enable-tests && cabal build && cabal test"
           end
 
           protected

--- a/spec/build/job/test/haskell_spec.rb
+++ b/spec/build/job/test/haskell_spec.rb
@@ -10,14 +10,14 @@ describe Travis::Build::Job::Test::Haskell do
 
   describe 'install' do
     it "uses cabal" do
-      job.install.should == "cabal install --enable-tests"
+      job.install.should == "cabal install --only-dependencies --enable-tests"
     end
   end
 
 
   describe 'script' do
     it "uses cabal" do
-      job.script.should == "cabal test"
+      job.script.should == "cabal configure --enable-tests && cabal build && cabal test"
     end
   end
 end


### PR DESCRIPTION
The issue with the current setup is that it runs the test suite twice.
This was an oversight on my part, when I adapted Travis CI's Haskell
support for cabal-install-0.14.0.

This patch resolves the issue.

The related thread on haskell-cafe is here:
http://www.haskell.org/pipermail/haskell-cafe/2012-December/104992.html
