### PR TITLE
Gradle build detection and testing for Scala.

### DIFF
--- a/examples/build_scala.sh
+++ b/examples/build_scala.sh
@@ -109,6 +109,9 @@ travis_start script
 if [[ -d project || -f build.sbt ]]; then
   echo \$\ sbt\ \+\+2.9.2\ test
   sbt ++2.9.2 test
+elif [[ -f build.gradle ]]; then
+  echo \$\ gradle\ check
+  gradle check
 else
   echo \$\ mvn\ test
   mvn test

--- a/lib/travis/build/script/scala.rb
+++ b/lib/travis/build/script/scala.rb
@@ -20,6 +20,7 @@ module Travis
 
         def script
           sh_if   '-d project || -f build.sbt', "sbt ++#{config[:scala]} test"
+          sh_elif   '-f build.gradle', 'gradle check'
           sh_else 'mvn test'
         end
       end

--- a/spec/script/scala_spec.rb
+++ b/spec/script/scala_spec.rb
@@ -31,6 +31,11 @@ describe Travis::Build::Script::Scala do
     should run_script 'sbt ++2.9.2 test'
   end
 
+  it 'runs gradle check if ./build.gradle exists' do
+    file('build.gradle')
+    should run_script 'gradle check'
+  end
+
   it 'runs mvn test if no project directory or build file exists' do
     should run_script 'mvn test'
   end


### PR DESCRIPTION
Previous logic was:

```
if build.sbt exists
  sbt ++2.9.2 test
else
  mvn test
```

New logic is:

```
if build.sbt exists
  sbt ++2.9.2 test
else if build.gradle exists
  gradle check
else
  mvn test
```
