### PR TITLE
Fix travis_retry comparison.

### DIFF
--- a/lib/travis/build/script/templates/header.sh
+++ b/lib/travis/build/script/templates/header.sh
@@ -104,7 +104,7 @@ travis_retry() {
     sleep 1
   done
 
-  [ $count -eq 3 ] && {
+  [ $count -gt 3 ] && {
     echo "\n${RED}The command \"$@\" failed 3 times.${RESET}\n" >&2
   }
 


### PR DESCRIPTION
If the command fails the first time, fails the second time,
and succeeds the third time, travis_retry will incorrectly
report that the command failed three times (but still return
a successful exit code).
