### PR TITLE
Remove --use-mirrors from pip.

### DIFF
--- a/spec/script/python_spec.rb
+++ b/spec/script/python_spec.rb
@@ -49,7 +49,7 @@ describe Travis::Build::Script::Python do
     end
 
     it 'installs with pip' do
-      should install 'pip install -r Requirements.txt --use-mirrors', retry: true
+      should install 'pip install -r Requirements.txt', retry: true
     end
   end
 
@@ -60,7 +60,7 @@ describe Travis::Build::Script::Python do
 
     # TODO [[ -f file ]] matches case insensitive on mac osx but doesn't on ubuntu?
     xit 'installs with pip' do
-      should install 'pip install -r requirements.txt --use-mirrors', retry: true
+      should install 'pip install -r requirements.txt', retry: true
     end
   end
   


### PR DESCRIPTION
Per https://pypi.python.org/mirrors this is no longer recommended as pypi uses a CDN.

See also https://github.com/travis-ci/travis-ci.github.com/pull/381
