### PR TITLE
Include Travis specific environment variables.

### DIFF
--- a/lib/travis/build/data/env.rb
+++ b/lib/travis/build/data/env.rb
@@ -33,6 +33,9 @@ module Travis
               TRAVIS_COMMIT_RANGE:    job[:commit_range],
               TRAVIS_REPO_SLUG:       repository[:slug].shellescape,
               TRAVIS_OS_NAME:         job[:os],
+              TRAVIS:                 'true',
+              CI:                     'true',
+              CONTINUOUS_INTEGRATION: 'true'
             )
           end
 


### PR DESCRIPTION
These are currently set in the Linux environment by our
provisioning process. They're missing from Mac though as per
travis-ci/travis-ci#1764 and travis-ci/travis-ci#1769.

As all other environment variables are set in here, makes sense
to include these as well.
