### PR TITLE
Without sbt configuration, scala builder should behave like other jvm languages

### DIFF
--- a/examples/build_scala.sh
+++ b/examples/build_scala.sh
@@ -120,6 +120,10 @@ travis_assert
 travis_finish setup $?
 
 travis_start announce
+echo \$\ java\ -version
+java -version
+echo \$\ javac\ -version
+javac -version
 echo Using\ Scala\ 2.10.0
 travis_finish announce $?
 
@@ -137,6 +141,21 @@ echo -en 'travis_fold:end:before_install.2\r'
 travis_finish before_install $?
 
 travis_start install
+if [[ ! -d project && ! -f build.sbt ]]; then
+if [[ -f build.gradle ]]; then
+  echo -en 'travis_fold:start:install\r'
+  echo \$\ gradle\ assemble
+  travis_retry gradle assemble
+  travis_assert
+  echo -en 'travis_fold:end:install\r'
+elif [[ -f pom.xml ]]; then
+  echo -en 'travis_fold:start:install\r'
+  echo \$\ mvn\ install\ -DskipTests\=true\ -B
+  travis_retry mvn install -DskipTests=true -B
+  travis_assert
+  echo -en 'travis_fold:end:install\r'
+fi
+fi
 travis_finish install $?
 
 travis_start before_script
@@ -156,12 +175,17 @@ travis_start script
 if [[ -d project || -f build.sbt ]]; then
   echo \$\ sbt\ \+\+2.10.0\ test
   sbt ++2.10.0 test
-elif [[ -f build.gradle ]]; then
+else
+if [[ -f build.gradle ]]; then
   echo \$\ gradle\ check
   gradle check
+elif [[ -f pom.xml ]]; then
+  echo \$\ mvn\ test\ -B
+  mvn test -B
 else
-  echo \$\ mvn\ test
-  mvn test
+  echo \$\ ant\ test
+  ant test
+fi
 fi
 travis_result $?
 travis_finish script $TRAVIS_TEST_RESULT

--- a/lib/travis/build/script/scala.rb
+++ b/lib/travis/build/script/scala.rb
@@ -1,8 +1,7 @@
 module Travis
   module Build
     class Script
-      class Scala < Script
-        include Jdk
+      class Scala < Jvm
 
         DEFAULTS = {
           scala: '2.10.0',
@@ -15,13 +14,17 @@ module Travis
         end
 
         def announce
+          super
           echo "Using Scala #{config[:scala]}"
+        end
+
+        def install
+          self.if  ('! -d project && ! -f build.sbt') { super }
         end
 
         def script
           self.if   '-d project || -f build.sbt', "sbt#{sbt_args} ++#{config[:scala]} test"
-          self.elif '-f build.gradle', 'gradle check'
-          self.else 'mvn test'
+          self.else { super }
         end
 
         private

--- a/spec/script/scala_spec.rb
+++ b/spec/script/scala_spec.rb
@@ -11,7 +11,7 @@ describe Travis::Build::Script::Scala do
   end
 
   it_behaves_like 'a build script'
-  # it_behaves_like 'a jdk build'
+  it_behaves_like 'a jvm build'
 
   it 'sets TRAVIS_SCALA_VERSION' do
     should set 'TRAVIS_SCALA_VERSION', '2.10.0'
@@ -29,15 +29,6 @@ describe Travis::Build::Script::Scala do
   it 'runs sbt ++2.10.0 test if ./build.sbt exists' do
     file('build.sbt')
     should run_script 'sbt ++2.10.0 test'
-  end
-
-  it 'runs gradle check if ./build.gradle exists' do
-    file('build.gradle')
-    should run_script 'gradle check'
-  end
-
-  it 'runs mvn test if no project directory or build file exists' do
-    should run_script 'mvn test'
   end
 
   it "runs sbt with sbt_args if they are given" do


### PR DESCRIPTION
Avoid code repetitions between scala builder and other JVM languages, by
applying same rules for build tool detection (Gradle, Maven and Ant). 

By DRYing this, cases like #126 are easier to maintain.
