### PR TITLE
Fix issue where CocoaPods is running actool

### DIFF
--- a/lib/travis/build/script/objective_c.rb
+++ b/lib/travis/build/script/objective_c.rb
@@ -17,6 +17,13 @@ module Travis
           has_podfile? then: 'pod --version'
         end
 
+        def setup
+          super
+
+          cmd "echo '#!/bin/bash\n# no-op' > /usr/local/bin/actool", echo: false
+          cmd "chmod +x /usr/local/bin/actool", echo: false
+        end
+
         def install
           has_gemfile? then: 'bundle install', fold: 'install.bundler', retry: true
           has_podfile? then: 'pod install', fold: 'install.cocoapods', retry: true


### PR DESCRIPTION
actool was introduced with Xcode 5, so this command is not available on our VMs yet. Was adviced [on Twitter](https://twitter.com/alloy/status/393438997902819328) to make it a no-op.
