### PR TITLE
feat(rvm): use .ruby-version file if it exists for default Ruby

### DIFF
--- a/lib/travis/build/script/rvm.rb
+++ b/lib/travis/build/script/rvm.rb
@@ -32,7 +32,7 @@ module Travis
             end
             cmd "rvm use #{ruby_version}"
           elsif ruby_version == 'default'
-            self.if "-f .ruby-version", then: "rvm use . || rvm use default"
+            self.if "-f .ruby-version", then: "rvm use . --install --binary --fuzzy"
             self.else "rvm use default"
           else
             cmd "rvm use #{ruby_version} --install --binary --fuzzy"

--- a/spec/script/ruby_spec.rb
+++ b/spec/script/ruby_spec.rb
@@ -26,7 +26,7 @@ describe Travis::Build::Script::Ruby do
     end
 
     it 'sets up rvm with .ruby-version' do
-      should setup 'rvm use . || rvm use default'
+      should setup 'rvm use . --install --binary --fuzzy'
     end
   end
 


### PR DESCRIPTION
If there is a .ruby-version file in the repository and a Ruby version isn't specified (or it's default), it would make more sense to pick the version in .ruby-version than whatever we have set as default.

Close travis-ci/travis-ci#1984.
