### PR TITLE
Skip generating JavaDocs during Maven builds

### DIFF
--- a/lib/travis/build/script/jvm.rb
+++ b/lib/travis/build/script/jvm.rb
@@ -11,7 +11,7 @@ module Travis
         def install
           self.if   '-f gradlew',      './gradlew assemble', fold: 'install', retry: true
           self.elif '-f build.gradle', 'gradle assemble', fold: 'install', retry: true
-          self.elif '-f pom.xml',      'mvn install -DskipTests=true -B -V', fold: 'install', retry: true # Otherwise mvn install will run tests which. Suggestion from Charles Nutter. MK.
+          self.elif '-f pom.xml',      'mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V', fold: 'install', retry: true # Otherwise mvn install will run tests which. Suggestion from Charles Nutter. MK.
         end
 
         def script

--- a/spec/shared/jvm.rb
+++ b/spec/shared/jvm.rb
@@ -36,8 +36,8 @@ shared_examples_for 'a jvm build' do
       file('pom.xml')
     end
 
-    it 'installs with mvn install -DskipTests=true -B' do
-      should run 'mvn install -DskipTests=true -B', echo: true, log: true, assert: true
+    it 'installs with mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V' do
+      should run 'mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V', echo: true, log: true, assert: true
     end
 
     it 'runs mvn test -B' do


### PR DESCRIPTION
Generating JavaDocs takes quite some time and may also break the build.

Defaulting to skip the doc generation is probably preferable. It may be noted in the docs that it can be enabled with a custom `script:` command for anyone who needs this to be part of the build.
