### PR TITLE
Disable npm's spinner

### DIFF
--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -19,6 +19,7 @@ module Travis
         def setup
           super
           cmd "nvm use #{config[:node_js]}"
+          cmd "npm config set spin false", echo: false
           if npm_should_disable_strict_ssl?
             cmd 'echo "### Disabling strict SSL ###"'
             cmd 'npm conf set strict-ssl false'

--- a/spec/script/node_js_spec.rb
+++ b/spec/script/node_js_spec.rb
@@ -15,6 +15,10 @@ describe Travis::Build::Script::NodeJs do
     is_expected.to travis_cmd 'nvm use 0.10', echo: true, timing: true, assert: true
   end
 
+  it 'disables the npm spinner' do
+    is_expected.to travis_cmd 'npm config set spin false', echo: false, timing: true, assert: true
+  end
+
   it 'announces node --version' do
     is_expected.to announce 'node --version'
   end


### PR DESCRIPTION
The spinner creates weird log output and the live view actually breaks pretty badly in a lot of cases.

Even though the latest version of npm only uses it on install (https://github.com/npm/npm/issues/5363), it still adds messiness.
