### PR TITLE
Adding Go to the list of versioned runtimes supported by deploy addon

### DIFF
--- a/lib/travis/build/script/addons/deploy.rb
+++ b/lib/travis/build/script/addons/deploy.rb
@@ -3,7 +3,7 @@ module Travis
     class Script
       module Addons
         class Deploy
-          VERSIONED_RUNTIMES = [:jdk, :node, :perl, :php, :python, :ruby, :scala, :node]
+          VERSIONED_RUNTIMES = [:jdk, :node, :perl, :php, :python, :ruby, :scala, :node, :go]
           USE_RUBY           = '1.9.3'
           attr_accessor :script, :config, :allow_failure
 


### PR DESCRIPTION
as it appears it will "Just Work" and I was operating under the assumption that it _did_ already work.
