### PR TITLE
Use :env and :global_env as env vars sources

### DIFF
--- a/examples/build_generic_secure_var.sh
+++ b/examples/build_generic_secure_var.sh
@@ -54,6 +54,10 @@ export TRAVIS_BRANCH=master
 export TRAVIS_COMMIT=313f61b
 export TRAVIS_COMMIT_RANGE=313f61b..313f61a
 export TRAVIS_REPO_SLUG=travis-ci/travis-ci
+echo \$\ export\ FOO\=foo
+export FOO=foo
+echo \$\ export\ BAR\=\[secure\]
+export BAR=bar
 echo \$\ export\ BAR\=\[secure\]
 export BAR=bar
 travis_finish export $?

--- a/lib/travis/build/data/env.rb
+++ b/lib/travis/build/data/env.rb
@@ -34,10 +34,14 @@ module Travis
             )
           end
 
-          def config_vars
-            vars = to_vars(Array(config[:env]).compact.reject(&:empty?))
+          def extract_config_vars(vars)
+            vars = to_vars(Array(vars).compact.reject(&:empty?))
             vars.reject!(&:secure?) if pull_request
             vars
+          end
+
+          def config_vars
+            extract_config_vars(config[:env]) + extract_config_vars(config[:global_env])
           end
 
           def to_vars(args)

--- a/spec/shared/env_vars.rb
+++ b/spec/shared/env_vars.rb
@@ -1,0 +1,71 @@
+shared_examples_for 'a script with env vars' do
+  it 'sets TRAVIS_SECURE_ENV_VARS to true when using secure env vars' do
+    data['config'][env_type] = 'SECURE BAR=bar'
+    should set 'TRAVIS_SECURE_ENV_VARS', 'true'
+    store_example 'secure_var' if described_class == Travis::Build::Script::Generic
+  end
+
+  it 'sets a given :env var' do
+    data['config'][env_type] = 'FOO=foo'
+    should set 'FOO', 'foo'
+  end
+
+  it 'sets a given :env var even if empty' do
+    data['config'][env_type] = 'FOO=""'
+    should set 'FOO', ''
+  end
+
+  it 'sets the exact value of a given :env var' do
+    data['config'][env_type] = 'FOO=foolish'
+    should_not set 'FOO', 'foo'
+  end
+
+  it 'sets the exact value of a given :env var, even if definition is unquoted' do
+    data['config'][env_type] = 'UNQUOTED=first second third ... OTHER=ok'
+    should set 'UNQUOTED', 'first'
+    should set 'OTHER', 'ok'
+  end
+
+  it 'it evaluates and sets the exact values of given :env vars, when their definition is encolsed within single or double quotes' do
+    data['config'][env_type] = 'SIMPLE_QUOTED=\'foo+bar (are) on a boat!\' DOUBLE_QUOTED="$SIMPLE_QUOTED"'
+    should set 'SIMPLE_QUOTED', 'foo+bar (are) on a boat!'
+    should set 'DOUBLE_QUOTED', 'foo+bar (are) on a boat!'
+  end
+
+  it 'sets multiple :env vars (space separated)' do
+    data['config'][env_type] = 'FOO=foo BAR=bar'
+    should set 'FOO', 'foo'
+    should set 'BAR', 'bar'
+  end
+
+  it 'sets multiple :env vars (array)' do
+    data['config'][env_type] = ['FOO=foo', 'BAR=bar']
+    should set 'FOO', 'foo'
+    should set 'BAR', 'bar'
+  end
+
+  it 'sets a given secure :env var' do
+    data['config'][env_type] = 'SECURE BAR=bar'
+    should set 'BAR', 'bar'
+  end
+
+  it 'echoes obfuscated secure env vars' do
+    data['config'][env_type] = 'SECURE BAR=bar'
+    should echo 'export BAR=[secure]'
+  end
+
+  it 'does not set secure :env vars on pull requests' do
+    data['job']['pull_request'] = 1
+    data['config'][env_type] = 'SECURE BAR=bar'
+    should_not set 'BAR', 'bar'
+  end
+
+  it 'sets both global and regular env vars' do
+    data['config']['env'] = ['FOO=foo', 'BAR=bar']
+    data['config']['global_env'] = ['BAZ=baz', 'QUX=qux']
+    should set 'FOO', 'foo'
+    should set 'BAR', 'bar'
+    should set 'BAZ', 'baz'
+    should set 'QUX', 'qux'
+  end
+end

--- a/spec/shared/script.rb
+++ b/spec/shared/script.rb
@@ -1,6 +1,14 @@
 shared_examples_for 'a build script' do
   it_behaves_like 'a git repo'
 
+  it_behaves_like "a script with env vars" do
+    let(:env_type) { 'env' }
+  end
+
+  it_behaves_like "a script with env vars" do
+    let(:env_type) { 'global_env' }
+  end
+
   it 'sets TRAVIS_* env vars' do
     data['config']['env'].delete_if { |var| var =~ /SECURE / }
 
@@ -21,67 +29,6 @@ shared_examples_for 'a build script' do
     data['job']['pull_request'] = 1
     should set 'TRAVIS_PULL_REQUEST', '1'
     store_example 'pull_request' if described_class == Travis::Build::Script::Generic
-  end
-
-  it 'sets TRAVIS_SECURE_ENV_VARS to true when using secure env vars' do
-    data['config']['env'] = 'SECURE BAR=bar'
-    should set 'TRAVIS_SECURE_ENV_VARS', 'true'
-    store_example 'secure_var' if described_class == Travis::Build::Script::Generic
-  end
-
-  it 'sets a given :env var' do
-    data['config']['env'] = 'FOO=foo'
-    should set 'FOO', 'foo'
-  end
-
-  it 'sets a given :env var even if empty' do
-    data['config']['env'] = 'FOO=""'
-    should set 'FOO', ''
-  end
-
-  it 'sets the exact value of a given :env var' do
-    data['config']['env'] = 'FOO=foolish'
-    should_not set 'FOO', 'foo'
-  end
-
-  it 'sets the exact value of a given :env var, even if definition is unquoted' do
-    data['config']['env'] = 'UNQUOTED=first second third ... OTHER=ok'
-    should set 'UNQUOTED', 'first'
-    should set 'OTHER', 'ok'
-  end
-
-  it 'it evaluates and sets the exact values of given :env vars, when their definition is encolsed within single or double quotes' do
-    data['config']['env'] = 'SIMPLE_QUOTED=\'foo+bar (are) on a boat!\' DOUBLE_QUOTED="$SIMPLE_QUOTED"'
-    should set 'SIMPLE_QUOTED', 'foo+bar (are) on a boat!'
-    should set 'DOUBLE_QUOTED', 'foo+bar (are) on a boat!'
-  end
-
-  it 'sets multiple :env vars (space separated)' do
-    data['config']['env'] = 'FOO=foo BAR=bar'
-    should set 'FOO', 'foo'
-    should set 'BAR', 'bar'
-  end
-
-  it 'sets multiple :env vars (array)' do
-    data['config']['env'] = ['FOO=foo', 'BAR=bar']
-    should set 'FOO', 'foo'
-    should set 'BAR', 'bar'
-  end
-
-  it 'sets a given secure :env var' do
-    data['config']['env'] = 'SECURE BAR=bar'
-    should set 'BAR', 'bar'
-  end
-
-  it 'echoes obfuscated secure env vars' do
-    data['config']['env'] = 'SECURE BAR=bar'
-    should echo 'export BAR=[secure]'
-  end
-
-  it 'does not set secure :env vars on pull requests' do
-    data['job']['pull_request'] = 1
-    data['config']['env'] = 'SECURE BAR=bar'
-    should_not set 'BAR', 'bar'
   end
 
   it 'sets TRAVIS_TEST_RESULT to 0 if all scripts exited with 0' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require 'shared/git'
 require 'shared/jdk'
 require 'shared/jvm'
 require 'shared/script'
+require 'shared/env_vars'
 
 STDOUT.sync = true
 


### PR DESCRIPTION
From commit message:

```
The ability to add 'global' env vars was added to .travis.yml. This
allows to set environment variables, which will be used in each of the
jobs in the build. There is a problem with handling such construct -
till now travis-build was able to handle only one env source:
config[:env]. Such behavior requires merging global and matrix env
arrays and put them together in job's config. This is the source of
limitations and problems. To solve the problem, this commit adds support
for :global_env key in config array, to allow send matrix env vars and
global env vars as separate objects.
```
