### PR TITLE
remove --quiet to enable debugging when the install step times out

### DIFF
--- a/lib/travis/build/script/jvm.rb
+++ b/lib/travis/build/script/jvm.rb
@@ -10,7 +10,7 @@ module Travis
 
         def install
           self.if   '-f build.gradle', 'gradle assemble', fold: 'install'
-          self.elif '-f pom.xml',      'mvn install --quiet -DskipTests=true -B', fold: 'install' # Otherwise mvn install will run tests which. Suggestion from Charles Nutter. MK.
+          self.elif '-f pom.xml',      'mvn install -DskipTests=true -B', fold: 'install' # Otherwise mvn install will run tests which. Suggestion from Charles Nutter. MK.
         end
 
         def script

--- a/spec/shared/jvm.rb
+++ b/spec/shared/jvm.rb
@@ -20,8 +20,8 @@ shared_examples_for 'a jvm build' do
       file('pom.xml')
     end
 
-    it 'installs with mvn install --quiet -DskipTests=true -B' do
-      should run 'mvn install --quiet -DskipTests=true -B', echo: true, log: true, assert: true, timeout: timeout_for(:install)
+    it 'installs with mvn install -DskipTests=true -B' do
+      should run 'mvn install -DskipTests=true -B', echo: true, log: true, assert: true, timeout: timeout_for(:install)
     end
 
     it 'runs mvn test -B' do


### PR DESCRIPTION
Sometimes the build fails because it times out in "install"

```
$ mvn install --quiet -DskipTests=true -B
No output has been received in the last 10 minutes, this potentially indicates a stalled build or something wrong with the build itself.
The build has been terminated
```

because of --quiet it is not possible to know what it is actually hanging on.

example of such a build:
https://travis-ci.org/Parquet/parquet-mr/builds/7162751
