### PR TITLE
Set Scala default version to 2.10.3

### DIFF
--- a/lib/travis/build/script/scala.rb
+++ b/lib/travis/build/script/scala.rb
@@ -4,7 +4,7 @@ module Travis
       class Scala < Jvm
 
         DEFAULTS = {
-          scala: '2.10.0',
+          scala: '2.10.3',
           jdk:   'default'
         }
 

--- a/spec/script/scala_spec.rb
+++ b/spec/script/scala_spec.rb
@@ -14,26 +14,26 @@ describe Travis::Build::Script::Scala do
   it_behaves_like 'a jvm build'
 
   it 'sets TRAVIS_SCALA_VERSION' do
-    should set 'TRAVIS_SCALA_VERSION', '2.10.0'
+    should set 'TRAVIS_SCALA_VERSION', '2.10.3'
   end
 
-  it 'announces Scala 2.10.0' do
-    should run 'echo Using Scala 2.10.0'
+  it 'announces Scala 2.10.3' do
+    should run 'echo Using Scala 2.10.3'
   end
 
-  it 'runs sbt ++2.10.0 test if ./project directory exists' do
+  it 'runs sbt ++2.10.3 test if ./project directory exists' do
     directory('project')
-    should run_script 'sbt ++2.10.0 test'
+    should run_script 'sbt ++2.10.3 test'
   end
 
-  it 'runs sbt ++2.10.0 test if ./build.sbt exists' do
+  it 'runs sbt ++2.10.3 test if ./build.sbt exists' do
     file('build.sbt')
-    should run_script 'sbt ++2.10.0 test'
+    should run_script 'sbt ++2.10.3 test'
   end
 
   it "runs sbt with sbt_args if they are given" do
     file("build.sbt")
     data["config"]["sbt_args"] = "-Dsbt.log.noformat=true"
-    should run_script "sbt -Dsbt.log.noformat=true ++2.10.0 test"
+    should run_script "sbt -Dsbt.log.noformat=true ++2.10.3 test"
   end
 end


### PR DESCRIPTION
Scala 2.10.3 is now the official latest stable release.

Even if next VM setup will have boot libraries preinstalled for Scala 2.10.3, this change can already be rolled out on current production (dynamic downloads will take place when necessary).
