### PR TITLE
README uses SVG for build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Travis Build [![Build Status](https://travis-ci.org/travis-ci/travis-build.png?branch=master)](https://travis-ci.org/travis-ci/travis-build)
+# Travis Build [![Build Status](https://travis-ci.org/travis-ci/travis-build.svg?branch=master)](https://travis-ci.org/travis-ci/travis-build)
 
 Travis Build is a library that [Travis
 Workers](https://github.com/travis-ci/travis-worker) use to generate a shell


### PR DESCRIPTION
If you check the [rendered diff](https://github.com/travis-ci/travis-build/pull/225/files?short_path=04c6e90#diff-04c6e90faac2675aa89e2176d2eec7d8) you can see it looks much better.

Thanks for adding the SVG version Travis!
