### PR TITLE
Inject /etc/hhvm/php.ini in PHP's configure for HHVM

### DIFF
--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -51,13 +51,13 @@ module Travis
         def configure
           super
           if config[:php] == 'hhvm'
-            echo "Modifying HHVM init file", ansi: :yellow
+            echo 'Modifying HHVM init file', ansi: :yellow
             ini_file_path = '/etc/hhvm/php.ini'
             ini_file_addition = <<-EOF
 date.timezone = "UTC"
 hhvm.libxml.ext_entity_whitelist=file,http,https
             EOF
-            raw "sudo mkdir -p `dirname #{ini_file_path}`; echo '#{ini_file_addition}' | sudo tee -a #{ini_file_path} > /dev/null"
+            raw "sudo mkdir -p $(dirname #{ini_file_path}); echo '#{ini_file_addition}' | sudo tee -a #{ini_file_path} > /dev/null"
           end
         end
       end


### PR DESCRIPTION
Modify `/etc/hhvm/php.ini` before `Travis::Build::Script#paranoid_mode` disables `sudo`.

This fixes https://github.com/travis-ci/travis-ci/issues/2863 and https://github.com/travis-ci/travis-ci/issues/2523.
