### PR TITLE
Using whatever "true" is available.  fixes #82

### DIFF
--- a/examples/build_go.sh
+++ b/examples/build_go.sh
@@ -103,8 +103,8 @@ travis_finish before_install $?
 
 travis_start install
 if [[ -f Makefile ]]; then
-  echo \$\ /usr/bin/true
-  /usr/bin/true
+  echo \$\ true \#\ \(using\ Makefile\)
+  true
   travis_assert
 else
   echo \$\ go\ get\ -d\ -v\ ./...\ \&\&\ go\ build\ -v\ ./...

--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -15,7 +15,7 @@ module Travis
         end
 
         def install
-          uses_make? then: '/usr/bin/true', else: 'go get -d -v ./... && go build -v ./...'
+          uses_make? then: 'true', else: 'go get -d -v ./... && go build -v ./...'
         end
 
         def script


### PR DESCRIPTION
since `/usr/bin/true` appears to be an OSX/BSD thing whereas the build
workers are (mostly? all?) Linux, which has `/bin/true`, plus the fact
that `true` is a bash builtin...
