### PR TITLE
Highlight exit status report strings

### DIFF
--- a/lib/travis/build/script/templates/header.sh
+++ b/lib/travis/build/script/templates/header.sh
@@ -22,7 +22,8 @@ travis_assert() {
 travis_result() {
   local result=$1
   export TRAVIS_TEST_RESULT=$(( ${TRAVIS_TEST_RESULT:-0} | $(($result != 0)) ))
-  echo -e "\nThe command \"$TRAVIS_CMD\" exited with $result."<%= " >> #{logs[:log]}" if logs[:log] %>
+
+  travis_print_color_coded_result $result $TRAVIS_CMD
 }
 
 travis_terminate() {
@@ -58,7 +59,8 @@ travis_wait() {
     ps -p$jigger_pid 2>&1>/dev/null && kill $jigger_pid
   } || return 1
 
-  echo -e "\nThe command \"$cmd\" exited with $result."
+  travis_print_color_coded_result $result $cmd
+
   echo -e "\n\033[32;1mLog:\033[0m\n"
   cat $log_file
 
@@ -106,6 +108,20 @@ travis_retry() {
   }
 
   return $result
+}
+
+travis_print_color_coded_result() {
+  local result=$1
+  shift
+  local cmd=$@
+
+  message="The command \"$cmd\" exited with status $result"
+
+  if [ $result -eq 0 ]; then
+    echo -e "\n\033[32;1m${message}\033[0m"
+  else
+    echo -e "\n\033[31;1m${message}\033[0m"
+  fi
 }
 
 decrypt() {


### PR DESCRIPTION
Highlight `travis_result` and `travis_wait` message with green (if exit status is 0) and red (otherwise).
![travis_ci_-_free_hosted_continuous_integration_platform_for_the_open_source_community](https://cloud.githubusercontent.com/assets/25666/2543307/f6886ac6-b5f0-11e3-8e4f-b91906c815ac.png)
