### PR TITLE
Quote the branch name to fix an edge case

### DIFF
--- a/lib/travis/build/script/git.rb
+++ b/lib/travis/build/script/git.rb
@@ -72,7 +72,7 @@ module Travis
 
           def clone_args
             args = "--depth=#{config[:git][:depth]}"
-            args << " --branch=#{data.branch}" unless data.ref
+            args << " --branch=\"#{data.branch}\"" unless data.ref
             args
           end
 

--- a/spec/shared/git.rb
+++ b/spec/shared/git.rb
@@ -1,13 +1,13 @@
 shared_examples_for 'a git repo' do
   it 'clones the git repo' do
-    cmd = 'git clone --depth=50 --branch=master git://github.com/travis-ci/travis-ci.git travis-ci/travis-ci'
+    cmd = 'git clone --depth=50 --branch="master" git://github.com/travis-ci/travis-ci.git travis-ci/travis-ci'
     timeout = Travis::Build::Data::DEFAULTS[:timeouts][:git_clone]
     should run cmd, echo: true, log: true, assert: true, timeout: timeout
   end
 
   it 'clones with a custom depth if given' do
     data['config']['git'] = { depth: 1 }
-    cmd = 'git clone --depth=1 --branch=master git://github.com/travis-ci/travis-ci.git travis-ci/travis-ci'
+    cmd = 'git clone --depth=1 --branch="master" git://github.com/travis-ci/travis-ci.git travis-ci/travis-ci'
     should run cmd, echo: true
   end
 


### PR DESCRIPTION
Without this change, cloning would break if the branch name had special characters in it.

The branch name that spurred this fix: "metasearch->ransack"
