### PR TITLE
Export sbt environment variables in 'setup' stage

### DIFF
--- a/lib/travis/build/script/scala.rb
+++ b/lib/travis/build/script/scala.rb
@@ -15,9 +15,13 @@ module Travis
         def export
           super
           set 'TRAVIS_SCALA_VERSION', config[:scala], echo: false
+        end
+
+        def setup
+          super
           self.if '-d project || -f build.sbt' do
-            set 'JVM_OPTS', '@/etc/sbt/jvmopts', echo: false
-            set 'SBT_OPTS', '@/etc/sbt/sbtopts', echo: false
+            set 'JVM_OPTS', '@/etc/sbt/jvmopts', echo: true
+            set 'SBT_OPTS', '@/etc/sbt/sbtopts', echo: true
           end
         end
 


### PR DESCRIPTION
In #154, export of SBT_OPTS and JVM_OPTS were wrongly added to 'export'
stage, which is _useless_ since this stage is executed before 'git clone' of project repository.

I propose to do these exports in 'setup' stage, similarly to `jdk_switcher` call in [jdk.rb](https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/script/jdk.rb#L12)
