### PR TITLE
Use '$HOME' instead of tilde ('~') to be able to use $TRAVIS_BUILD_DIR in $PATH

### DIFF
--- a/examples/build_c.sh
+++ b/examples/build_c.sh
@@ -35,8 +35,8 @@ decrypt() {
   echo $1 | base64 -d | openssl rsautl -decrypt -inkey ~/.ssh/id_rsa.repo
 }
 
-mkdir -p ~/build
-cd       ~/build
+mkdir -p $HOME/build
+cd       $HOME/build
 
 trap 'travis_finish build 1' TERM
 trap 'TRAVIS_CMD=$TRAVIS_NEXT_CMD; TRAVIS_NEXT_CMD=$BASH_COMMAND' DEBUG
@@ -47,7 +47,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
-export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
+export TRAVIS_BUILD_DIR="$HOME/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_clojure_lein2_config.sh
+++ b/examples/build_clojure_lein2_config.sh
@@ -35,8 +35,8 @@ decrypt() {
   echo $1 | base64 -d | openssl rsautl -decrypt -inkey ~/.ssh/id_rsa.repo
 }
 
-mkdir -p ~/build
-cd       ~/build
+mkdir -p $HOME/build
+cd       $HOME/build
 
 trap 'travis_finish build 1' TERM
 trap 'TRAVIS_CMD=$TRAVIS_NEXT_CMD; TRAVIS_NEXT_CMD=$BASH_COMMAND' DEBUG
@@ -47,7 +47,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
-export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
+export TRAVIS_BUILD_DIR="$HOME/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_clojure_no_lein_config.sh
+++ b/examples/build_clojure_no_lein_config.sh
@@ -35,8 +35,8 @@ decrypt() {
   echo $1 | base64 -d | openssl rsautl -decrypt -inkey ~/.ssh/id_rsa.repo
 }
 
-mkdir -p ~/build
-cd       ~/build
+mkdir -p $HOME/build
+cd       $HOME/build
 
 trap 'travis_finish build 1' TERM
 trap 'TRAVIS_CMD=$TRAVIS_NEXT_CMD; TRAVIS_NEXT_CMD=$BASH_COMMAND' DEBUG
@@ -47,7 +47,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
-export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
+export TRAVIS_BUILD_DIR="$HOME/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_cpp.sh
+++ b/examples/build_cpp.sh
@@ -35,8 +35,8 @@ decrypt() {
   echo $1 | base64 -d | openssl rsautl -decrypt -inkey ~/.ssh/id_rsa.repo
 }
 
-mkdir -p ~/build
-cd       ~/build
+mkdir -p $HOME/build
+cd       $HOME/build
 
 trap 'travis_finish build 1' TERM
 trap 'TRAVIS_CMD=$TRAVIS_NEXT_CMD; TRAVIS_NEXT_CMD=$BASH_COMMAND' DEBUG
@@ -47,7 +47,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
-export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
+export TRAVIS_BUILD_DIR="$HOME/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_erlang.sh
+++ b/examples/build_erlang.sh
@@ -35,8 +35,8 @@ decrypt() {
   echo $1 | base64 -d | openssl rsautl -decrypt -inkey ~/.ssh/id_rsa.repo
 }
 
-mkdir -p ~/build
-cd       ~/build
+mkdir -p $HOME/build
+cd       $HOME/build
 
 trap 'travis_finish build 1' TERM
 trap 'TRAVIS_CMD=$TRAVIS_NEXT_CMD; TRAVIS_NEXT_CMD=$BASH_COMMAND' DEBUG
@@ -47,7 +47,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
-export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
+export TRAVIS_BUILD_DIR="$HOME/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master
@@ -83,8 +83,8 @@ rm -f ~/.ssh/source_rsa
 travis_finish checkout $?
 
 travis_start setup
-echo \$\ source\ \~/otp/R14B04/activate
-source ~/otp/R14B04/activate
+echo \$\ source\ \$HOME/otp/R14B04/activate
+source $HOME/otp/R14B04/activate
 travis_assert
 travis_finish setup $?
 

--- a/examples/build_generic_no_logs.sh
+++ b/examples/build_generic_no_logs.sh
@@ -35,8 +35,8 @@ decrypt() {
   echo $1 | base64 -d | openssl rsautl -decrypt -inkey ~/.ssh/id_rsa.repo
 }
 
-mkdir -p ~/build
-cd       ~/build
+mkdir -p $HOME/build
+cd       $HOME/build
 
 trap 'travis_finish build 1' TERM
 trap 'TRAVIS_CMD=$TRAVIS_NEXT_CMD; TRAVIS_NEXT_CMD=$BASH_COMMAND' DEBUG
@@ -47,7 +47,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
-export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
+export TRAVIS_BUILD_DIR="$HOME/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_generic_no_timeouts.sh
+++ b/examples/build_generic_no_timeouts.sh
@@ -35,8 +35,8 @@ decrypt() {
   echo $1 | base64 -d | openssl rsautl -decrypt -inkey ~/.ssh/id_rsa.repo
 }
 
-mkdir -p ~/build
-cd       ~/build
+mkdir -p $HOME/build
+cd       $HOME/build
 
 trap 'travis_finish build 1' TERM
 trap 'TRAVIS_CMD=$TRAVIS_NEXT_CMD; TRAVIS_NEXT_CMD=$BASH_COMMAND' DEBUG
@@ -47,7 +47,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
-export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
+export TRAVIS_BUILD_DIR="$HOME/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_generic_pull_request.sh
+++ b/examples/build_generic_pull_request.sh
@@ -35,8 +35,8 @@ decrypt() {
   echo $1 | base64 -d | openssl rsautl -decrypt -inkey ~/.ssh/id_rsa.repo
 }
 
-mkdir -p ~/build
-cd       ~/build
+mkdir -p $HOME/build
+cd       $HOME/build
 
 trap 'travis_finish build 1' TERM
 trap 'TRAVIS_CMD=$TRAVIS_NEXT_CMD; TRAVIS_NEXT_CMD=$BASH_COMMAND' DEBUG
@@ -47,7 +47,7 @@ export TRAVIS_PULL_REQUEST=1
 export TRAVIS_SECURE_ENV_VARS=false
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
-export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
+export TRAVIS_BUILD_DIR="$HOME/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_generic_secure_var.sh
+++ b/examples/build_generic_secure_var.sh
@@ -35,8 +35,8 @@ decrypt() {
   echo $1 | base64 -d | openssl rsautl -decrypt -inkey ~/.ssh/id_rsa.repo
 }
 
-mkdir -p ~/build
-cd       ~/build
+mkdir -p $HOME/build
+cd       $HOME/build
 
 trap 'travis_finish build 1' TERM
 trap 'TRAVIS_CMD=$TRAVIS_NEXT_CMD; TRAVIS_NEXT_CMD=$BASH_COMMAND' DEBUG
@@ -47,7 +47,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
-export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
+export TRAVIS_BUILD_DIR="$HOME/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_go.sh
+++ b/examples/build_go.sh
@@ -35,8 +35,8 @@ decrypt() {
   echo $1 | base64 -d | openssl rsautl -decrypt -inkey ~/.ssh/id_rsa.repo
 }
 
-mkdir -p ~/build
-cd       ~/build
+mkdir -p $HOME/build
+cd       $HOME/build
 
 trap 'travis_finish build 1' TERM
 trap 'TRAVIS_CMD=$TRAVIS_NEXT_CMD; TRAVIS_NEXT_CMD=$BASH_COMMAND' DEBUG
@@ -47,7 +47,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
-export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
+export TRAVIS_BUILD_DIR="$HOME/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master
@@ -58,8 +58,8 @@ echo \$\ export\ FOO\=foo
 export FOO=foo
 echo \$\ export\ BAR\=\[secure\]
 export BAR=bar
-echo \$\ export\ GOPATH\=\~/gopath
-export GOPATH=~/gopath
+echo \$\ export\ GOPATH\=\$HOME/gopath
+export GOPATH=$HOME/gopath
 travis_finish export $?
 
 travis_start checkout

--- a/examples/build_groovy.sh
+++ b/examples/build_groovy.sh
@@ -35,8 +35,8 @@ decrypt() {
   echo $1 | base64 -d | openssl rsautl -decrypt -inkey ~/.ssh/id_rsa.repo
 }
 
-mkdir -p ~/build
-cd       ~/build
+mkdir -p $HOME/build
+cd       $HOME/build
 
 trap 'travis_finish build 1' TERM
 trap 'TRAVIS_CMD=$TRAVIS_NEXT_CMD; TRAVIS_NEXT_CMD=$BASH_COMMAND' DEBUG
@@ -47,7 +47,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
-export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
+export TRAVIS_BUILD_DIR="$HOME/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_haskell.sh
+++ b/examples/build_haskell.sh
@@ -35,8 +35,8 @@ decrypt() {
   echo $1 | base64 -d | openssl rsautl -decrypt -inkey ~/.ssh/id_rsa.repo
 }
 
-mkdir -p ~/build
-cd       ~/build
+mkdir -p $HOME/build
+cd       $HOME/build
 
 trap 'travis_finish build 1' TERM
 trap 'TRAVIS_CMD=$TRAVIS_NEXT_CMD; TRAVIS_NEXT_CMD=$BASH_COMMAND' DEBUG
@@ -47,7 +47,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
-export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
+export TRAVIS_BUILD_DIR="$HOME/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_node_js.sh
+++ b/examples/build_node_js.sh
@@ -35,8 +35,8 @@ decrypt() {
   echo $1 | base64 -d | openssl rsautl -decrypt -inkey ~/.ssh/id_rsa.repo
 }
 
-mkdir -p ~/build
-cd       ~/build
+mkdir -p $HOME/build
+cd       $HOME/build
 
 trap 'travis_finish build 1' TERM
 trap 'TRAVIS_CMD=$TRAVIS_NEXT_CMD; TRAVIS_NEXT_CMD=$BASH_COMMAND' DEBUG
@@ -47,7 +47,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
-export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
+export TRAVIS_BUILD_DIR="$HOME/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_node_js_npm_args.sh
+++ b/examples/build_node_js_npm_args.sh
@@ -35,8 +35,8 @@ decrypt() {
   echo $1 | base64 -d | openssl rsautl -decrypt -inkey ~/.ssh/id_rsa.repo
 }
 
-mkdir -p ~/build
-cd       ~/build
+mkdir -p $HOME/build
+cd       $HOME/build
 
 trap 'travis_finish build 1' TERM
 trap 'TRAVIS_CMD=$TRAVIS_NEXT_CMD; TRAVIS_NEXT_CMD=$BASH_COMMAND' DEBUG
@@ -47,7 +47,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
-export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
+export TRAVIS_BUILD_DIR="$HOME/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_objective_c.sh
+++ b/examples/build_objective_c.sh
@@ -35,8 +35,8 @@ decrypt() {
   echo $1 | base64 -d | openssl rsautl -decrypt -inkey ~/.ssh/id_rsa.repo
 }
 
-mkdir -p ~/build
-cd       ~/build
+mkdir -p $HOME/build
+cd       $HOME/build
 
 trap 'travis_finish build 1' TERM
 trap 'TRAVIS_CMD=$TRAVIS_NEXT_CMD; TRAVIS_NEXT_CMD=$BASH_COMMAND' DEBUG
@@ -47,7 +47,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
-export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
+export TRAVIS_BUILD_DIR="$HOME/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_objective_c_cocoapods.sh
+++ b/examples/build_objective_c_cocoapods.sh
@@ -35,8 +35,8 @@ decrypt() {
   echo $1 | base64 -d | openssl rsautl -decrypt -inkey ~/.ssh/id_rsa.repo
 }
 
-mkdir -p ~/build
-cd       ~/build
+mkdir -p $HOME/build
+cd       $HOME/build
 
 trap 'travis_finish build 1' TERM
 trap 'TRAVIS_CMD=$TRAVIS_NEXT_CMD; TRAVIS_NEXT_CMD=$BASH_COMMAND' DEBUG
@@ -47,7 +47,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
-export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
+export TRAVIS_BUILD_DIR="$HOME/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_perl.sh
+++ b/examples/build_perl.sh
@@ -35,8 +35,8 @@ decrypt() {
   echo $1 | base64 -d | openssl rsautl -decrypt -inkey ~/.ssh/id_rsa.repo
 }
 
-mkdir -p ~/build
-cd       ~/build
+mkdir -p $HOME/build
+cd       $HOME/build
 
 trap 'travis_finish build 1' TERM
 trap 'TRAVIS_CMD=$TRAVIS_NEXT_CMD; TRAVIS_NEXT_CMD=$BASH_COMMAND' DEBUG
@@ -47,7 +47,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
-export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
+export TRAVIS_BUILD_DIR="$HOME/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_php.sh
+++ b/examples/build_php.sh
@@ -35,8 +35,8 @@ decrypt() {
   echo $1 | base64 -d | openssl rsautl -decrypt -inkey ~/.ssh/id_rsa.repo
 }
 
-mkdir -p ~/build
-cd       ~/build
+mkdir -p $HOME/build
+cd       $HOME/build
 
 trap 'travis_finish build 1' TERM
 trap 'TRAVIS_CMD=$TRAVIS_NEXT_CMD; TRAVIS_NEXT_CMD=$BASH_COMMAND' DEBUG
@@ -47,7 +47,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
-export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
+export TRAVIS_BUILD_DIR="$HOME/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_pure_java.sh
+++ b/examples/build_pure_java.sh
@@ -35,8 +35,8 @@ decrypt() {
   echo $1 | base64 -d | openssl rsautl -decrypt -inkey ~/.ssh/id_rsa.repo
 }
 
-mkdir -p ~/build
-cd       ~/build
+mkdir -p $HOME/build
+cd       $HOME/build
 
 trap 'travis_finish build 1' TERM
 trap 'TRAVIS_CMD=$TRAVIS_NEXT_CMD; TRAVIS_NEXT_CMD=$BASH_COMMAND' DEBUG
@@ -47,7 +47,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
-export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
+export TRAVIS_BUILD_DIR="$HOME/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_python_2.7.sh
+++ b/examples/build_python_2.7.sh
@@ -35,8 +35,8 @@ decrypt() {
   echo $1 | base64 -d | openssl rsautl -decrypt -inkey ~/.ssh/id_rsa.repo
 }
 
-mkdir -p ~/build
-cd       ~/build
+mkdir -p $HOME/build
+cd       $HOME/build
 
 trap 'travis_finish build 1' TERM
 trap 'TRAVIS_CMD=$TRAVIS_NEXT_CMD; TRAVIS_NEXT_CMD=$BASH_COMMAND' DEBUG
@@ -47,7 +47,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
-export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
+export TRAVIS_BUILD_DIR="$HOME/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_python_pypy.sh
+++ b/examples/build_python_pypy.sh
@@ -35,8 +35,8 @@ decrypt() {
   echo $1 | base64 -d | openssl rsautl -decrypt -inkey ~/.ssh/id_rsa.repo
 }
 
-mkdir -p ~/build
-cd       ~/build
+mkdir -p $HOME/build
+cd       $HOME/build
 
 trap 'travis_finish build 1' TERM
 trap 'TRAVIS_CMD=$TRAVIS_NEXT_CMD; TRAVIS_NEXT_CMD=$BASH_COMMAND' DEBUG
@@ -47,7 +47,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
-export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
+export TRAVIS_BUILD_DIR="$HOME/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_ruby.sh
+++ b/examples/build_ruby.sh
@@ -35,8 +35,8 @@ decrypt() {
   echo $1 | base64 -d | openssl rsautl -decrypt -inkey ~/.ssh/id_rsa.repo
 }
 
-mkdir -p ~/build
-cd       ~/build
+mkdir -p $HOME/build
+cd       $HOME/build
 
 trap 'travis_finish build 1' TERM
 trap 'TRAVIS_CMD=$TRAVIS_NEXT_CMD; TRAVIS_NEXT_CMD=$BASH_COMMAND' DEBUG
@@ -47,7 +47,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
-export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
+export TRAVIS_BUILD_DIR="$HOME/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_ruby_jruby.sh
+++ b/examples/build_ruby_jruby.sh
@@ -35,8 +35,8 @@ decrypt() {
   echo $1 | base64 -d | openssl rsautl -decrypt -inkey ~/.ssh/id_rsa.repo
 }
 
-mkdir -p ~/build
-cd       ~/build
+mkdir -p $HOME/build
+cd       $HOME/build
 
 trap 'travis_finish build 1' TERM
 trap 'TRAVIS_CMD=$TRAVIS_NEXT_CMD; TRAVIS_NEXT_CMD=$BASH_COMMAND' DEBUG
@@ -47,7 +47,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
-export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
+export TRAVIS_BUILD_DIR="$HOME/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/examples/build_scala.sh
+++ b/examples/build_scala.sh
@@ -35,8 +35,8 @@ decrypt() {
   echo $1 | base64 -d | openssl rsautl -decrypt -inkey ~/.ssh/id_rsa.repo
 }
 
-mkdir -p ~/build
-cd       ~/build
+mkdir -p $HOME/build
+cd       $HOME/build
 
 trap 'travis_finish build 1' TERM
 trap 'TRAVIS_CMD=$TRAVIS_NEXT_CMD; TRAVIS_NEXT_CMD=$BASH_COMMAND' DEBUG
@@ -47,7 +47,7 @@ export TRAVIS_PULL_REQUEST=false
 export TRAVIS_SECURE_ENV_VARS=true
 export TRAVIS_BUILD_ID=1
 export TRAVIS_BUILD_NUMBER=1
-export TRAVIS_BUILD_DIR="~/build/travis-ci/travis-ci"
+export TRAVIS_BUILD_DIR="$HOME/build/travis-ci/travis-ci"
 export TRAVIS_JOB_ID=1
 export TRAVIS_JOB_NUMBER=1.1
 export TRAVIS_BRANCH=master

--- a/lib/travis/build.rb
+++ b/lib/travis/build.rb
@@ -7,12 +7,12 @@ module Travis
     autoload :Services, 'travis/build/services'
     autoload :Shell,    'travis/build/shell'
 
-    HOME_DIR  = '~'
-    BUILD_DIR = '~/build'
+    HOME_DIR  = '$HOME'
+    BUILD_DIR = File.join(HOME_DIR, 'build')
 
     LOGS = {
-      build: '~/build.log',
-      state: '~/state.log'
+      build: File.join(HOME_DIR, 'build.log'),
+      state: File.join(HOME_DIR, 'state.log')
     }
 
     class << self


### PR DESCRIPTION
Problem before this fix:
Character `~` in environment variable is considered as a literal and
thus is not expanded within shell execution. It is thus not yet possible to use `TRAVIS_BUILD_DIR` to customize the `PATH` environement variable. 
- Integration problem example: https://travis-ci.org/gildegoma/cappuccino/builds/4877254 
- Reference: http://stackoverflow.com/questions/3984074/tilde-expansion-in-environment-variable

**Solution:** By using `$HOME` instead, the variable `$TRAVIS_BUILD_DIR` can be safely
used to extend other variables, such as `PATH`.

**Related issue:** By removing these `~`, I also planned to pack in this pull request to replace all `~/.ssh` with a Ruby variable. I already started to work on it, but I'll propose it in the frame of this pull request only if Travis team members confirm the interest to unify the way to refer to "home" resources...
