### PR TITLE
Warn if no 'build-tools' is specified in an Android project

### DIFF
--- a/lib/travis/build/script/android.rb
+++ b/lib/travis/build/script/android.rb
@@ -13,6 +13,14 @@ module Travis
 
         def setup
           super
+          if build_tools_desired.empty?
+            echo <<-MSG, ansi: :yellow
+No build-tools version is specified in android.components. Consider adding one of:
+#{available_build_tools_versions.map {|v| "build-tools-#{v}"}.join("\n")}
+The following versions are pre-installed: #{installed_build_tools_versions.join(" ")}
+See http://docs.travis-ci.com/user/languages/android/#How-to-install-Android-SDK-components for more information.
+            MSG
+          end
           install_sdk_components(config[:android][:components]) unless config[:android][:components].empty?
         end
 
@@ -40,6 +48,21 @@ module Travis
             install_cmd += " --accept-licenses='#{config[:android][:licenses].join('|')}'"
           end
           script.cmd install_cmd
+        end
+
+        def build_tools_desired
+          config[:android][:components].map { |component|
+            match = /build-tools-(?<version>[\d\.]+)/.match(component)
+            match[:version] if match
+          }
+        end
+
+        def available_build_tools_versions
+          @available_build_tools_versions ||= `android list sdk --extended --no-ui --all | awk -F\\" '/^id.*build-tools/ {print $2}'`.split("\n").sort.reverse
+        end
+
+        def installed_build_tools_versions
+          @installed_build_tools_versions ||= `ls /usr/local/android-sdk/build-tools/ 2>/dev/null`.split.sort.reverse
         end
       end
     end


### PR DESCRIPTION
As discussed in https://github.com/travis-ci/travis-cookbooks/pull/360#issuecomment-52902921
Communicate with the user that build-tools should be specified.

If there is a possibility that an Android project does not need one,
then we should detect it and suppress this warning.