### PR TITLE
feat(services): start services using Homebrew on OS X

### DIFF
--- a/lib/travis/build/script/services.rb
+++ b/lib/travis/build/script/services.rb
@@ -12,7 +12,8 @@ module Travis
 
         def start_services
           services.each do |name|
-            cmd "sudo service #{name} start", timeout: :start_service, assert: false
+            self.if "hash brew 2>/dev/null", "brew services start #{name}", timeout: :start_service, assert: false
+            self.else                        "sudo service #{name} start", timeout: :start_service, assert: false
           end
           cmd 'sleep 3', log: false, assert: false if services.any? # give services a moment to start
         end


### PR DESCRIPTION
This is one of several steps towards making the OS X and Linux environment more similar.

This still needs to be updated more to use the right service names on OS X (I also need to pre-install the services that should be pre-installed), but I figured I'd start the discussion by showing some code.

@svenfuchs I think you were working on something to extract starting services into a Bash script? Maybe it would be a good idea to wait until that's merged.
