### PR TITLE
Deployment: Use build data rather than environmental variable to check whether build is a pull request

### DIFF
--- a/spec/script/addons/deploy_spec.rb
+++ b/spec/script/addons/deploy_spec.rb
@@ -1,8 +1,15 @@
+require 'ostruct'
 require 'spec_helper'
 
 describe Travis::Build::Script::Addons::Deploy do
   let(:script) { stub('script') }
+  let(:data) do
+    OpenStruct.new.tap do |o|
+      o.pull_request = false
+    end
+  end
 
+  before(:each) { script.stubs(:data).returns(data) }
   before(:each) { script.stubs(:fold).yields(script) }
   subject { described_class.new(script, config) }
 
@@ -12,7 +19,7 @@ describe Travis::Build::Script::Addons::Deploy do
     it 'runs the command' do
       script.expects(:run_stage).with(:before_deploy)
       script.expects(:else)
-      script.expects(:if).with('($TRAVIS_PULL_REQUEST = false) && ($TRAVIS_BRANCH = master)').yields(script)
+      script.expects(:if).with('($TRAVIS_BRANCH = master)').yields(script)
       script.expects(:cmd).with('rvm 1.9.3 --fuzzy do ruby -S gem install dpl', assert: true, echo: false)
       script.expects(:cmd).with(<<-DPL.gsub(/\s+/, ' ').strip, assert: false, echo: false)
         rvm 1.9.3 --fuzzy do ruby -S dpl --provider="heroku" --password="foo" --email="user@host" --fold;
@@ -32,9 +39,10 @@ describe Travis::Build::Script::Addons::Deploy do
     end
 
     it 'runs the command' do
+      script.data.expects(:pull_request)
       script.expects(:run_stage).with(:before_deploy)
       script.expects(:else)
-      script.expects(:if).with('($TRAVIS_PULL_REQUEST = false) && ($TRAVIS_BRANCH = staging || $TRAVIS_BRANCH = production)').yields(script)
+      script.expects(:if).with('($TRAVIS_BRANCH = staging || $TRAVIS_BRANCH = production)').yields(script)
       script.expects(:cmd).with('rvm 1.9.3 --fuzzy do ruby -S gem install dpl', assert: true, echo: false)
       script.expects(:cmd).with(<<-DPL.gsub(/\s+/, ' ').strip, assert: false, echo: false)
         rvm 1.9.3 --fuzzy do ruby -S dpl --provider="heroku" --app="foo" --fold;
@@ -51,7 +59,7 @@ describe Travis::Build::Script::Addons::Deploy do
     it 'runs the command' do
       script.expects(:run_stage).with(:before_deploy)
       script.expects(:else)
-      script.expects(:if).with('($TRAVIS_PULL_REQUEST = false) && ($TRAVIS_BRANCH = master) && ("$TRAVIS_TAG" != "")').yields(script)
+      script.expects(:if).with('($TRAVIS_BRANCH = master) && ("$TRAVIS_TAG" != "")').yields(script)
       script.expects(:cmd).with('rvm 1.9.3 --fuzzy do ruby -S gem install dpl', assert: true, echo: false)
       script.expects(:cmd).with(<<-DPL.gsub(/\s+/, ' ').strip, assert: false, echo: false)
         rvm 1.9.3 --fuzzy do ruby -S dpl --provider="heroku" --fold;
@@ -69,8 +77,8 @@ describe Travis::Build::Script::Addons::Deploy do
     it 'runs the command' do
       script.expects(:run_stage).with(:before_deploy).twice
       script.expects(:else).twice
-      script.expects(:if).with('($TRAVIS_PULL_REQUEST = false) && ($TRAVIS_BRANCH = master) && ($ENV_1 = 1)').yields(script).once
-      script.expects(:if).with('($TRAVIS_PULL_REQUEST = false) && ($TRAVIS_BRANCH = master) && ($ENV_2 = 2)').yields(script).once
+      script.expects(:if).with('($TRAVIS_BRANCH = master) && ($ENV_1 = 1)').yields(script).once
+      script.expects(:if).with('($TRAVIS_BRANCH = master) && ($ENV_2 = 2)').yields(script).once
       script.expects(:cmd).with('rvm 1.9.3 --fuzzy do ruby -S gem install dpl', assert: true, echo: false).twice
       script.expects(:cmd).with(<<-DPL.gsub(/\s+/, ' ').strip, assert: false, echo: false)
         rvm 1.9.3 --fuzzy do ruby -S dpl --provider="heroku" --password="foo" --email="foo@blah.com" --fold;
@@ -92,7 +100,7 @@ describe Travis::Build::Script::Addons::Deploy do
     it 'runs the command' do
       script.expects(:run_stage).with(:before_deploy)
       script.expects(:else)
-      script.expects(:if).with('($TRAVIS_PULL_REQUEST = false) && ($TRAVIS_BRANCH = master)').yields(script)
+      script.expects(:if).with('($TRAVIS_BRANCH = master)').yields(script)
       script.expects(:cmd).with('rvm 1.9.3 --fuzzy do ruby -S gem install dpl', assert: false, echo: false)
       script.expects(:cmd).with(<<-DPL.gsub(/\s+/, ' ').strip, assert: false, echo: false)
         rvm 1.9.3 --fuzzy do ruby -S dpl --provider="heroku" --password="foo" --email="user@host" --fold
@@ -108,7 +116,7 @@ describe Travis::Build::Script::Addons::Deploy do
     it 'displays non-deploy reason' do
       script.expects(:run_stage).with(:before_deploy)
       script.expects(:else)
-      script.expects(:if).with('($TRAVIS_PULL_REQUEST = false) && ($TRAVIS_BRANCH = master) && ($ENV_1 = 1) && ($ENV_2 = 2)').yields(script).once
+      script.expects(:if).with('($TRAVIS_BRANCH = master) && ($ENV_1 = 1) && ($ENV_2 = 2)').yields(script).once
       script.expects(:cmd).with('rvm 1.9.3 --fuzzy do ruby -S gem install dpl', assert: true, echo: false).once
       script.expects(:cmd).with(<<-DPL.gsub(/\s+/, ' ').strip, assert: false, echo: false)
         rvm 1.9.3 --fuzzy do ruby -S dpl --provider="heroku" --fold;
@@ -125,9 +133,8 @@ describe Travis::Build::Script::Addons::Deploy do
 
     it 'displays non-deploy reason' do
       script.expects(:run_stage).with(:before_deploy)
-      script.expects(:if).with('($TRAVIS_PULL_REQUEST = false) && ($TRAVIS_BRANCH = master) && ($ENV_2 = 1)').yields(script).once
+      script.expects(:if).with('($TRAVIS_BRANCH = master) && ($ENV_2 = 1)').yields(script).once
       script.expects(:else).yields
-      script.expects(:if).with(' ! $TRAVIS_PULL_REQUEST = false').yields(script)
       script.expects(:if).with(' ! $TRAVIS_BRANCH = master')
       script.expects(:if).with(' ! $ENV_2 = 1')
       script.expects(:cmd).with('rvm 1.9.3 --fuzzy do ruby -S gem install dpl', assert: true, echo: false).once
@@ -136,8 +143,6 @@ describe Travis::Build::Script::Addons::Deploy do
         if [ $? -ne 0 ]; then echo "failed to deploy"; travis_terminate 2; fi
       DPL
       script.expects(:run_stage).with(:after_deploy).once
-
-      subject.expects(:failure_message)
 
       subject.deploy
     end
@@ -148,9 +153,8 @@ describe Travis::Build::Script::Addons::Deploy do
 
     it 'displays non-deploy reason' do
       script.expects(:run_stage).with(:before_deploy)
-      script.expects(:if).with('($TRAVIS_PULL_REQUEST = false) && ($TRAVIS_BRANCH = master) && ($ENV_1 = 1) && ($ENV_2 = 2)').yields(script).once
+      script.expects(:if).with('($TRAVIS_BRANCH = master) && ($ENV_1 = 1) && ($ENV_2 = 2)').yields(script).once
       script.expects(:else).yields(script)
-      script.expects(:if).with(' ! $TRAVIS_PULL_REQUEST = false')
       script.expects(:if).with(' ! $TRAVIS_BRANCH = master')
       script.expects(:if).with(' ! $ENV_1 = 1 &&  ! $ENV_2 = 2').yields(script)
       script.expects(:cmd).with('rvm 1.9.3 --fuzzy do ruby -S gem install dpl', assert: true, echo: false).once
@@ -161,6 +165,17 @@ describe Travis::Build::Script::Addons::Deploy do
       script.expects(:run_stage).with(:after_deploy).once
 
       subject.expects(:failure_message).with('a custom condition was not met.')
+
+      subject.deploy
+    end
+  end
+
+  describe 'build is a pull request' do
+    let(:config) {{ provider: "heroku", password: 'foo', email: 'user@host' }}
+    
+    it 'displays a error message' do
+      data.pull_request = true
+      subject.expects(:failure_message).with("the current build is a pull request.")
 
       subject.deploy
     end


### PR DESCRIPTION
This is slightly more secure as it prevents pull requesters from simply setting `$TRAVIS_PULL_REQUEST=false` and shortens the build script for pull requests by several lines.
