### PR TITLE
Fold potentially noisy RVM fetching

### DIFF
--- a/lib/travis/build/script/rvm.rb
+++ b/lib/travis/build/script/rvm.rb
@@ -39,11 +39,11 @@ module Travis
           elsif ruby_version == 'default'
             self.if "-f .ruby-version" do |script|
               script.cmd 'echo -e "\033[33mBETA:\033[0m Using Ruby version from .ruby-version. This is a beta feature and may be removed in the future."', echo: false, assert: false
-              script.cmd "rvm use . --install --binary --fuzzy"
+              fold("rvm.1") { script.cmd "rvm use . --install --binary --fuzzy" }
             end
             self.else "rvm use default"
           else
-            cmd "rvm use #{ruby_version} --install --binary --fuzzy"
+            fold("rvm.1") { cmd "rvm use #{ruby_version} --install --binary --fuzzy" }
           end
         end
 


### PR DESCRIPTION
Hide the following noise when using rubies that need fetching (such as 2.1.1, currently):

![travis ci - hosted continuous integration that just works 2014-05-02 23-21-34 2014-05-02 23-54-09](https://cloud.githubusercontent.com/assets/2560/2869787/bae76a74-d28f-11e3-9353-09bcc14829a6.png)
