### PR TITLE
Update RVM before selecting Ruby

### DIFF
--- a/lib/travis/build/script/rvm.rb
+++ b/lib/travis/build/script/rvm.rb
@@ -9,6 +9,7 @@ module Travis
 
         def setup
           super
+          cmd "rvm get latest-minor"
           cmd "rvm use #{ruby_version} --install --binary --fuzzy"
         end
 

--- a/spec/script/ruby_spec.rb
+++ b/spec/script/ruby_spec.rb
@@ -16,6 +16,10 @@ describe Travis::Build::Script::Ruby do
     should set 'TRAVIS_RUBY_VERSION', 'default'
   end
 
+  it 'tries to update RVM' do
+    should setup 'rvm get latest-minor'
+  end
+
   it 'sets the default ruby if no :rvm config given' do
     should setup 'rvm use default'
   end


### PR DESCRIPTION
This allows RVM to download the latest Ruby definitions. I'm not completely sure if we want to run this all the time, though, it could cause issues if there's a bad RVM version.

/cc @mpapis @joshk
