### PR TITLE
Fix accidental escaping of $HOME in $TRAVIS_BUILD_DIR.

### DIFF
--- a/lib/travis/build/data/env.rb
+++ b/lib/travis/build/data/env.rb
@@ -25,7 +25,7 @@ module Travis
               TRAVIS_SECURE_ENV_VARS: secure_env_vars?,
               TRAVIS_BUILD_ID:        build[:id],
               TRAVIS_BUILD_NUMBER:    build[:number],
-              TRAVIS_BUILD_DIR:       [ BUILD_DIR, repository[:slug] ].join('/').shellescape,
+              TRAVIS_BUILD_DIR:       [ BUILD_DIR, repository[:slug].shellescape ].join('/'),
               TRAVIS_JOB_ID:          job[:id],
               TRAVIS_JOB_NUMBER:      job[:number],
               TRAVIS_BRANCH:          job[:branch].shellescape,

--- a/spec/data/env_spec.rb
+++ b/spec/data/env_spec.rb
@@ -25,5 +25,26 @@ describe Travis::Build::Data::Env do
   it 'escapes TRAVIS_ vars as needed' do
     env.vars.find { |var| var.key == 'TRAVIS_BRANCH' }.value.should == "foo-\\(dev\\)"
   end
+
+  context "with TRAVIS_BUILD_DIR including $HOME" do
+    before do
+      replace_const 'Travis::Build::BUILD_DIR', '$HOME'
+    end
+
+    after do
+      replace_const 'Travis::Build::BUILD_DIR', './tmp'
+    end
+
+    it "shouldn't escape $HOME" do
+      env.vars.find {|var| var.key == 'TRAVIS_BUILD_DIR'}.value.should == "$HOME/travis-ci/travis-ci"
+    end
+
+    it "should escape the repository slug" do
+      data.stubs(:repository).returns(slug: 'travis-ci/travis-ci ci')
+      env.vars.find {|var| var.key == 'TRAVIS_BUILD_DIR'}.value.should == "$HOME/travis-ci/travis-ci\\ ci"
+    end
+  end
+
+
 end
 


### PR DESCRIPTION
Related to the escaping code introduced in #179, which broke usage of $TRAVIS_BUILD_DIR mentioned in travis-ci/travis-ci#1727.
