### PR TITLE
Copying source code from TRAVIS_BUILD_DIR into gopath more idempotently

### DIFF
--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -33,8 +33,8 @@ module Travis
           # easier to find and our `git clone`'d libraries are found by the
           # `go` commands.
           set 'GOPATH', "#{HOME_DIR}/gopath:$GOPATH"
-          cmd "mkdir -p #{HOME_DIR}/gopath/src/#{data.source_host}/#{data.slug.split('/').first}", assert: false, timing: false
-          cmd "cp -r $TRAVIS_BUILD_DIR #{HOME_DIR}/gopath/src/#{data.source_host}/#{data.slug}", assert: false, timing: false
+          cmd "mkdir -p #{HOME_DIR}/gopath/src/#{data.source_host}/#{data.slug}", assert: false, timing: false
+          cmd "rsync -az ${TRAVIS_BUILD_DIR}/ #{HOME_DIR}/gopath/src/#{data.source_host}/#{data.slug}/", assert: false, timing: false
           set "TRAVIS_BUILD_DIR", "#{HOME_DIR}/gopath/src/#{data.source_host}/#{data.slug}"
           cd "#{HOME_DIR}/gopath/src/#{data.source_host}/#{data.slug}"
         end

--- a/spec/script/go_spec.rb
+++ b/spec/script/go_spec.rb
@@ -38,11 +38,11 @@ describe Travis::Build::Script::Go do
   end
 
   it 'creates the src dir' do
-    is_expected.to travis_cmd "mkdir -p #{Travis::Build::HOME_DIR}/gopath/src/github.com/travis-ci"
+    is_expected.to travis_cmd "mkdir -p #{Travis::Build::HOME_DIR}/gopath/src/github.com/travis-ci/travis-ci"
   end
 
-  it "copies the repository to the GOPATH" do
-    is_expected.to travis_cmd "cp -r $TRAVIS_BUILD_DIR #{Travis::Build::HOME_DIR}/gopath/src/github.com/travis-ci/travis-ci", echo: true
+  it 'copies the repository to the GOPATH' do
+    is_expected.to travis_cmd "rsync -az ${TRAVIS_BUILD_DIR}/ #{Travis::Build::HOME_DIR}/gopath/src/github.com/travis-ci/travis-ci/", echo: true
   end
 
   it "updates TRAVIS_BUILD_DIR" do
@@ -59,11 +59,11 @@ describe Travis::Build::Script::Go do
     end
 
     it 'creates the src dir' do
-      is_expected.to travis_cmd "mkdir -p #{Travis::Build::HOME_DIR}/gopath/src/ghe.example.com/travis-ci"
+      is_expected.to travis_cmd "mkdir -p #{Travis::Build::HOME_DIR}/gopath/src/ghe.example.com/travis-ci/travis-ci"
     end
 
-    it "copies the repository to the GOPATH" do
-      is_expected.to travis_cmd "cp -r $TRAVIS_BUILD_DIR #{Travis::Build::HOME_DIR}/gopath/src/ghe.example.com/travis-ci/travis-ci", echo: true
+    it 'copies the repository to the GOPATH' do
+      is_expected.to travis_cmd "rsync -az ${TRAVIS_BUILD_DIR}/ #{Travis::Build::HOME_DIR}/gopath/src/ghe.example.com/travis-ci/travis-ci/", echo: true
     end
 
     it "updates TRAVIS_BUILD_DIR" do


### PR DESCRIPTION
So that `mkdir -p` operations performed prior to this step don't
result in the source code being copied into a nested directory, as
is the case when using casher.
