### PR TITLE
addons: Create packages addon

### DIFF
--- a/lib/travis/build/script/addons.rb
+++ b/lib/travis/build/script/addons.rb
@@ -3,6 +3,7 @@ require 'travis/build/script/addons/firefox'
 require 'travis/build/script/addons/hosts'
 require 'travis/build/script/addons/sauce_connect'
 require 'travis/build/script/addons/code_climate'
+require 'travis/build/script/addons/packages'
 
 module Travis
   module Build
@@ -14,6 +15,7 @@ module Travis
           hosts:         Hosts,
           sauce_connect: SauceConnect,
           code_climate:  CodeClimate,
+          packages:      Packages,
         }
 
         def run_addons(stage)

--- a/lib/travis/build/script/addons/packages.rb
+++ b/lib/travis/build/script/addons/packages.rb
@@ -1,0 +1,27 @@
+require "shellwords"
+
+module Travis
+  module Build
+    class Script
+      module Addons
+        class Packages
+          def initialize(script, config)
+            @script = script
+            @packages = Array(config).map(&:to_s).map(&:shellescape).join(" ")
+          end
+
+          def before_install
+            @script.if("hash brew 2>/dev/null") do |script|
+              script.cmd("brew update", assert: true)
+              script.cmd("brew install #{@packages}", assert: true)
+            end
+            @script.else do |script|
+              script.cmd("sudo apt-get -qq update", assert: true)
+              script.cmd("sudo apt-get -qq install #{@packages}", assert: true)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/script/addons/packages_spec.rb
+++ b/spec/script/addons/packages_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+describe Travis::Build::Script::Addons::Packages do
+  let(:script) { stub("script", cmd: nil, if: nil, else: nil) }
+  let(:config) {[ "foo", "bar=1" ]}
+
+  subject { described_class.new(script, config) }
+
+  it "checks for an available package manager" do
+    script.expects(:if).with("hash brew 2>/dev/null").yields(script)
+    subject.before_install
+  end
+
+  it "uses brew to install packages for mac builds" do
+    if_script = stub("if_script")
+    script.expects(:if).yields(if_script)
+    if_script.expects(:cmd).with("brew update", assert: true)
+    if_script.expects(:cmd).with("brew install foo bar\\=1", assert: true)
+    subject.before_install
+  end
+
+  it "uses brew to install packages for mac builds" do
+    else_script = stub("else_script")
+    script.expects(:else).yields(else_script)
+    else_script.expects(:cmd).with("sudo apt-get -qq update", assert: true)
+    else_script.expects(:cmd).with("sudo apt-get -qq install foo bar\\=1", assert: true)
+    subject.before_install
+  end
+end


### PR DESCRIPTION
This'll allow to specify packages in the .travis.yml file and let us
pick sensible defaults for how to call apt-get/brew.

Closes travis-ci/travis-ci#1222.
