### PR TITLE
Ensure success when calling pkill

### DIFF
--- a/lib/travis/build/script/templates/header.sh
+++ b/lib/travis/build/script/templates/header.sh
@@ -27,7 +27,7 @@ travis_result() {
 
 travis_terminate() {
   travis_finish build $1
-  pkill -9 -P $$ > /dev/null 2>&1
+  pkill -9 -P $$ > /dev/null 2>&1 || true
   exit $1
 }
 


### PR DESCRIPTION
An innocuous `set -e` can terminate our build script prematurely.
Ensure our correct exit by calling `true`.

This fixes https://github.com/travis-ci/travis-ci/issues/891.
