### PR TITLE
fix(go): use the right package paths for non-github.com githubs

### DIFF
--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -33,10 +33,10 @@ module Travis
           # easier to find and our `git clone`'d libraries are found by the
           # `go` commands.
           set 'GOPATH', "#{HOME_DIR}/gopath:$GOPATH"
-          cmd "mkdir -p #{HOME_DIR}/gopath/src/github.com/#{data.slug.split('/').first}"
-          cmd "cp -r $TRAVIS_BUILD_DIR #{HOME_DIR}/gopath/src/github.com/#{data.slug}"
-          set "TRAVIS_BUILD_DIR", "#{HOME_DIR}/gopath/src/github.com/#{data.slug}"
-          cd "#{HOME_DIR}/gopath/src/github.com/#{data.slug}"
+          cmd "mkdir -p #{HOME_DIR}/gopath/src/#{data.source_host}/#{data.slug.split('/').first}"
+          cmd "cp -r $TRAVIS_BUILD_DIR #{HOME_DIR}/gopath/src/#{data.source_host}/#{data.slug}"
+          set "TRAVIS_BUILD_DIR", "#{HOME_DIR}/gopath/src/#{data.source_host}/#{data.slug}"
+          cd "#{HOME_DIR}/gopath/src/#{data.source_host}/#{data.slug}"
         end
 
         def install

--- a/spec/script/go_spec.rb
+++ b/spec/script/go_spec.rb
@@ -53,6 +53,28 @@ describe Travis::Build::Script::Go do
     should run "cd #{Travis::Build::HOME_DIR}/gopath/src/github.com/travis-ci/travis-ci"
   end
 
+  context "on a GHE instance" do
+    before do
+      data['repository']['source_url'] = 'git@ghe.example.com:travis-ci/travis-ci.git'
+    end
+
+    it 'creates the src dir' do
+      should run "mkdir -p #{Travis::Build::HOME_DIR}/gopath/src/ghe.example.com/travis-ci"
+    end
+
+    it "copies the repository to the GOPATH" do
+      should run "cp -r #{Travis::Build::BUILD_DIR}/travis-ci/travis-ci #{Travis::Build::HOME_DIR}/gopath/src/ghe.example.com/travis-ci/travis-ci"
+    end
+
+    it "updates TRAVIS_BUILD_DIR" do
+      should set "TRAVIS_BUILD_DIR", "#{Travis::Build::HOME_DIR}/gopath/src/ghe.example.com/travis-ci/travis-ci"
+    end
+
+    it "cds to the GOPATH version of the project" do
+      should run "cd #{Travis::Build::HOME_DIR}/gopath/src/ghe.example.com/travis-ci/travis-ci"
+    end
+  end
+
   it 'installs the gvm version' do
     data['config']['go'] = 'go1.1'
     should run 'gvm install go1.1'


### PR DESCRIPTION
This is the case for GitHub Enterprise installations.

/cc @svenfuchs
