### PR TITLE
Ensure that HHVM defined session.save_path exists

### DIFF
--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -86,6 +86,9 @@ date.timezone = "UTC"
 hhvm.libxml.ext_entity_whitelist=file,http,https
           EOF
           sh.raw "sudo mkdir -p $(dirname #{ini_file_path}); echo '#{ini_file_addition}' | sudo tee -a #{ini_file_path} > /dev/null"
+          # Ensure that the configured session storage directory exists if
+          # specified in the ini file.
+          sh.raw "grep session.save_path #{ini_file_path} | cut -d= -f2 | sudo xargs mkdir -p"
         end
       end
     end


### PR DESCRIPTION
Work around hhvm/packaging#81 by ensuring that any session.save_path
defined in /etc/hhvm/php.ini is created on the local file system. This
change is intended to fix travis-ci/travis-ci#2942.
