### PR TITLE
Run build script using login shell

### DIFF
--- a/lib/travis/build/script/templates/header.sh
+++ b/lib/travis/build/script/templates/header.sh
@@ -1,5 +1,4 @@
 #!/bin/bash --login
-source /etc/profile
 
 travis_start() {
   TRAVIS_STAGE=$1


### PR DESCRIPTION
I think the build script has always been intended to be run using a login shell, however, due to the way this is run it's not run in a login shell, which means that RVM isn't sourced unless you add it to some other places (which is done on the Linux VMs but not the OS X VMs). The OS X worker is currently running with this, I think it should be fine to deploy to Linux as well, although we probably want to test this on staging first.
