### PR TITLE
Add travis_wait

### DIFF
--- a/lib/travis/build/script/templates/header.sh
+++ b/lib/travis/build/script/templates/header.sh
@@ -61,7 +61,7 @@ travis_jigger() {
 
   while [ $count -lt $timeout ]; do
     count=$(($count + 1))
-    echo "Still running ($count of $timeout): $@"
+    echo -ne "Still running ($count of $timeout): $@\r"
     sleep 60
   done
 


### PR DESCRIPTION
Make it easier to run a task that is expected to run for a long
time without output

See travis-ci/travis-ci#1962
