### PR TITLE
Allow to pass arguments to sbt

### DIFF
--- a/examples/build_objective_c_xctool.sh
+++ b/examples/build_objective_c_xctool.sh
@@ -91,6 +91,7 @@ travis_assert
 echo -en 'travis_fold:end:git.1\r'
 echo \$\ cd\ travis-ci/travis-ci
 cd travis-ci/travis-ci
+travis_assert
 echo -en 'travis_fold:start:git.2\r'
 echo \$\ git\ checkout\ -qf\ 313f61b
 git checkout -qf 313f61b
@@ -150,19 +151,19 @@ echo -en 'travis_fold:end:before_install.2\r'
 travis_finish before_install $?
 
 travis_start install
-if [[ -f Podfile ]]; then
-  echo -en 'travis_fold:start:install.cocoapods\r'
-  echo \$\ pod\ install
-  travis_retry pod install
-  travis_assert
-  echo -en 'travis_fold:end:install.cocoapods\r'
-fi
 if [[ -f Gemfile ]]; then
   echo -en 'travis_fold:start:install.bundler\r'
   echo \$\ bundle\ install
   travis_retry bundle install
   travis_assert
   echo -en 'travis_fold:end:install.bundler\r'
+fi
+if [[ -f Podfile ]]; then
+  echo -en 'travis_fold:start:install.cocoapods\r'
+  echo \$\ pod\ install
+  travis_retry pod install
+  travis_assert
+  echo -en 'travis_fold:end:install.cocoapods\r'
 fi
 travis_finish install $?
 

--- a/lib/travis/build/script/scala.rb
+++ b/lib/travis/build/script/scala.rb
@@ -19,12 +19,17 @@ module Travis
         end
 
         def script
-          self.if   '-d project || -f build.sbt', "sbt ++#{config[:scala]} test"
+          self.if   '-d project || -f build.sbt', "sbt#{sbt_args} ++#{config[:scala]} test"
           self.elif '-f build.gradle', 'gradle check'
           self.else 'mvn test'
+        end
+
+        private
+
+        def sbt_args
+          config[:sbt_args] && " #{config[:sbt_args]}"
         end
       end
     end
   end
 end
-

--- a/spec/script/scala_spec.rb
+++ b/spec/script/scala_spec.rb
@@ -39,4 +39,10 @@ describe Travis::Build::Script::Scala do
   it 'runs mvn test if no project directory or build file exists' do
     should run_script 'mvn test'
   end
+
+  it "runs sbt with sbt_args if they are given" do
+    file("build.sbt")
+    data["config"]["sbt_args"] = "-Dsbt.log.noformat=true"
+    should run_script "sbt -Dsbt.log.noformat=true ++2.10.0 test"
+  end
 end


### PR DESCRIPTION
For example, you can add the following to disable colours in the SBT output:

``` YAML
sbt_args: -Dsbt.log.noformat=true
```

Closes travis-ci/travis-ci#1230.
