### PR TITLE
Only install Godeps/Godep requirements in go_version >= 1.1

### DIFF
--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -42,9 +42,11 @@ module Travis
 
         def install
           uses_make? then: 'true', else: "#{go_get} #{gobuild_args} ./...", fold: 'install', retry: true
-          self.if '-f Godeps/Godeps.json' do |sub|
-            sub.cmd "#{go_get} github.com/tools/godep", echo: true, retry: true, timing: true, assert: true
-            sub.cmd 'godep restore', retry: true, timing: true, assert: true, echo: true
+          if go_version >= 'go1.1'
+            self.if '-f Godeps/Godeps.json' do |sub|
+              sub.cmd "#{go_get} github.com/tools/godep", echo: true, retry: true, timing: true, assert: true
+              sub.cmd 'godep restore', retry: true, timing: true, assert: true, echo: true
+            end
           end
         end
 

--- a/spec/script/go_spec.rb
+++ b/spec/script/go_spec.rb
@@ -116,7 +116,25 @@ describe Travis::Build::Script::Go do
     is_expected.to fold 'gvm install', 'gvm.install'
   end
 
-  %w(1.0.3 1.1 1.1.2).each do |old_go_version|
+  %w(1.0 1.0.1 1.0.2 1.0.3).each do |old_go_version|
+    describe "if Godeps/Godeps.json exists on 1.0.3" do
+      before { data['config']['go'] = old_go_version }
+
+      before(:each) do
+        file('Godeps/Godeps.json')
+      end
+
+      it 'not install godep' do
+        is_expected.not_to travis_cmd 'go get github.com/tools/godep', echo: true, timing: true, assert: true, retry: true
+      end
+
+      it 'not attempt to restore the deps' do
+        is_expected.not_to travis_cmd 'godep restore', echo: true, timing: true, assert: true, retry: true
+      end
+    end
+  end
+
+  %w(1.1 1.1.2).each do |old_go_version|
     describe "if Godeps/Godeps.json exists on #{old_go_version}" do
       before { data['config']['go'] = old_go_version }
 


### PR DESCRIPTION
This limits the installation as mentioned in the previous pull request.
