### PR TITLE
directory-cache: change signature to use AWS's v4

### DIFF
--- a/lib/travis/build/script/directory_cache.rb
+++ b/lib/travis/build/script/directory_cache.rb
@@ -3,38 +3,127 @@ require 'base64'
 require 'digest/sha1'
 require 'addressable/uri'
 require 'shellwords'
+require 'uri'
 
 module Travis
   module Build
     class Script
       module DirectoryCache
         class S3
+          Location = Struct.new(:scheme, :region, :bucket, :path) do
+            def hostname
+              if region == "us-east-1"
+                "#{bucket}.s3.amazonaws.com"
+              else
+                "#{bucket}.s3-#{region}.amazonaws.com"
+              end
+            end
+          end
+
+          KeyPair = Struct.new(:id, :secret)
+
+          class AWS4Signature
+            def initialize(key_pair, verb, location, expires, timestamp=Time.now)
+              @key_pair = key_pair
+              @verb = verb
+              @location = location
+              @expires = expires
+              @timestamp = timestamp
+            end
+
+            def to_uri
+              query = canonical_query_params.dup
+              query["X-Amz-Signature"] = OpenSSL::HMAC.hexdigest("sha256", signing_key, string_to_sign)
+
+              Addressable::URI.new(
+                scheme: @location.scheme,
+                host: @location.hostname,
+                path: @location.path,
+                query_values: query,
+              )
+            end
+
+            private
+
+            def date
+              @timestamp.utc.strftime("%Y%m%d")
+            end
+
+            def timestamp
+              @timestamp.utc.strftime("%Y%m%dT%H%M%SZ")
+            end
+
+            def query_string
+              canonical_query_params.map { |key, value|
+                "#{URI.encode(key.to_s, /[^~a-zA-Z0-9_.-]/)}=#{URI.encode(value.to_s, /[^~a-zA-Z0-9_.-]/)}"
+              }.join("&")
+            end
+
+            def request_sha
+              OpenSSL::Digest::SHA256.hexdigest(
+                [
+                  @verb,
+                  @location.path,
+                  query_string,
+                  "host:#{@location.hostname}\n",
+                  "host",
+                  "UNSIGNED-PAYLOAD"
+                ].join("\n")
+              )
+            end
+
+            def canonical_query_params
+              @canonical_query_params ||= {
+                "X-Amz-Algorithm" => "AWS4-HMAC-SHA256",
+                "X-Amz-Credential" => "#{@key_pair.id}/#{date}/#{@location.region}/s3/aws4_request",
+                "X-Amz-Date" => timestamp,
+                "X-Amz-Expires" => @expires,
+                "X-Amz-SignedHeaders" => "host",
+              }
+            end
+
+            def string_to_sign
+              [
+                "AWS4-HMAC-SHA256",
+                timestamp,
+                "#{date}/#{@location.region}/s3/aws4_request",
+                request_sha
+              ].join("\n")
+            end
+
+            def signing_key
+              @signing_key ||= recursive_hmac(
+                "AWS4#{@key_pair.secret}",
+                date,
+                @location.region,
+                "s3",
+                "aws4_request",
+              )
+            end
+
+            def recursive_hmac(*args)
+              args.inject { |key, data| OpenSSL::HMAC.digest("sha256", key, data) }
+            end
+          end
+
           # TODO: Switch to different branch from master?
           CASHER_URL = "https://raw.githubusercontent.com/travis-ci/casher/%s/bin/casher"
           USE_RUBY   = "1.9.3"
-
-          attr_accessor :fetch_timeout, :push_timeout, :bucket, :secret_access_key, :access_key_id, :uri_parser, :host, :scheme, :slug, :data, :start, :casher_url
+          BIN_PATH   = "$CASHER_DIR/bin/casher"
 
           def initialize(data, slug, casher_branch, start = Time.now)
-            @fetch_timeout     = data.cache_options.fetch(:fetch_timeout)
-            @push_timeout      = data.cache_options.fetch(:push_timeout)
-            @bucket            = data.cache_options[:s3].fetch(:bucket)
-            @secret_access_key = data.cache_options[:s3].fetch(:secret_access_key)
-            @access_key_id     = data.cache_options[:s3].fetch(:access_key_id)
-            @scheme            = data.cache_options[:s3][:scheme] || "https"
-            @host              = data.cache_options[:s3][:host]   || "s3.amazonaws.com"
-            @slug              = slug
-            @data              = data
-            @start             = start
-            @casher_url        = CASHER_URL % casher_branch
+            @data = data
+            @slug = slug
+            @casher_branch = casher_branch
+            @start = start
           end
 
           def install(sh)
             sh.cmd "export CASHER_DIR=$HOME/.casher", log: false, echo: false
             sh.cmd "mkdir -p $CASHER_DIR/bin", log: false, echo: false
-            sh.cmd "curl #{casher_url} -L -o #{binary} -s --fail", echo: false, log: false, retry: true, assert: false
-            sh.cmd "[ $? -ne 0 ] && echo 'Failed to fetch casher from GitHub, disabling cache.' && echo > #{binary}", echo: false, log: false, assert: false
-            sh.if("-f #{binary}") { |sh| sh.cmd "chmod +x #{binary}", log: false, echo: false }
+            sh.cmd "curl #{CASHER_URL % @casher_branch} -L -o #{BIN_PATH} -s --fail", echo: false, log: false, retry: true, assert: false
+            sh.cmd "[ $? -ne 0 ] && echo 'Failed to fetch casher from GitHub, disabling cache.' && echo > #{BIN_PATH}", echo: false, log: false, assert: false
+            sh.if("-f #{BIN_PATH}") { |sh| sh.cmd "chmod +x #{BIN_PATH}", log: false, echo: false }
           end
 
           def add(sh, path)
@@ -43,7 +132,7 @@ module Travis
 
           def fetch(sh)
             urls = [Shellwords.escape(fetch_url.to_s)]
-            urls << Shellwords.escape(fetch_url('master').to_s) if data.branch != 'master'
+            urls << Shellwords.escape(fetch_url('master').to_s) if @data.branch != 'master'
             urls << Shellwords.escape(fetch_url(nil).to_s)
             run(sh, "fetch", *urls)
           end
@@ -52,12 +141,12 @@ module Travis
             run(sh, "push", Shellwords.escape(push_url.to_s))
           end
 
-          def fetch_url(branch = data.branch)
-            url("GET", prefixed(branch), expires: start + fetch_timeout)
+          def fetch_url(branch = @data.branch)
+            url("GET", prefixed(branch), expires: fetch_timeout)
           end
 
-          def push_url(branch = data.branch)
-            url("PUT", prefixed(branch), expires: start + push_timeout)
+          def push_url(branch = @data.branch)
+            url("PUT", prefixed(branch), expires: push_timeout)
           end
 
           def fold(sh, message = nil)
@@ -71,28 +160,37 @@ module Travis
 
           private
 
+            def fetch_timeout
+              @data.cache_options.fetch(:fetch_timeout)
+            end
+
+            def push_timeout
+              @data.cache_options.fetch(:push_timeout)
+            end
+
+            def location(path)
+              Location.new(
+                @data.cache_options[:s3].fetch(:scheme, "https"),
+                @data.cache_options[:s3].fetch(:region, "us-east-1"),
+                @data.cache_options[:s3].fetch(:bucket),
+                path
+              )
+            end
+
             def prefixed(branch)
-              args = [data.repository.fetch(:github_id), branch, slug].compact
+              args = [@data.repository.fetch(:github_id), branch, @slug].compact
               args.map! { |a| a.to_s.gsub(/[^\w\.\_\-]+/, '') }
-              File.join(*args)<< ".tbz"
+              "/" << args.join("/") << ".tbz"
             end
 
             def url(verb, path, options = {})
-              path    = File.join("/", bucket, path)
-              expires = Integer(options[:expires])
-              string  = [ verb, options[:md5], options[:content_type], expires, path ].join("\n")
-              hmac    = OpenSSL::HMAC.digest('sha1', secret_access_key, string)
-              Addressable::URI.new(host: host, scheme: scheme, path: path, query_values: {
-                AWSAccessKeyId: access_key_id, Expires: expires, Signature: Base64.encode64(hmac).strip })
-            end
-
-            def binary
-              "$CASHER_DIR/bin/casher"
+              @key_pair ||= KeyPair.new(@data.cache_options[:s3].fetch(:access_key_id), @data.cache_options[:s3].fetch(:secret_access_key))
+              AWS4Signature.new(@key_pair, verb, location(path), options[:expires], @start).to_uri
             end
 
             def run(sh, command, *arguments)
-              sh.if("-f #{binary}") do |sh|
-                sh.cmd("rvm #{USE_RUBY} --fuzzy do #{binary} #{command} #{arguments.join(" ")}", echo: false)
+              sh.if("-f #{BIN_PATH}") do |sh|
+                sh.cmd("rvm #{USE_RUBY} --fuzzy do #{BIN_PATH} #{command} #{arguments.join(" ")}", echo: false)
               end
             end
         end


### PR DESCRIPTION
I'm opening this as a PR for now until I have this tested on the Linux workers as well.

In order to do this as cleanly as possible, this also includes a refactoring of
the DirectoryCache implementation. The external API is shrunk to only the parts
used, but otherwise hasn't changed much.

BREAKING CHANGES

One change that could possibly break:
- The `host` config for s3 cache is no longer used. Use `region` instead.

This should not affect our Linux workers, since none of them use this config.
The OS X worker does use it, but this change is made to attempt to fix the
broken implementation.
