### PR TITLE
fix(hosts-addon): change sed invocation to work on OS X

### DIFF
--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -131,7 +131,7 @@ module Travis
         end
 
         def fix_etc_hosts
-          cmd %Q{sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 '`hostname`'/' --in-place /etc/hosts}, assert: false, echo: false, log: false
+          cmd %Q{sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 '`hostname`'/' -i'' /etc/hosts}, assert: false, echo: false, log: false
         end
 
         def fix_ps4

--- a/lib/travis/build/script/addons/hosts.rb
+++ b/lib/travis/build/script/addons/hosts.rb
@@ -10,8 +10,8 @@ module Travis
 
           def setup
             @script.fold("hosts") do |script|
-              script.cmd("sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 #{@config.join(' ')}/' --in-place /etc/hosts")
-              script.cmd("sudo sed -e 's/^\\(::1.*\\)$/\\1 #{@config.join(' ')}/' --in-place /etc/hosts")
+              script.cmd("sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 #{@config.join(' ')}/' -i'' /etc/hosts")
+              script.cmd("sudo sed -e 's/^\\(::1.*\\)$/\\1 #{@config.join(' ')}/' -i'' /etc/hosts")
             end
           end
         end

--- a/spec/script/addons/hosts_spec.rb
+++ b/spec/script/addons/hosts_spec.rb
@@ -10,8 +10,8 @@ describe Travis::Build::Script::Addons::Hosts do
 
   it "runs the commands" do
     script.expects(:fold).with("hosts").yields(script)
-    script.expects(:cmd).with("sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 #{config}/' --in-place /etc/hosts")
-    script.expects(:cmd).with("sudo sed -e 's/^\\(::1.*\\)$/\\1 #{config}/' --in-place /etc/hosts")
+    script.expects(:cmd).with("sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 #{config}/' -i'' /etc/hosts")
+    script.expects(:cmd).with("sudo sed -e 's/^\\(::1.*\\)$/\\1 #{config}/' -i'' /etc/hosts")
     subject
   end
 
@@ -20,8 +20,8 @@ describe Travis::Build::Script::Addons::Hosts do
 
     it "runs the command" do
       script.expects(:fold).with("hosts").yields(script)
-      script.expects(:cmd).with("sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 johndoe.local example.local/' --in-place /etc/hosts")
-      script.expects(:cmd).with("sudo sed -e 's/^\\(::1.*\\)$/\\1 johndoe.local example.local/' --in-place /etc/hosts")
+      script.expects(:cmd).with("sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 johndoe.local example.local/' -i'' /etc/hosts")
+      script.expects(:cmd).with("sudo sed -e 's/^\\(::1.*\\)$/\\1 johndoe.local example.local/' -i'' /etc/hosts")
 
       subject
     end

--- a/spec/shared/script.rb
+++ b/spec/shared/script.rb
@@ -92,7 +92,7 @@ shared_examples_for 'a build script' do
   end
 
   it "adds an entry to /etc/hosts for localhost" do
-    subject.should include(%Q{sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 '`hostname`'/' --in-place /etc/hosts})
+    subject.should include(%Q{sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 '`hostname`'/' -i'' /etc/hosts})
   end
 
   describe "result" do


### PR DESCRIPTION
The sed installed on OS X is a BSD sed instead of a Gnu sed, and as such the options are different. The -i option should be available in both seds and do the same thing.

Could someone check if this works on OS X as well (`sed -i''  ...` as opposed to `sed -i '' ...`)?
