### PR TITLE
Use ssh key from settings

### DIFF
--- a/lib/travis/build/data.rb
+++ b/lib/travis/build/data.rb
@@ -85,6 +85,8 @@ module Travis
       def ssh_key
         if ssh_key = data[:ssh_key]
           SshKey.new(ssh_key[:value], ssh_key[:source], ssh_key[:encoded])
+        elsif source_key = data[:config][:source_key]
+          SshKey.new(source_key, nil, true)
         end
       end
 

--- a/lib/travis/build/script/git.rb
+++ b/lib/travis/build/script/git.rb
@@ -29,11 +29,17 @@ module Travis
             data.ssh_key.encoded? ? ' | base64 --decode ' : ''
           end
 
+          def ssh_key_source
+            return unless data.ssh_key.source
+
+            source = data.ssh_key.source.gsub(/[_-]+/, ' ')
+            " from: #{source}"
+          end
+
           def install_ssh_key
             return unless data.ssh_key
 
-            source = data.ssh_key.source.gsub(/[_-]+/, ' ')
-            echo "\nInstalling an SSH key from #{source}\n"
+            echo "\nInstalling an SSH key#{ssh_key_source}\n"
             cmd "echo #{data.ssh_key.value.shellescape} #{decode_cmd} > ~/.ssh/id_rsa", echo: false, log: false
             cmd 'chmod 600 ~/.ssh/id_rsa',                echo: false, log: false
             cmd 'eval `ssh-agent` &> /dev/null',      echo: false, log: false

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -26,8 +26,15 @@ describe Travis::Build::Data do
   end
 
   describe 'ssh_key' do
+    it 'returns ssh_key from source_key as a fallback' do
+      data = Travis::Build::Data.new(config: { source_key: 'foo' })
+      data.ssh_key.value.should == 'foo'
+      data.ssh_key.source.should be_nil
+      data.ssh_key.should be_encoded
+    end
+
     it 'returns nil if there is no ssh_key' do
-      data = Travis::Build::Data.new({})
+      data = Travis::Build::Data.new({ config: {} })
       data.ssh_key.should be_nil
     end
 


### PR DESCRIPTION
This PR changes travis build to get `ssh_key` from payload, not from job's config. That way we can decide which key to send in travis hub. Currently I don't use `source`, because we can't distinguish between a key from a config file and a key from the DB.
