### PR TITLE
Provide a fallback for a function argument

### DIFF
--- a/lib/travis/build/script/templates/header.sh
+++ b/lib/travis/build/script/templates/header.sh
@@ -90,7 +90,7 @@ travis_assert() {
 }
 
 travis_result() {
-  local result=$1
+  local result=${1:-""}
   export TRAVIS_TEST_RESULT=$(( ${TRAVIS_TEST_RESULT:-0} | $(($result != 0)) ))
 
   if [ $result -eq 0 ]; then


### PR DESCRIPTION
For ease of debugging, we like to `set -u` in our scripts.  Unfortunately, if it leaks out to the environment where build.sh is running, referencing an undefined '$1' breaks build.sh. This should fix that problem.
