### PR TITLE
Fixed git fetch

### DIFF
--- a/lib/travis/build/script/git.rb
+++ b/lib/travis/build/script/git.rb
@@ -62,6 +62,7 @@ module Travis
             end
             self.else do
               cmd "git -C #{dir} fetch origin", assert: true, fold: "git.#{next_git_fold_number}", retry: true
+              cmd "git -C #{dir} reset --hard", assert: true, timing: false, fold: "git.#{next_git_fold_number}"
             end
           end
 

--- a/spec/shared/git.rb
+++ b/spec/shared/git.rb
@@ -94,6 +94,10 @@ shared_examples_for 'a git repo' do
       it 'fetches the changes' do
         is_expected.to travis_cmd 'git -C travis-ci/travis-ci fetch origin'
       end
+
+      it 'resets repository' do
+        is_expected.to travis_cmd 'git -C travis-ci/travis-ci reset --hard'
+      end
     end
 
     it 'changes to the git repo dir' do


### PR DESCRIPTION
This bug goes unnoticed in Travis environment because of immutable Virtual Machines, but when running on already dirty machines `git fetch origin` works in non-build dir.
