### PR TITLE
Naive cocoapods caching implementation

### DIFF
--- a/lib/travis/build/script/objective_c.rb
+++ b/lib/travis/build/script/objective_c.rb
@@ -5,16 +5,27 @@ module Travis
     class Script
       class ObjectiveC < Script
         DEFAULTS = {
-          rvm:     'default'
+          rvm:     'default',
+          gemfile: 'Gemfile',
+          podfile: 'Podfile'
         }
 
         include RVM
+
+        def cache_slug
+          # ruby version is added by RVM]
+          super << "--podfile-" << config[:podfile].to_s
+        end
+
+        def use_directory_cache?
+          super or data.cache?(:bundler) or data.cache?(:cocoapods)
+        end
 
         def announce
           super
           cmd 'xcodebuild -version -sdk', fold: 'announce'
           uses_rubymotion? then: 'motion --version'
-          has_podfile? then: 'pod --version'
+          podfile? then: 'pod --version'
         end
 
         def export
@@ -36,8 +47,24 @@ module Travis
         end
 
         def install
-          has_gemfile? then: 'bundle install', fold: 'install.bundler', retry: true
-          has_podfile? then: 'pod install', fold: 'install.cocoapods', retry: true
+          gemfile? do |sh|
+            sh.if "-f #{config[:gemfile]}.lock" do |sub|
+              directory_cache.add(sub, bundler_path) if data.cache? :bundler
+              sub.cmd bundler_command("--deployment"), fold: 'install.bundler', retry: true
+            end
+
+            sh.else do |sub|
+              # cache bundler if it has been explicitely enabled
+              directory_cache.add(sub, bundler_path) if data.cache? :bundler, false
+              sub.cmd bundler_command, fold: 'install.bundler', retry: true
+            end
+          end
+
+          podfile? do |sh|
+            # cache cocoapods if it has been explicitely enabled
+            directory_cache.add(sh, cocoapods_path) if data.cache? :cocoapods, false
+            sh.cmd cocoapods_command, fold: 'install.cocoapods', retry: true
+          end
         end
 
         def script
@@ -55,12 +82,46 @@ module Travis
 
         private
 
-        def has_podfile?(*args)
-          self.if '-f Podfile', *args
+        def bundler_args_path
+          args = Array(bundler_args).join(" ")
+          path = args[/--path[= ](\S+)/, 1]
+          path ||= 'vendor/bundle' if args.include?('--deployment')
+          path
         end
 
-        def has_gemfile?(*args)
-          self.if '-f Gemfile', *args
+        def bundler_path
+          bundler_args_path || "${BUNDLE_PATH:-vendor/bundle}"
+        end
+
+        def bundler_args
+          config[:bundler_args]
+        end
+
+        def bundler_command(args = nil)
+          args = bundler_args if bundler_args
+          args = [args].flatten << "--path=#{bundler_path}" if data.cache?(:bundler) and !bundler_args_path
+          ["bundle install", *args].compact.join(" ")
+        end
+
+        def gemfile?(*args, &block)
+          self.if "-f #{config[:gemfile]}", *args, &block
+        end
+
+        def cocoapods_path
+          "${POD_PATH:-Pods}"
+        end
+
+        def cocoapods_args
+          config[:cocoapods_args]
+        end
+
+        def cocoapods_command(args = nil)
+          args = cocoapods_args if cocoapods_args
+          ["pod install", *args].compact.join(" ")
+        end
+
+        def podfile?(*args, &block)
+          self.if "-f #{config[:podfile]}", *args, &block
         end
 
         def uses_rubymotion?(*args)

--- a/play/cache_cocoapods.rb
+++ b/play/cache_cocoapods.rb
@@ -1,0 +1,66 @@
+#!/usr/bin/env ruby
+
+$: << 'lib'
+require 'travis/build'
+
+data = {
+  urls: {
+    log:   'http://localhost:3000/jobs/1/log',
+    state: 'http://localhost:3000/jobs/1/state', # not sure about this ...
+  },
+  repository: {
+    source_url: 'http://github.com/travis-ci/travis-support.git',
+    github_id: 42,
+    slug: 'travis-support'
+  },
+  source: {
+    id: 1,
+    number: 1
+  },
+  job: {
+    id: 1,
+    number: '1.1',
+    branch: 'master',
+    commit: 'a214c21',
+    commit_range: 'abcdefg..a214c21',
+    pull_request: false
+  },
+  cache_options: {
+    type: "s3",
+    fetch_timeout: 10*60,
+    push_timeout: 80*60,
+    s3: { bucket: 's3_bucket', secret_access_key: 's3_secret_access_key', access_key_id: 's3_access_key_id' }
+  },
+  config: {
+    language: 'objective-c',
+    rvm: '1.9.3',
+    bundler_args: '--without foo --deployment',
+    before_deploy: "foo bar",
+    cache: {
+      directories: ["foo", "bar"],
+      cocoapods: true
+    },
+    addons: {
+      deploy: {
+        provider: 'heroku',
+        on: { rvm: '1.9.3' },
+        app: {
+          production: 'travis-api-production',
+          staging: 'travis-api-staging'
+        }
+      }
+    }
+  },
+  timeouts: {
+    # git_clone: 300
+  }
+}
+
+# require 'yaml'
+# data[:config] = YAML.load_file('play/config.yml')
+
+# script = Travis::Build.script(data, logs: { build: false, state: true })
+script = Travis::Build.script(data, logs: { build: false, state: true })
+script = script.compile
+puts script
+

--- a/spec/script/objective_c_spec.rb
+++ b/spec/script/objective_c_spec.rb
@@ -54,7 +54,7 @@ describe Travis::Build::Script::ObjectiveC do
     end
 
     it 'folds pod install' do
-      should fold 'pod install', 'install'
+      should fold 'pod install', 'install.cocoapods'
     end
   end
 


### PR DESCRIPTION
- This is a straight copy of the ruby bundler code
- It also allows caching bundler in obj-c projects if you want
- cocoapods doesn't support --deployment for obvious reasons

I think long term it makes sense to modularize the caching code but I
couldn't come up with a decent abstraction trivially and I really miss
the caching having moved to an ios project from ruby.

To be honest I'm not 100% sure this does what I want, not really knowing how the cacher works, and if I need a different directory cache per type of "bundle" I want cached. It seemed like I could just add multiple directories to the same bundle and it would "just work"

Edit:
I removed an option you can't seem to use with cocoapods.
