### PR TITLE
python: only load virtualenv on linux

### DIFF
--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -21,7 +21,7 @@ module Travis
 
         def setup
           super
-          cmd "source #{virtualenv_activate}"
+          cmd "source #{virtualenv_activate}" if config[:os] == "linux"
         end
 
         def announce

--- a/spec/script/python_spec.rb
+++ b/spec/script/python_spec.rb
@@ -29,6 +29,11 @@ describe Travis::Build::Script::Python do
     store_example '2.7'
   end
 
+  it 'does not set up the python version on OS X' do
+    data['config']['os'] = 'osx'
+    should_not run 'echo $ source ~/virtualenv/python2.7/bin/activate' # TODO can't really capture source, yet
+  end
+
   it 'announces python --version' do
     should announce 'python --version'
   end

--- a/spec/support/payloads.rb
+++ b/spec/support/payloads.rb
@@ -2,6 +2,7 @@ PAYLOADS = {
   :push => {
     'type' => 'test',
     'config' => {
+      'os' => 'linux',
       'env' => ['FOO=foo', 'SECURE BAR=bar'],
       'before_install' => ['./before_install_1.sh', './before_install_2.sh'],
       'before_script'  => ['./before_script_1.sh',  './before_script_2.sh'],


### PR DESCRIPTION
This allows `language: python` builds to run on OS X, although they need to set up Python manually (for now).

Requires travis-ci/travis-core#375 to be deployed before this can be deployed on the Linux workers. Should work on the OS X workers out of the box, though.
