### PR TITLE
Set TERM to 'dumb' when Gradle config is detected

### DIFF
--- a/lib/travis/build/script/jdk.rb
+++ b/lib/travis/build/script/jdk.rb
@@ -5,6 +5,9 @@ module Travis
         def export
           super
           set('TRAVIS_JDK_VERSION', config[:jdk], echo: false) if uses_jdk?
+          self.if '-f build.gradle' do
+            set('TERM', 'dumb', echo: false)
+          end
         end
 
         def setup

--- a/lib/travis/build/script/jvm.rb
+++ b/lib/travis/build/script/jvm.rb
@@ -21,10 +21,6 @@ module Travis
           self.else                    'ant test'
         end
 
-        def export
-          super
-          set 'TERM', 'dumb', echo: false
-        end
       end
     end
   end

--- a/spec/shared/jdk.rb
+++ b/spec/shared/jdk.rb
@@ -4,6 +4,10 @@ shared_examples_for 'a jdk build' do
       data['config']['jdk'] = nil
     end
 
+    it 'does not set TERM' do
+      should_not set 'TERM'
+    end
+
     it 'does not set TRAVIS_JDK_VERSION' do
       should_not set 'TRAVIS_JDK_VERSION'
     end
@@ -33,6 +37,17 @@ shared_examples_for 'a jdk build' do
 
   it 'runs javac -version' do
     should announce 'javac -version'
+  end
+
+  describe 'if build.gradle exists' do
+    before :each do
+      file('build.gradle')
+    end
+
+    it "sets TERM to 'dumb'" do
+      should set 'TERM', 'dumb'
+    end
+
   end
 end
 

--- a/spec/shared/jvm.rb
+++ b/spec/shared/jvm.rb
@@ -51,7 +51,4 @@ shared_examples_for 'a jvm build' do
     end
   end
 
-  it "sets TERM to 'dumb'" do
-    should set 'TERM', 'dumb'
-  end
 end


### PR DESCRIPTION
There are following issues with #240 (dfe2bfc):
- Android builder does not export TERM=dumb (common parts are in jdk.rb,
  not jvm.rb)
- TERM=dumb would be exported for all JVM languages, even if not built
  with Gradle.

@BanzaiMan @joshk The first point is mandatory and I think the second one is safer as this is not a general convention for other build tools like Ant, Maven, Leiningen or sbt (the risk to hurt something by always exporting `TERM=dumb` might be quite low, but I have no information on this, hence this safety way)
