### PR TITLE
Export the 'build home directory' as environment variable

### DIFF
--- a/examples/build_c.sh
+++ b/examples/build_c.sh
@@ -42,6 +42,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
+export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_clojure_lein2_config.sh
+++ b/examples/build_clojure_lein2_config.sh
@@ -42,6 +42,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
+export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_clojure_no_lein_config.sh
+++ b/examples/build_clojure_no_lein_config.sh
@@ -42,6 +42,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
+export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_cpp.sh
+++ b/examples/build_cpp.sh
@@ -42,6 +42,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
+export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_erlang.sh
+++ b/examples/build_erlang.sh
@@ -42,6 +42,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
+export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_generic_no_logs.sh
+++ b/examples/build_generic_no_logs.sh
@@ -42,6 +42,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
+export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_generic_no_timeouts.sh
+++ b/examples/build_generic_no_timeouts.sh
@@ -42,6 +42,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
+export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_generic_pull_request.sh
+++ b/examples/build_generic_pull_request.sh
@@ -42,6 +42,7 @@ export TRAVIS_PULL_REQUEST=1
 export TRAVIS_SECURE_ENV_VARS=false
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
+export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_generic_secure_var.sh
+++ b/examples/build_generic_secure_var.sh
@@ -42,6 +42,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
+export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_go.sh
+++ b/examples/build_go.sh
@@ -42,6 +42,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
+export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_groovy.sh
+++ b/examples/build_groovy.sh
@@ -42,6 +42,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
+export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_haskell.sh
+++ b/examples/build_haskell.sh
@@ -42,6 +42,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
+export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_node_js.sh
+++ b/examples/build_node_js.sh
@@ -42,6 +42,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
+export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_node_js_npm_args.sh
+++ b/examples/build_node_js_npm_args.sh
@@ -42,6 +42,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
+export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_objective_c.sh
+++ b/examples/build_objective_c.sh
@@ -42,6 +42,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
+export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_objective_c_cocoapods.sh
+++ b/examples/build_objective_c_cocoapods.sh
@@ -42,6 +42,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
+export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_perl.sh
+++ b/examples/build_perl.sh
@@ -42,6 +42,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
+export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_php.sh
+++ b/examples/build_php.sh
@@ -42,6 +42,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
+export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_pure_java.sh
+++ b/examples/build_pure_java.sh
@@ -42,6 +42,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
+export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_python_2.7.sh
+++ b/examples/build_python_2.7.sh
@@ -42,6 +42,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
+export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_python_pypy.sh
+++ b/examples/build_python_pypy.sh
@@ -42,6 +42,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
+export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_ruby.sh
+++ b/examples/build_ruby.sh
@@ -42,6 +42,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
+export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_ruby_jruby.sh
+++ b/examples/build_ruby_jruby.sh
@@ -42,6 +42,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
+export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_scala.sh
+++ b/examples/build_scala.sh
@@ -42,6 +42,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
+export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/lib/travis/build/data/env.rb
+++ b/lib/travis/build/data/env.rb
@@ -24,6 +24,7 @@ module Travis
               TRAVIS_SECURE_ENV_VARS: secure_env_vars?,
               TRAVIS_BUILD_ID:        build[:id],
               TRAVIS_BUILD_NUMBER:    build[:number],
+              TRAVIS_BUILD_DIR:       '"' + [ BUILD_DIR, repository[:slug] ].join('/') + '"',
               TRAVIS_JOB_ID:          job[:id],
               TRAVIS_JOB_NUMBER:      job[:number],
               TRAVIS_BRANCH:          job[:branch],

--- a/spec/data/env_spec.rb
+++ b/spec/data/env_spec.rb
@@ -1,15 +1,16 @@
 require 'spec_helper'
 
 describe Travis::Build::Data::Env do
-  let(:data) { stub('data', pull_request: '100', config: { env: 'FOO=foo' }, build: {}, job: {}, repository: {}) }
+  let(:data) { stub('data', pull_request: '100', config: { env: 'FOO=foo' }, build: { id: '1', number: '1' }, job: { id: '1', number: '1.1', branch: 'master', commit: '313f61b', commit_range: '313f61b..313f61a' }, repository: { slug: 'travis-ci/travis-ci' }) }
   let(:env)  { described_class.new(data) }
 
   it 'vars respond to :key' do
     env.vars.first.should respond_to(:key)
   end
 
-  it 'includes travis env vars' do
-    env.vars.first.key.should =~ /^TRAVIS_/
+  it 'includes all travis env vars' do
+    travis_vars = env.vars.select { |v| v.key =~ /^TRAVIS_/ && v.value && v.value.length > 0 }
+    travis_vars.length.should == 11
   end
 
   it 'includes config env vars' do

--- a/spec/shared/script.rb
+++ b/spec/shared/script.rb
@@ -8,6 +8,7 @@ shared_examples_for 'a build script' do
     should set 'TRAVIS_SECURE_ENV_VARS', 'false'
     should set 'TRAVIS_BUILD_ID',        '1'
     should set 'TRAVIS_BUILD_NUMBER',    '1'
+    should set 'TRAVIS_BUILD_DIR',       "#{Travis::Build::BUILD_DIR}/travis-ci/travis-ci"
     should set 'TRAVIS_JOB_ID',          '1'
     should set 'TRAVIS_JOB_NUMBER',      '1.1'
     should set 'TRAVIS_BRANCH',          'master'


### PR DESCRIPTION
Following similar needs as https://github.com/travis-ci/travis-ci/issues/861, I propose here to export a `TRAVIS_BUILD_WD` environment variable (WD for _working directory_). 
This could greatly help in **two aspects**:
- customizations in `.travis.yml` are fully _repository/fork independant_.
- `.travis.yml` is safe from changes in Travis _'hidden' internals_ (e.g. build directory location)

Here the issue that motivated this pull request: https://github.com/cappuccino/cappuccino/pull/1728

For the second aspect, we recently had an example with https://github.com/travis-ci/travis-build/pull/60, where the path to build working directory has changed from `/home/travis/builds/owner/repo` to `/home/travis/build/owner/repo` ( **build** instead of **builds** )

**My Open Questions / Critics:**
- in `lib/travis/build/data/env.rb`: I did not find better than hard-coded value `/home/travis/build`, because
  - `~/build` is indeed hard-coded in `build.sh`. Should we rather use `~/build` there as well?
  - I don't know if `ENV[$HOME]` is available at **travis-build** level, and according to http://about.travis-ci.org/docs/user/ci-environment/#Environment-variables, I think it is even better not to compose with such value.
  - I would be very interested to know what should be the good practice here...
- I added b09469e BTW, and realized that maybe we could add a bit more specs about the names and values of `TRAVIS_` vars in `spec/data/env_spec.rb`. Any opinion about that ?
