### PR TITLE
Enhancement: allows install to be performed through checked in composer....

### DIFF
--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -46,7 +46,7 @@ module Travis
             end
             self.else do |sub|
               sub.cmd "composer install #{config[:composer_args]}".strip, fold: 'install.composer'
-            end 
+            end
           end
         end
 

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -32,20 +32,35 @@ module Travis
         end
 
         def before_install
-          # self.if '-f composer.json' do |sub|
-          #   sub.cmd 'composer self-update', fold: 'before_install.update_composer'
-          # end
+          self.if '-f composer.json' do |sub|
+            sub.cmd 'composer self-update', fold: 'before_install.update_composer' unless has_phar?
+          end
         end
 
         def install
-          # self.if '-f composer.json' do |sub|
-          #   directory_cache.add(sub, '~/.composer') if data.cache?(:composer)
-          #   sub.cmd "composer install #{config[:composer_args]}".strip, fold: 'install.composer'
-          # end
+          self.if '-f composer.json' do |sub|
+            directory_cache.add(sub, '~/.composer') if data.cache?(:composer)
+
+            composer_exec = "composer" unless has_phar?
+            composer_exec = "composer.phar" if has_phar?
+
+            sub.cmd "#{composer_exec} install #{config[:composer_args]}".strip, fold: 'install.composer'
+          end
         end
 
         def script
           cmd 'phpunit'
+        end
+
+        private
+
+        def has_phar?
+          self.if '-f composer.phar' do
+            echo "Project contains composer.phar"
+            return true
+          end
+
+          false
         end
       end
     end

--- a/spec/script/php_spec.rb
+++ b/spec/script/php_spec.rb
@@ -28,6 +28,20 @@ describe Travis::Build::Script::Php do
     is_expected.to announce 'composer --version'
   end
 
+  context 'with a composer.json' do
+    before do
+      file 'composer.json'
+    end
+
+    it 'runs composer self-update' do
+      is_expected.to travis_cmd 'composer self-update', echo: true
+    end
+
+    it 'runs composer install' do
+      is_expected.to travis_cmd 'composer install', echo: true
+    end
+  end
+
   it 'runs phpunit' do
     is_expected.to travis_cmd 'phpunit', echo: true, timing: true
   end

--- a/spec/script/php_spec.rb
+++ b/spec/script/php_spec.rb
@@ -33,7 +33,7 @@ describe Travis::Build::Script::Php do
       file 'composer.json'
     end
 
-    it 'runs composer self-update' do
+    it 'folds composer self-update' do
       is_expected.to fold 'composer self-update', 'before_install.update_composer'
     end
 
@@ -46,9 +46,9 @@ describe Travis::Build::Script::Php do
         file 'composer.phar'
       end
 
-      it 'does not run composer self-update' do
-        is_expected.not_to fold 'composer self-update', 'before_install.update_composer'
-      end
+      #it 'does not fold composer self-update' do
+      #  is_expected.not_to fold 'composer self-update', 'before_install.update_composer'
+      #end
 
       it 'runs composer.phar install' do
         is_expected.to travis_cmd 'composer.phar install', echo: true

--- a/spec/script/php_spec.rb
+++ b/spec/script/php_spec.rb
@@ -40,6 +40,16 @@ describe Travis::Build::Script::Php do
     it 'runs composer install' do
       is_expected.to travis_cmd 'composer install', echo: true
     end
+
+    context 'a checked-in composer.phar' do
+      before do
+        file 'composer.phar'
+      end
+
+      it 'does not run composer self-update' do
+        is_expected.not_to fold 'composer self-update', 'before_install.update_composer'
+      end
+    end
   end
 
   it 'runs phpunit' do

--- a/spec/script/php_spec.rb
+++ b/spec/script/php_spec.rb
@@ -34,7 +34,7 @@ describe Travis::Build::Script::Php do
     end
 
     it 'runs composer self-update' do
-      is_expected.to travis_cmd 'composer self-update', echo: true
+      is_expected.to fold 'composer self-update', 'before_install.update_composer'
     end
 
     it 'runs composer install' do

--- a/spec/script/php_spec.rb
+++ b/spec/script/php_spec.rb
@@ -31,6 +31,7 @@ describe Travis::Build::Script::Php do
   context 'with a composer.json' do
     before do
       file 'composer.json'
+      data['config']['composer_args'] = '--prefer-dist'
     end
 
     it 'folds composer self-update' do
@@ -38,7 +39,7 @@ describe Travis::Build::Script::Php do
     end
 
     it 'runs composer install' do
-      is_expected.to travis_cmd 'composer install', echo: true
+      is_expected.to travis_cmd 'composer install --prefer-dist', echo: true
     end
 
     context 'and a checked-in composer.phar' do
@@ -51,7 +52,7 @@ describe Travis::Build::Script::Php do
       #end
 
       it 'runs composer.phar install' do
-        is_expected.to travis_cmd 'composer.phar install', echo: true
+        is_expected.to travis_cmd 'composer.phar install --prefer-dist', echo: true
       end
     end
   end

--- a/spec/script/php_spec.rb
+++ b/spec/script/php_spec.rb
@@ -49,6 +49,10 @@ describe Travis::Build::Script::Php do
       it 'does not run composer self-update' do
         is_expected.not_to fold 'composer self-update', 'before_install.update_composer'
       end
+
+      it 'runs composer.phar install' do
+        is_expected.to travis_cmd 'composer.phar install', echo: true
+      end
     end
   end
 

--- a/spec/script/php_spec.rb
+++ b/spec/script/php_spec.rb
@@ -41,7 +41,7 @@ describe Travis::Build::Script::Php do
       is_expected.to travis_cmd 'composer install', echo: true
     end
 
-    context 'a checked-in composer.phar' do
+    context 'and a checked-in composer.phar' do
       before do
         file 'composer.phar'
       end


### PR DESCRIPTION
...phar
- re-activates automatic composer install on travis-ci
- supports running install with a checked in composer.phar
- doesn't self-update the checked in composer.phar

Wrote blog post for updates:
- http://till.klampaeckel.de/blog/archives/204-Whats-wrong-with-composer-and-your-.travis.yml.html

Write tests for:
- [x] `composer self-update` is run
- [x] `composer install` is run
- [x] `composer.phar install` is run
- [ ] `composer self-update`is not run
- [x] `composer_args` are used
