### PR TITLE
Enable pending example in spec/shared/jdk.rb

### DIFF
--- a/spec/shared/jdk.rb
+++ b/spec/shared/jdk.rb
@@ -4,7 +4,7 @@ shared_examples_for 'a jdk build' do
       data['config']['jdk'] = nil
     end
 
-    xit 'does not set TRAVIS_JDK_VERSION' do
+    it 'does not set TRAVIS_JDK_VERSION' do
       should_not set 'TRAVIS_JDK_VERSION'
     end
 


### PR DESCRIPTION
Is there any reason to keep this example pending?
