### PR TITLE
Remove CouchDB hack

### DIFF
--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -126,7 +126,6 @@ module Travis
         end
 
         def pre_setup
-          stop_couchdb
           start_services
           setup_apt_cache if data.cache? :apt
           fix_ps4
@@ -173,10 +172,6 @@ module Travis
 
         def fix_ps4
           set "PS4", "+ ", echo: false
-        end
-
-        def stop_couchdb
-          raw 'which service >/dev/null && sudo service couchdb stop || true', echo: false
         end
     end
   end


### PR DESCRIPTION
Build images should no longer start CouchDB on boot, so we remove this ugly hack.
