### PR TITLE
Activate virtualenv inside announce for Python

### DIFF
--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -19,12 +19,8 @@ module Travis
           set 'TRAVIS_PYTHON_VERSION', config[:python], echo: false
         end
 
-        def setup
-          super
-          cmd "source #{virtualenv_activate}"
-        end
-
         def announce
+          cmd "source #{virtualenv_activate}"
           cmd 'python --version'
           cmd 'pip --version'
         end


### PR DESCRIPTION
Genral workflow was changed so that #announce is invoked inside
the #setup.

This fixes https://github.com/travis-ci/travis-ci/issues/2339
