### PR TITLE
deploy: Add `true` as a valid key instead of `:on`

### DIFF
--- a/lib/travis/build/script/addons/deploy.rb
+++ b/lib/travis/build/script/addons/deploy.rb
@@ -30,7 +30,7 @@ module Travis
           private
             def on
               @on ||= begin
-                on = config.delete(:on) || config.delete(:true) || {}
+                on = config.delete(:on) || config.delete(true) || config.delete(:true) || {}
                 on = { branch: on.to_str } if on.respond_to? :to_str
                 on[:ruby] ||= on[:rvm] if on.include? :rvm
                 on


### PR DESCRIPTION
The YAML `on: foo` is parsed into the Ruby hash `{true=>"foo"}`. We call `deep_symbolize_keys` on the hash, but boolean values are not symbolized.

/cc @rkh
