### PR TITLE
Specify --tags with git describe

### DIFF
--- a/lib/travis/build/script/addons/deploy.rb
+++ b/lib/travis/build/script/addons/deploy.rb
@@ -50,7 +50,7 @@ module Travis
             end
 
             def want_tags(on)
-              '$(git describe --exact-match)' if on[:tags]
+              '$(git describe --tags --exact-match)' if on[:tags]
             end
 
             def want_condition(on)


### PR DESCRIPTION
git describe only looks at annotated tags unless you use --tags.
