### PR TITLE
use exit code 113 to denote an error and not exit code 2

### DIFF
--- a/examples/build_c.sh
+++ b/examples/build_c.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_clojure_lein2_config.sh
+++ b/examples/build_clojure_lein2_config.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_clojure_no_lein_config.sh
+++ b/examples/build_clojure_no_lein_config.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_cpp.sh
+++ b/examples/build_cpp.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_erlang.sh
+++ b/examples/build_erlang.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_generic_addons_firefox.sh
+++ b/examples/build_generic_addons_firefox.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_generic_addons_hosts.sh
+++ b/examples/build_generic_addons_hosts.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_generic_addons_sauce_connect.sh
+++ b/examples/build_generic_addons_sauce_connect.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_generic_no_logs.sh
+++ b/examples/build_generic_no_logs.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_generic_no_timeouts.sh
+++ b/examples/build_generic_no_timeouts.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_generic_pull_request.sh
+++ b/examples/build_generic_pull_request.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_generic_secure_var.sh
+++ b/examples/build_generic_secure_var.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_go.sh
+++ b/examples/build_go.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_groovy.sh
+++ b/examples/build_groovy.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_haskell.sh
+++ b/examples/build_haskell.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_node_js.sh
+++ b/examples/build_node_js.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_node_js_npm_args.sh
+++ b/examples/build_node_js_npm_args.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_objective_c.sh
+++ b/examples/build_objective_c.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_objective_c_cocoapods.sh
+++ b/examples/build_objective_c_cocoapods.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_objective_c_rubymotion.sh
+++ b/examples/build_objective_c_rubymotion.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_perl.sh
+++ b/examples/build_perl.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_php.sh
+++ b/examples/build_php.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_pure_java.sh
+++ b/examples/build_pure_java.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_python_2.7.sh
+++ b/examples/build_python_2.7.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_python_pypy.sh
+++ b/examples/build_python_pypy.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_ruby.sh
+++ b/examples/build_ruby.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_ruby_jruby.sh
+++ b/examples/build_ruby_jruby.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/examples/build_scala.sh
+++ b/examples/build_scala.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." 
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 

--- a/lib/travis/build/script/templates/header.sh
+++ b/lib/travis/build/script/templates/header.sh
@@ -15,7 +15,7 @@ travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then
     echo -e "\nThe command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.\n\nYour build has been stopped." <%= ">> #{logs[:log]}" if logs[:log] %>
-    travis_terminate 2
+    travis_terminate 113
   fi
 }
 


### PR DESCRIPTION
exit code 2 is a reserved exit code, 113 is recommended for use by
http://www.tldp.org/LDP/abs/html/exitcodes.html
