### PR TITLE
Rework template logic

### DIFF
--- a/lib/travis/build/script/templates/header.sh
+++ b/lib/travis/build/script/templates/header.sh
@@ -68,9 +68,9 @@ travis_wait() {
   } || return 1
 
   if [ $result -eq 0 ]; then
-    echo -e "\nThe command \"$TRAVIS_CMD\" exited with $result."
+    echo -e "\n${GREEN}The command \"$TRAVIS_CMD\" exited with $result.${RESET}"
   else
-    echo -e "\nThe command \"$TRAVIS_CMD\" exited with $result."
+    echo -e "\n${RED}The command \"$TRAVIS_CMD\" exited with $result.${RESET}"
   fi
 
   echo -e "\n${GREEN}Log:${RESET}\n"


### PR DESCRIPTION
ANSI escapes are now constants, so they are more readable
Re-instate the ERb logic that was previously lost
