### PR TITLE
Adds travis_time tags to logs [WIP]

### DIFF
--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -53,7 +53,7 @@ module Travis
       def initialize(data, options = {})
         @data = Data.new({ config: self.class.defaults }.deep_merge(data.deep_symbolize_keys))
         @options = options
-        @stack = [Shell::Script.new(log: true, echo: true)]
+        @stack = [Shell::Script.new(log: true, echo: true, timing: true)]
       end
 
       def compile

--- a/lib/travis/build/script/templates/header.sh
+++ b/lib/travis/build/script/templates/header.sh
@@ -5,6 +5,19 @@ RED="\033[31;1m"
 GREEN="\033[32;1m"
 RESET="\033[0m"
 
+travis_time_start() {
+  travis_start_time=$(date +%s)
+  echo -en "travis_time:start\r\033[0K"
+}
+
+travis_time_finish() {
+  local result=$?
+  travis_end_time=$(date +%s)
+  local duration=$(($travis_end_time-$travis_start_time))
+  echo -en "travis_time:finish:start=$travis_start_time,finish=$travis_end_time,duration=$duration\r\033[0K"
+  return $result
+}
+
 travis_assert() {
   local result=$?
   if [ $result -ne 0 ]; then

--- a/lib/travis/build/shell.rb
+++ b/lib/travis/build/shell.rb
@@ -7,6 +7,7 @@ module Travis
       autoload :Cmd,     'travis/build/shell/node'
 
       Cmd.send(:include, Filters::Retry)
+      Cmd.send(:include, Filters::Timing)
       Cmd.send(:include, Filters::Assertion)
       Cmd.send(:include, Filters::Echoize)
 

--- a/lib/travis/build/shell/dsl.rb
+++ b/lib/travis/build/shell/dsl.rb
@@ -21,7 +21,7 @@ module Travis
         end
 
         def set(var, value, options = {})
-          cmd "export #{var}=#{value}", options.merge(log: false)
+          cmd "export #{var}=#{value}", options.merge(log: false, timing: false)
         end
 
         def echo(string, options = {})

--- a/lib/travis/build/shell/filters.rb
+++ b/lib/travis/build/shell/filters.rb
@@ -12,6 +12,18 @@ module Travis
           end
         end
 
+        module Timing
+          def code
+            timing = options[:timing]
+            echo = options[:echo]
+            timing && echo ? measure(super) : super
+          end
+
+          def measure(code)
+            "travis_time_start\n#{code}\ntravis_time_finish"
+          end
+        end
+
         module Echoize
           def code
             echo = options[:echo]

--- a/spec/shared/jdk.rb
+++ b/spec/shared/jdk.rb
@@ -47,7 +47,6 @@ shared_examples_for 'a jdk build' do
     it "sets TERM to 'dumb'" do
       is_expected.to set 'TERM', 'dumb'
     end
-
   end
 end
 

--- a/spec/shared/script.rb
+++ b/spec/shared/script.rb
@@ -52,7 +52,7 @@ shared_examples_for 'a build script' do
     it "runs the given :#{script} command" do
       data['config'][script] = script
       assert = %w(before_install install before_script).include?(script)
-      is_expected.to run script, echo: true, log: true, assert: assert
+      is_expected.to run script, echo: true, log: true, assert: assert, timing: true
     end
 
     next if script == 'script'

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -17,6 +17,19 @@ def folds?(lines, cmd, name)
   ix_start && ix_end && lines[ix_start..ix_end].index { |line| line =~ cmd }
 end
 
+def measures_time?(lines, cmd)
+  cmd = /^(?:travis_retry )?#{Regexp.escape(cmd)}/ if cmd.is_a?(String)
+
+  icmd = lines.index { |line| line =~ cmd }
+
+  return false unless icmd
+
+  x_start = lines[icmd - 1] =~ /^echo -en travis_time:start/
+  x_end   = lines[icmd + 1] =~ /^echo -en travis_time:finish:/
+
+  x_start && x_end
+end
+
 def logs?(lines, cmd)
   # cmd = /^output from #{Regexp.escape(cmd)}/
   # lines = File.read('tmp/build.log').split("\n")
@@ -32,6 +45,7 @@ end
 def asserts?(lines, cmd)
   cmd = /^(?:travis_retry )?#{Regexp.escape(cmd)}/ if cmd.is_a?(String)
   ix = lines.index { |line| line =~ cmd }
+  ix = ix + 1 if measures_time?(lines, cmd)
   ix && lines[ix + 1] == "travis_assert"
 end
 
@@ -77,7 +91,7 @@ end
 
 RSpec::Matchers.define :run_script do |cmd, options = {}|
   match do |script|
-    options = options.merge(echo: true, log: true)
+    options = options.merge(echo: true, log: true, timing: true)
     expect(script).to run cmd, options
   end
   failure_message do |script|
@@ -93,6 +107,7 @@ RSpec::Matchers.define :run do |cmd, options = {}|
     (!options[:log]     || logs?(lines, cmd)) &&
     (!options[:echo]    || echoes?(lines, cmd)) &&
     (!options[:retry]   || retries?(lines, cmd)) &&
+    (!options[:timing]  || measures_time?(lines, cmd)) &&
     (!options[:assert]  || asserts?(lines, cmd))
   end
   failure_message do |script|
@@ -147,5 +162,17 @@ RSpec::Matchers.define :fold do |cmd, name|
   end
   failure_message do |script|
     "expected the script to mark #{cmd} with fold markers named #{name.inspect}"
+  end
+end
+
+RSpec::Matchers.define :measures_time do |cmd|
+  match do |script|
+    lines = log_for(script).split("\n")
+
+    failure_message_for_should do
+      "expected the script to mark #{cmd} with fold markers named #{name.inspect}"
+    end
+
+    measures_time?(lines, cmd)
   end
 end


### PR DESCRIPTION
This adds `travis_time:start` and `travis_time:end:s=0.01:u=0.01:r=0.01` tags to logs. This is marked as WIP because it is more like proof of concept which I would like to discuss. It was much harder to come up with than I expected and I would love to hear, if you also think that this is the way to go.

All commands with `echo` and `timing` are wrapped in `time` block and wrapped in `travis_time` tags:

``` bash
  echo -en 'travis_time:start:\r'
  echo \$\ git\ fetch\ origin
  { time
  travis_retry git fetch origin;
  } 2> /tmp/timing.out
  travis_assert
  echo -en 'travis_time:end:`cat /tmp/timing.out`\r'
```

On the beginning I wanted to make `time` one line but it broke almost all of the tests, so for now there are new lines to avoid this. I am wondering whether I should make it one line and change matchers or leave it like that with new lines.

When command is finished, time is saved to timing.out file in `u=%U:r=%E:s=%S` format (it is set in environment variable `TIMEFORMAT="u=%U:r=%E:s=%S"`). Then on `travis_time:end` tag its content is added using `cat` command.

I am not sure if we need two tags, but I don't think that there is other way for knowing on what line command was displayed since we know time after output is printed. So basically time label in travis web would be shown where starting tag is, but time would be taken from ending tag.

I hope that I will proceed much faster with this feature from this point. Please let me know if you think that there is better way or if there is some hole in my logic. I will try to run travis locally soon and check this using `travis-web` (right now I am assuming that it will be possible to use it looking at how fold tags look like).

Related issue: travis-ci/travis-ci#1246
