### PR TITLE
Accept addons specified as list.

### DIFF
--- a/lib/travis/build/script/addons.rb
+++ b/lib/travis/build/script/addons.rb
@@ -25,7 +25,7 @@ module Travis
         end
 
         def addons
-          @addons ||= (config[:addons] || {}).map do |name, addon_config|
+          @addons ||= (config[:addons] || {}).map(&:flatten).map do |name, addon_config|
             init_addon(name, addon_config)
           end
         end

--- a/spec/script/addons_spec.rb
+++ b/spec/script/addons_spec.rb
@@ -45,4 +45,12 @@ describe Travis::Build::Script::Generic do
 
     should set 'SAUCE_USERNAME', 'johndoe'
   end
+
+  it "works with addons as a list" do
+    data['config']['addons'] = [
+      { 'firefox' => '20.0' }
+    ]
+    subject
+    store_example "addons_hosts"
+  end
 end


### PR DESCRIPTION
Some folks specify a list in their addons section, causing a nasty
error message to show up in the build logs. This change accepts
both a hash and a list.

Both of these will work:

```
addons:
  - firefox: 19
```

and

```
addons:
  firefox: 19
```
