### PR TITLE
Set TERM to 'dumb' for JVM builds

### DIFF
--- a/lib/travis/build/script/jvm.rb
+++ b/lib/travis/build/script/jvm.rb
@@ -20,6 +20,11 @@ module Travis
           self.elif '-f pom.xml',      'mvn test -B'
           self.else                    'ant test'
         end
+
+        def export
+          super
+          set 'TERM', 'dumb', echo: false
+        end
       end
     end
   end

--- a/spec/shared/jvm.rb
+++ b/spec/shared/jvm.rb
@@ -50,4 +50,8 @@ shared_examples_for 'a jvm build' do
       should run 'ant test', echo: true, log: true, timeout: timeout_for(:script)
     end
   end
+
+  it "sets TERM to 'dumb'" do
+    should set 'TERM', 'dumb'
+  end
 end


### PR DESCRIPTION
On JVM builds, set `TERM` to `dumb`. Fixes travis-ci/travis-ci#2275.
