### PR TITLE
Use  --verbose when building Rust code

### DIFF
--- a/lib/travis/build/script/rust.rb
+++ b/lib/travis/build/script/rust.rb
@@ -37,8 +37,8 @@ module Travis
         end
 
         def script
-          cmd "cargo build"
-          cmd "cargo test"
+          cmd "cargo build --verbose"
+          cmd "cargo test --verbose"
         end
 
         private


### PR DESCRIPTION
When things go wrong, the default (non verbose) output from Cargo can be as unhelpful as [`subcommand failed with signal: 11`](https://travis-ci.org/servo/rust-cssparser/builds/32654281)
