### PR TITLE
Rework go version alias handling

### DIFF
--- a/examples/build_go.sh
+++ b/examples/build_go.sh
@@ -112,6 +112,11 @@ rm -f ~/.ssh/source_rsa
 travis_finish checkout $?
 
 travis_start setup
+echo -en 'travis_fold:start:gvm.update\r'
+echo \$\ gvm\ get
+gvm get
+travis_assert
+echo -en 'travis_fold:end:gvm.update\r'
 echo -en 'travis_fold:start:gvm.install\r'
 echo \$\ gvm\ install\ go1.0.3
 gvm install go1.0.3

--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -48,10 +48,13 @@ module Travis
           end
 
           def go_version
-            if config[:go] == "tip"
-              config[:go]
-            else
+            version = config[:go].to_s
+            if version == '1.0'
+              'go1.0.3'
+            elsif version =~ /^[0-9]\.[0-9\.]+/
               "go#{config[:go]}"
+            else
+              config[:go]
             end
           end
       end

--- a/spec/script/go_spec.rb
+++ b/spec/script/go_spec.rb
@@ -50,6 +50,18 @@ describe Travis::Build::Script::Go do
     should run 'gvm install go1.1'
   end
 
+  {'1.1' => 'go1.1', '1.0' => 'go1.0.3', '1.0.2' => 'go1.0.2'}.each do |version_alias,version|
+    it "sets version #{version.inspect} for alias #{version_alias.inspect}" do
+      data['config']['go'] = version_alias
+      should run "gvm install #{version}"
+    end
+  end
+
+  it 'passes through arbitrary tag versions' do
+    data['config']['go'] = 'release9000'
+    should run 'gvm install release9000'
+  end
+
   it 'announces go version' do
     should announce 'go version'
   end


### PR DESCRIPTION
such that `tip` still passes through, but numbered versions are prefixed with `go`.  Also aliasing '1.0' to '1.0.3'.
