### PR TITLE
Set TRAVIS_CMD when no script is given for Python

### DIFF
--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -39,6 +39,7 @@ module Travis
           # This always fails the build, asking the user to provide a custom :script.
           # The Python ecosystem has no good default build command most of the
           # community aggrees on. Per discussion with jezjez, josh-k and others. MK
+          set 'TRAVIS_CMD', 'no_script', echo: false
           failure NO_SCRIPT
         end
 


### PR DESCRIPTION
Fixes https://github.com/travis-ci/travis-ci/issues/2870

Without this, `$TRAVIS_CMD` is set to whatever was executed beforehand
(e.g., `install` or `before_install` command), which could very well
have succeeded, but the absence of `script` will display the confusing
message:

```
The command "$TRAVIS_CMD" exited with 1.
```
