### PR TITLE
Show maven version on the install step by default

### DIFF
--- a/lib/travis/build/script/jvm.rb
+++ b/lib/travis/build/script/jvm.rb
@@ -11,7 +11,7 @@ module Travis
         def install
           self.if   '-f gradlew',      './gradlew assemble', fold: 'install', retry: true
           self.elif '-f build.gradle', 'gradle assemble', fold: 'install', retry: true
-          self.elif '-f pom.xml',      'mvn install -DskipTests=true -B', fold: 'install', retry: true # Otherwise mvn install will run tests which. Suggestion from Charles Nutter. MK.
+          self.elif '-f pom.xml',      'mvn install -DskipTests=true -B -V', fold: 'install', retry: true # Otherwise mvn install will run tests which. Suggestion from Charles Nutter. MK.
         end
 
         def script


### PR DESCRIPTION
This is based on a user's feature request - when a build fails because of the dependencies problem, knowing the exact maven version can help with debugging.
