### PR TITLE
Update PATH for the right PostgreSQL version's psql tools

### DIFF
--- a/lib/travis/build/script/addons/postgresql.rb
+++ b/lib/travis/build/script/addons/postgresql.rb
@@ -10,6 +10,7 @@ module Travis
 
           def before_install
             @script.fold('postgresql') do |script|
+              script.set "PATH", "/usr/lib/postgresql/#{@postgresql_version}/bin:$PATH", echo: false, assert: false
               script.cmd "echo -e \"\033[33;1mStart PostgreSQL v#{@postgresql_version}\033[0m\"; ", assert: false, echo: false
               script.cmd "sudo service postgresql stop", assert: false
               script.cmd "sudo service postgresql start #{@postgresql_version}", assert: false

--- a/spec/script/addons/postgresql_spec.rb
+++ b/spec/script/addons/postgresql_spec.rb
@@ -16,4 +16,9 @@ describe Travis::Build::Script::Addons::Postgresql do
     script.expects(:cmd).with("sudo service postgresql start 9.3", assert: false)
     subject
   end
+
+  it "updates the PATH with the right version for the psql tools" do
+    script.expects(:set).with('PATH', '/usr/lib/postgresql/9.3/bin:$PATH', echo: false, assert: false)
+    subject
+  end
 end


### PR DESCRIPTION
There's a potential for conflict when using different versions
of the command line tools (installed in /usr/bin, overwriting each
other currently) are used with a different version of the server.

As we don't have full control about which version of the tools are
installed in /usr/bin, this change automatically prepends the right
version to the PATH.

Maybe we should set a default for 9.1?
