### PR TITLE
Use only script stage for gradle powered builds

### DIFF
--- a/lib/travis/build/script/jvm.rb
+++ b/lib/travis/build/script/jvm.rb
@@ -9,14 +9,12 @@ module Travis
         }
 
         def install
-          self.if   '-f gradlew',      './gradlew assemble', fold: 'install', retry: true
-          self.elif '-f build.gradle', 'gradle assemble', fold: 'install', retry: true
-          self.elif '-f pom.xml',      'mvn install -DskipTests=true -B', fold: 'install', retry: true # Otherwise mvn install will run tests which. Suggestion from Charles Nutter. MK.
+          self.if '-f pom.xml', 'mvn install -DskipTests=true -B', fold: 'install', retry: true # Otherwise mvn install will run tests which. Suggestion from Charles Nutter. MK.
         end
 
         def script
-          self.if   '-f gradlew',      './gradlew check'
-          self.elif '-f build.gradle', 'gradle check'
+          self.if   '-f gradlew',      './gradlew build'
+          self.elif '-f build.gradle', 'gradle build'
           self.elif '-f pom.xml',      'mvn test -B'
           self.else                    'ant test'
         end

--- a/spec/shared/jvm.rb
+++ b/spec/shared/jvm.rb
@@ -7,12 +7,8 @@ shared_examples_for 'a jvm build' do
     end
 
     context 'without a gradle wrapper' do
-      it 'installs with gradle assemble' do
-        should run 'gradle assemble', echo: true, log: true, assert: true, timeout: timeout_for(:install)
-      end
-
-      it 'runs gradle check' do
-        should run 'gradle check', echo: true, log: true, timeout: timeout_for(:script)
+      it 'runs gradle build' do
+        should run 'gradle build', echo: true, log: true, timeout: timeout_for(:script)
       end
     end
 
@@ -21,12 +17,8 @@ shared_examples_for 'a jvm build' do
         executable('./gradlew')
       end
 
-      it 'installs with ./gradlew assemble' do
-        should run './gradlew assemble', echo: true, log: true, assert: true, timeout: timeout_for(:install)
-      end
-
-      it 'runs ./gradlew check' do
-        should run './gradlew check', echo: true, log: true, timeout: timeout_for(:script)
+      it 'runs ./gradlew build' do
+        should run './gradlew build', echo: true, log: true, timeout: timeout_for(:script)
       end
     end
   end


### PR DESCRIPTION
As coordinated with @gildegoma on #126, this PR makes `gradle` powered builds for Java use only a single stage approach. I've not changed `maven` behavior because I don't know if exists an equivalent command for it.

This is a pretty simple change, but if anyone find any issue with it, please inform me so I can provide any eventual fix.

Thanks :smile: 
