### PR TITLE
Add `TRAVIS_OS_NAME` env var

### DIFF
--- a/lib/travis/build/data/env.rb
+++ b/lib/travis/build/data/env.rb
@@ -32,6 +32,7 @@ module Travis
               TRAVIS_COMMIT:          job[:commit],
               TRAVIS_COMMIT_RANGE:    job[:commit_range],
               TRAVIS_REPO_SLUG:       repository[:slug].shellescape,
+              TRAVIS_OS_NAME:         job[:os],
             )
           end
 

--- a/spec/data/env_spec.rb
+++ b/spec/data/env_spec.rb
@@ -1,7 +1,14 @@
 require 'spec_helper'
 
 describe Travis::Build::Data::Env do
-  let(:data) { stub('data', secure_env_enabled?: false, pull_request: '100', config: { env: 'FOO=foo' }, build: { id: '1', number: '1' }, job: { id: '1', number: '1.1', branch: 'foo-(dev)', commit: '313f61b', commit_range: '313f61b..313f61a' }, repository: { slug: 'travis-ci/travis-ci' }) }
+  let(:data) { stub('data',
+    secure_env_enabled?: false,
+    pull_request: '100',
+    config: { env: 'FOO=foo' },
+    build: { id: '1', number: '1' },
+    job: { id: '1', number: '1.1', branch: 'foo-(dev)', commit: '313f61b', commit_range: '313f61b..313f61a', os: 'linux' },
+    repository: { slug: 'travis-ci/travis-ci' }
+    ) }
   let(:env)  { described_class.new(data) }
 
   it 'vars respond to :key' do
@@ -10,7 +17,7 @@ describe Travis::Build::Data::Env do
 
   it 'includes all travis env vars' do
     travis_vars = env.vars.select { |v| v.key =~ /^TRAVIS_/ && v.value && v.value.length > 0 }
-    travis_vars.length.should == 11
+    travis_vars.length.should == 12
   end
 
   it 'includes config env vars' do

--- a/spec/shared/script.rb
+++ b/spec/shared/script.rb
@@ -23,6 +23,7 @@ shared_examples_for 'a build script' do
     should set 'TRAVIS_COMMIT',          '313f61b'
     should set 'TRAVIS_COMMIT_RANGE',    '313f61b..313f61a'
     should set 'TRAVIS_REPO_SLUG',       'travis-ci/travis-ci'
+    should set 'TRAVIS_OS_NAME',         'linux'
   end
 
   it 'sets TRAVIS_PULL_REQUEST to the given number when running a pull_request' do

--- a/spec/support/payloads.rb
+++ b/spec/support/payloads.rb
@@ -24,6 +24,7 @@ PAYLOADS = {
       'commit' => '313f61b',
       'branch' => 'master',
       'commit_range' => '313f61b..313f61a',
+      'os' => 'linux',
       'secure_env_enabled' => true
     }
   }


### PR DESCRIPTION
Based on a Job's `:os` parameter, set the environment variable
`TRAVIS_OS_NAME`.
