### PR TITLE
Updated build/script/perl.rb for Dist::Zilla

### DIFF
--- a/lib/travis/build/script/perl.rb
+++ b/lib/travis/build/script/perl.rb
@@ -23,12 +23,14 @@ module Travis
         end
 
         def install
-          cmd 'cpanm --quiet --installdeps --notest .', fold: 'install'
+          self.if   '-f dist.ini',    'cpanm Dist::Zilla && (dzil authordeps | cpanm) && (dzil listdeps | cpanm)'
+          self.else                   'cpanm --quiet --installdeps --notest .', fold: 'install'
         end
 
         def script
           self.if   '-f Build.PL',    'perl Build.PL && ./Build && ./Build test'
           self.elif '-f Makefile.PL', 'perl Makefile.PL && make test'
+          self.elif '-f dist.ini'     'dzil test'
           self.else                   'make test'
         end
 


### PR DESCRIPTION
It is common to create a Perl distribution using the Dist::Zilla helper,
which means keeping the package un-ready for release in version control
and only creating the release-ready version (with Makefile.PL or
Build.PL) when it actually gets shipped off to the CPAN.

For example:

https://metacpan.org/source/KAORU/App-highlight-0.09
https://github.com/kaoru/App-highlight

Added the steps to recognise that a repository has a dist.ini file and
that Dist::Zilla should therefore be used to install the dependencies
and to run the tests.
