### PR TITLE
All Rubies can behave like a JDK builder

### DIFF
--- a/lib/travis/build/script/ruby.rb
+++ b/lib/travis/build/script/ruby.rb
@@ -86,11 +86,7 @@ module Travis
           end
 
           def uses_java?
-            config[:rvm] =~ /jruby/i
-          end
-
-          def uses_jdk?
-            uses_java? && super
+            uses_jdk?
           end
       end
     end

--- a/spec/script/ruby_spec.rb
+++ b/spec/script/ruby_spec.rb
@@ -79,20 +79,19 @@ describe Travis::Build::Script::Ruby do
     should run_script 'rake'
   end
 
-  describe 'using jruby' do
+  describe 'using a jdk' do
     before :each do
-      data['config']['rvm'] = 'jruby'
       data['config']['jdk'] = 'openjdk7'
     end
 
     after :each do
-      store_example 'jruby'
+      store_example 'ruby_with_jdk'
     end
 
     it_behaves_like 'a jdk build'
   end
 
-  describe 'not using jruby' do
+  describe 'not using a jdk' do
     it 'does not announce java' do
       should_not announce 'java'
     end


### PR DESCRIPTION
A Non-JRuby project may rely on a specific JDK in their build chain.

Examples:
- https://github.com/ruboto/ruboto/blob/master/.travis.yml
- https://github.com/cassandra-rb/cassandra/blob/master/.travis.yml

Motivated by travis-ci/travis-ci#686

**Note:** JDK switch is possible for Ruby language, because multiple JDK versions are available on the Ruby worker VM.
