### PR TITLE
fix(objective-c): start up the simulator at the beginning of the build

### DIFF
--- a/lib/travis/build/script/objective_c.rb
+++ b/lib/travis/build/script/objective_c.rb
@@ -22,6 +22,8 @@ module Travis
 
           cmd "echo '#!/bin/bash\n# no-op' > /usr/local/bin/actool", echo: false
           cmd "chmod +x /usr/local/bin/actool", echo: false
+
+          cmd "osascript -e 'set simpath to \"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Applications/iPhone Simulator.app/Contents/MacOS/iPhone Simulator\" as POSIX file' -e 'tell application \"Finder\"' -e 'open simpath' -e 'end tell'"
         end
 
         def install


### PR DESCRIPTION
Starting the simulator at the beginning of the build causes interaction with the simulator to be much more stable. While testing this it looked like the command finished very quickly, since it only tells the Finder to open the simulator, it does not wait for it to open. Therefore I do not think it's an issue to run this command for every build.

@krohling Does this look correct to you?

I tried adding specs for this, but due to the way our tests work the quotes are removed so it's hard to test that the command was run like it should. I manually checked the build script that was created, and the command was inserted correctly. If anyone has suggestions on how to get this tested, I'd love to hear them.
