### PR TITLE
handle config errors

### DIFF
--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -57,7 +57,7 @@ module Travis
 
       def compile
         raw template 'header.sh'
-        run_stages
+        run_stages if check_config
         raw template 'footer.sh'
         sh.to_s
       end
@@ -67,6 +67,22 @@ module Travis
       end
 
       private
+
+        def check_config
+          case data.config[:".result"]
+          when 'not_found'
+            cmd 'echo -e "\033[31;1mCould not find .travis.yml, using standard configuration.\033[0m"', assert: false, echo: false
+            true
+          when 'server_error'
+            cmd 'echo -e "\033[31;1mCould not fetch .travis.yml from GitHub.\033[0m"', assert: false, echo: false
+            cmd 'travis_terminate 2', assert: false, echo: false
+            false
+          when nil
+            true
+          else
+            raise "unknown result %p" % data.config[:".result"]
+          end
+        end
 
         def config
           data.config

--- a/spec/shared/script.rb
+++ b/spec/shared/script.rb
@@ -80,4 +80,23 @@ shared_examples_for 'a build script' do
   it "fixed the DNS entries in /etc/resolv.conf" do
     subject.should include(%Q{echo 'nameserver 199.91.168.70\nnameserver 199.91.168.71' | sudo tee /etc/resolv.conf 2>&1 > /dev/null})
   end
+
+  describe "result" do
+    before do
+      data['config']['.result'] = result
+      data['config']['script'] = 'echo "THE SCIPT"'
+    end
+
+    describe "server error" do
+      let(:result) { "server_error" }
+      it { should include("echo -e \"\\033[31;1mCould not fetch .travis.yml from GitHub.\\033[0m\"\ntravis_terminate 2") }
+      it { should_not include('echo "THE SCIPT"') }
+    end
+
+    describe "not found" do
+      let(:result) { "not_found" }
+      it { should include("echo -e \"\\033[31;1mCould not find .travis.yml, using standard configuration.\\033[0m\"") }
+      it { should include('echo "THE SCIPT"') }
+    end
+  end
 end


### PR DESCRIPTION
This is not a full solution, we should actually be restarting the builds on server_error, but at least we tell the user what's going on and we don't run with the standard config on server error anymore.

Also displays a message (but still runs the build) if there simply is no .travis.yml.

`.result` is set by [fetch_config](https://github.com/travis-ci/travis-core/blob/master/lib/travis/github/services/fetch_config.rb#L13-L23).
