### PR TITLE
Call standalone ./Build before calling ./Build test

### DIFF
--- a/examples/build_perl.sh
+++ b/examples/build_perl.sh
@@ -139,8 +139,8 @@ travis_finish before_script $?
 
 travis_start script
 if [[ -f Build.PL ]]; then
-  echo \$\ perl\ Build.PL\ \&\&\ ./Build\ test
-  perl Build.PL && ./Build test
+  echo \$\ perl\ Build.PL\ \&\&\ ./Build\ \&\&\ ./Build\ test
+  perl Build.PL && ./Build && ./Build test
 elif [[ -f Makefile.PL ]]; then
   echo \$\ perl\ Makefile.PL\ \&\&\ make\ test
   perl Makefile.PL && make test

--- a/lib/travis/build/script/perl.rb
+++ b/lib/travis/build/script/perl.rb
@@ -27,7 +27,7 @@ module Travis
         end
 
         def script
-          self.if   '-f Build.PL',    'perl Build.PL && ./Build test'
+          self.if   '-f Build.PL',    'perl Build.PL && ./Build && ./Build test'
           self.elif '-f Makefile.PL', 'perl Makefile.PL && make test'
           self.else                   'make test'
         end

--- a/spec/script/perl_spec.rb
+++ b/spec/script/perl_spec.rb
@@ -54,7 +54,7 @@ describe Travis::Build::Script::Perl do
     end
 
     it 'runs perl Build.PL && ./Build test' do
-      should run 'echo $ perl Build.PL && ./Build test'
+      should run 'echo $ perl Build.PL && ./Build && ./Build test'
       should run 'perl Build.PL'
       # TODO can't really capture this yet
       # should run './Build test', log: true, timeout: timeout_for(:script)


### PR DESCRIPTION
per [Module::Build](https://metacpan.org/module/Module::Build) spec, `./Build` should be called before running `./Build test`.

`./Build test` without `./Build` happened to work with the current version of Module::Build but it was an undocumented behavior.

Rationale: [Some builds](https://travis-ci.org/tokuhirom/Minilla/jobs/5701450) using a variant of Module::Build breaks because of the omission of the standalone `./Build` process.
