### PR TITLE
Add non-empty extension for sed

### DIFF
--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -131,7 +131,7 @@ module Travis
         end
 
         def fix_etc_hosts
-          cmd %Q{sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 '`hostname`'/' -i '' /etc/hosts}, assert: false, echo: false, log: false
+          cmd %Q{sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 '`hostname`'/' -i'.bak' /etc/hosts}, assert: false, echo: false, log: false
         end
 
         def fix_ps4

--- a/lib/travis/build/script/addons/hosts.rb
+++ b/lib/travis/build/script/addons/hosts.rb
@@ -10,8 +10,8 @@ module Travis
 
           def setup
             @script.fold("hosts") do |script|
-              script.cmd("sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 #{@config.join(' ')}/' -i '' /etc/hosts")
-              script.cmd("sudo sed -e 's/^\\(::1.*\\)$/\\1 #{@config.join(' ')}/' -i '' /etc/hosts")
+              script.cmd("sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 #{@config.join(' ')}/' -i'.bak' /etc/hosts")
+              script.cmd("sudo sed -e 's/^\\(::1.*\\)$/\\1 #{@config.join(' ')}/' -i'.bak' /etc/hosts")
             end
           end
         end

--- a/spec/script/addons/hosts_spec.rb
+++ b/spec/script/addons/hosts_spec.rb
@@ -10,8 +10,8 @@ describe Travis::Build::Script::Addons::Hosts do
 
   it "runs the commands" do
     script.expects(:fold).with("hosts").yields(script)
-    script.expects(:cmd).with("sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 #{config}/' -i '' /etc/hosts")
-    script.expects(:cmd).with("sudo sed -e 's/^\\(::1.*\\)$/\\1 #{config}/' -i '' /etc/hosts")
+    script.expects(:cmd).with("sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 #{config}/' -i'.bak' /etc/hosts")
+    script.expects(:cmd).with("sudo sed -e 's/^\\(::1.*\\)$/\\1 #{config}/' -i'.bak' /etc/hosts")
     subject
   end
 
@@ -20,8 +20,8 @@ describe Travis::Build::Script::Addons::Hosts do
 
     it "runs the command" do
       script.expects(:fold).with("hosts").yields(script)
-      script.expects(:cmd).with("sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 johndoe.local example.local/' -i '' /etc/hosts")
-      script.expects(:cmd).with("sudo sed -e 's/^\\(::1.*\\)$/\\1 johndoe.local example.local/' -i '' /etc/hosts")
+      script.expects(:cmd).with("sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 johndoe.local example.local/' -i'.bak' /etc/hosts")
+      script.expects(:cmd).with("sudo sed -e 's/^\\(::1.*\\)$/\\1 johndoe.local example.local/' -i'.bak' /etc/hosts")
 
       subject
     end

--- a/spec/shared/script.rb
+++ b/spec/shared/script.rb
@@ -92,7 +92,7 @@ shared_examples_for 'a build script' do
   end
 
   it "adds an entry to /etc/hosts for localhost" do
-    subject.should include(%Q{sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 '`hostname`'/' -i '' /etc/hosts})
+    subject.should include(%Q{sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 '`hostname`'/' -i'.bak' /etc/hosts})
   end
 
   describe "result" do


### PR DESCRIPTION
The sed commands are now compatible with both Linux and Mac.

See comments in https://github.com/travis-ci/travis-build/pull/207
