### PR TITLE
Update directory cache install spec for echoing

### DIFF
--- a/spec/script/directory_cache_spec.rb
+++ b/spec/script/directory_cache_spec.rb
@@ -96,7 +96,7 @@ describe Travis::Build::Script::DirectoryCache do
       expect(sh.commands).to be == [
         "export CASHER_DIR=$HOME/.casher",
         "mkdir -p $CASHER_DIR/bin",
-        "curl https://raw.githubusercontent.com/travis-ci/casher/production/bin/casher -L -o $CASHER_DIR/bin/casher -s --fail",
+        "echo Installing caching utilities; curl https://raw.githubusercontent.com/travis-ci/casher/production/bin/casher -L -o $CASHER_DIR/bin/casher -s --fail",
         "[ $? -ne 0 ] && echo 'Failed to fetch casher from GitHub, disabling cache.' && echo > $CASHER_DIR/bin/casher",
         "chmod +x $CASHER_DIR/bin/casher"
       ]


### PR DESCRIPTION
Commit https://github.com/travis-ci/travis-build/commit/f205bbe76d65b0289c931b007064cfc6e3ca8cb7 added an `echo` statement, which the tests don't expect to find.

This commit adds the `echo` statement to the expected output, so the tests pass.
