### PR TITLE
Make git commands much more efficient

### DIFF
--- a/lib/travis/build/script/git.rb
+++ b/lib/travis/build/script/git.rb
@@ -13,9 +13,13 @@ module Travis
           if tarball_clone?
             download_tarball
           else
-            git_clone
-            cd dir
-            fetch_ref if fetch_ref?
+            if fetch_ref?
+              git_init
+              fetch_ref
+            else
+              git_clone
+              cd dir
+            end
             git_checkout
             submodules if submodules?
           end
@@ -67,6 +71,13 @@ module Travis
             end
           end
 
+          def git_init
+            cmd "mkdir -p #{dir}", assert: true
+            cd dir
+            cmd "git init"
+            cmd "git remote add origin #{data.source_url}"
+          end
+
           def rm_key
             raw 'rm -f ~/.ssh/source_rsa'
           end
@@ -76,7 +87,7 @@ module Travis
           end
 
           def fetch_ref
-            cmd "git fetch origin +#{data.ref}:", assert: true, fold: "git.#{next_git_fold_number}", retry: true
+            cmd "git fetch --depth=1 origin +#{data.ref}:", assert: true, fold: "git.#{next_git_fold_number}", retry: true
           end
 
           def git_checkout

--- a/spec/shared/git.rb
+++ b/spec/shared/git.rb
@@ -108,10 +108,31 @@ shared_examples_for 'a git repo' do
       is_expected.not_to run 'git\\ fetch'
     end
 
-    it 'fetches a ref if given' do
-      data['job']['ref'] = 'refs/pull/118/merge'
-      cmd = 'git fetch origin +refs/pull/118/merge:'
-      is_expected.to travis_cmd cmd, echo: true, assert: true, timing: true, retry: true
+    context 'with ref' do
+      before do
+        data['job']['ref'] = 'refs/pull/118/merge'
+      end
+
+      it 'does not clone' do
+        is_expected.not_to run 'git clone'
+      end
+
+      it 'creates the repo dir' do
+        is_expected.to travis_cmd 'mkdir -p travis-ci/travis-ci', assert: true
+      end
+
+      it 'inits a git repo' do
+        is_expected.to travis_cmd 'git init'
+      end
+
+      it 'sets the remote for the repo' do
+        is_expected.to travis_cmd 'git remote add origin git://github.com/travis-ci/travis-ci.git'
+      end
+
+      it 'fetches the ref' do
+        cmd = 'git fetch --depth=1 origin +refs/pull/118/merge:'
+        is_expected.to travis_cmd cmd, echo: true, assert: true, timing: true, retry: true
+      end
     end
 
     it 'removes the ssh key' do


### PR DESCRIPTION
When the branch is set, we only need to pull down that branch:
Adding --single-branch to the clone command tells git to only pull down the branch we need

When grabbing a specific ref, we only need the one ref:
Instead of pulling down 50 commits from each branch, initialize an empty git repo, setup the remote, and pull down the PR ref.

In the context of one of the apps I am working on, this lowers the git download from 140MB to about 1.6MB. While I realize everyone won't save that much, this should still help a lot.

For another reference, this would save about 140MB of download bandwidth per current rails PR build
