### PR TITLE
Android: use gradle build instead of gradle check

### DIFF
--- a/lib/travis/build/script/android.rb
+++ b/lib/travis/build/script/android.rb
@@ -17,8 +17,8 @@ module Travis
         end
 
         def script
-          self.if   '-f gradlew',      './gradlew check connectedCheck'
-          self.elif '-f build.gradle', 'gradle check connectedCheck'
+          self.if   '-f gradlew',      './gradlew build connectedCheck'
+          self.elif '-f build.gradle', 'gradle build connectedCheck'
           self.elif '-f pom.xml',      'mvn install -B'
           self.else                    'ant debug installt test'
         end

--- a/spec/script/android_spec.rb
+++ b/spec/script/android_spec.rb
@@ -64,14 +64,14 @@ describe Travis::Build::Script::Android do
       end
 
       it 'runs ./gradlew check connectedCheck' do
-        should run_script './gradlew check connectedCheck'
-        should_not run_script 'gradle check connectedCheck'
+        should run_script './gradlew build connectedCheck'
+        should_not run_script 'gradle build connectedCheck'
       end
     end
 
     context 'without gradle wrapper' do
-      it 'runs gradle check connectedCheck' do
-        should run_script 'gradle check connectedCheck'
+      it 'runs gradle build connectedCheck' do
+        should run_script 'gradle build connectedCheck'
       end
     end
   end


### PR DESCRIPTION
As discussed with @andrewhr, it makes sense to use `build` (which will include `assemble`). All `check` tests are included.

Please @joshk could you merge this one for today's production rollout. The corresponding documentation update follows quite soon...

ref #238 and #142

@henrikhodne takes care to bring travis-build to green, thanks!
