### PR TITLE
Change time tag format

### DIFF
--- a/lib/travis/build/script/templates/header.sh
+++ b/lib/travis/build/script/templates/header.sh
@@ -54,7 +54,7 @@ function travis_cmd() {
 }
 
 travis_time_start() {
-  travis_timer_id=$RANDOM
+  travis_timer_id=$(printf %08x $(( RANDOM * RANDOM )))
   travis_start_time=$(travis_nanoseconds)
   echo -en "travis_time:start:$travis_timer_id\r${ANSI_CLEAR}"
 }


### PR DESCRIPTION
We need to include a unique id to each start and end tag. Also this changes travis_time_finish to output "travis_time:end" in order to align this with the fold tags.
