### PR TITLE
Print xctool version in objc announce fold

### DIFF
--- a/lib/travis/build/script/objective_c.rb
+++ b/lib/travis/build/script/objective_c.rb
@@ -19,7 +19,10 @@ module Travis
 
         def announce
           super
-          cmd 'xcodebuild -version -sdk', fold: 'announce'
+          fold 'announce' do
+            cmd 'xcodebuild -version -sdk'
+            cmd 'xctool -version'
+          end
           uses_rubymotion? then: 'motion --version'
           podfile? then: 'pod --version'
         end

--- a/spec/script/objective_c_spec.rb
+++ b/spec/script/objective_c_spec.rb
@@ -117,6 +117,10 @@ describe Travis::Build::Script::ObjectiveC do
       data['config']['xcode_scheme'] = 'YourScheme'
     end
 
+    it 'prints xctool version' do
+      is_expected.to travis_cmd 'xctool -version'
+    end
+
     it 'runs xctool' do
       is_expected.to travis_cmd 'xctool -workspace YourWorkspace.xcworkspace -scheme YourScheme build test', echo: true, timing: true
       store_example 'xctool'
@@ -127,6 +131,10 @@ describe Travis::Build::Script::ObjectiveC do
     before(:each) do
       data['config']['xcode_project'] = 'YourProject.xcodeproj'
       data['config']['xcode_scheme'] = 'YourScheme'
+    end
+
+    it 'prints xctool version' do
+      is_expected.to travis_cmd 'xctool -version'
     end
 
     it 'runs xctool' do


### PR DESCRIPTION
so that folks know which version of xctool is being used, as this helps clear up confusion with support issues.
