### PR TITLE
Refactor stages

### DIFF
--- a/lib/travis/build/addons/code_climate.rb
+++ b/lib/travis/build/addons/code_climate.rb
@@ -6,7 +6,7 @@ module Travis
       class CodeClimate < Base
         SUPER_USER_SAFE = true
 
-        def before_before_script
+        def after_export
           sh.export 'CODECLIMATE_REPO_TOKEN', token, echo: false if token
         end
 

--- a/lib/travis/build/addons/coverity_scan.rb
+++ b/lib/travis/build/addons/coverity_scan.rb
@@ -20,7 +20,7 @@ module Travis
         #   script depending on the TRAVIS_BRANCH env variable.
         # The Coverity Scan build therefore overrides the default script, but only on the
         #   coverity_scan branch.
-        def script
+        def before_script
           sh.raw "echo -en 'coverity_scan:start\\r'"
           sh.if "${COVERITY_VERBOSE} = 1", echo: true do
             sh.raw "set -x"

--- a/lib/travis/build/addons/deploy.rb
+++ b/lib/travis/build/addons/deploy.rb
@@ -11,11 +11,11 @@ module Travis
           super(script, sh, data, config.is_a?(Array) ? config : [config].compact)
         end
 
-        def after_finish?
+        def deploy?
           !config.empty?
         end
 
-        def after_finish
+        def deploy
           # sh.if('$TRAVIS_TEST_RESULT = 0') do
           #   providers.map(&:deploy)
           # end

--- a/lib/travis/build/addons/deploy.rb
+++ b/lib/travis/build/addons/deploy.rb
@@ -11,11 +11,11 @@ module Travis
           super(script, sh, data, config.is_a?(Array) ? config : [config].compact)
         end
 
-        def after_after_success?
+        def after_finish?
           !config.empty?
         end
 
-        def after_after_success
+        def after_finish
           # sh.if('$TRAVIS_TEST_RESULT = 0') do
           #   providers.map(&:deploy)
           # end

--- a/lib/travis/build/addons/firefox.rb
+++ b/lib/travis/build/addons/firefox.rb
@@ -7,7 +7,7 @@ module Travis
       class Firefox < Base
         SUPER_USER_SAFE = true
 
-        def before_before_install
+        def before_setup
           sh.fold 'install_firefox' do
             sh.echo "Installing Firefox v#{version}", ansi: :yellow
             sh.raw "mkdir -p #{HOME_DIR}/firefox-#{version}"
@@ -31,7 +31,7 @@ module Travis
         private
 
           def version
-            config.to_s #.shellescape
+            config.to_s.gsub(/[^\d\._\-]/, '').shellescape
           end
 
           def install_dir

--- a/lib/travis/build/addons/firefox.rb
+++ b/lib/travis/build/addons/firefox.rb
@@ -7,7 +7,6 @@ module Travis
       class Firefox < Base
         SUPER_USER_SAFE = true
 
-        # def after_prepare
         def before_before_install
           sh.fold 'install_firefox' do
             sh.echo "Installing Firefox v#{version}", ansi: :yellow

--- a/lib/travis/build/addons/hosts.rb
+++ b/lib/travis/build/addons/hosts.rb
@@ -7,7 +7,7 @@ module Travis
       class Hosts < Base
         SUPER_USER_SAFE = true
 
-        def after_prepare
+        def before_prepare
           sh.fold 'hosts' do
             sh.cmd "sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 '#{hosts}'/' -i'.bak' /etc/hosts"
             sh.cmd "sudo sed -e 's/^\\(::1.*\\)$/\\1 '#{hosts}'/' -i'.bak' /etc/hosts"

--- a/lib/travis/build/addons/hosts.rb
+++ b/lib/travis/build/addons/hosts.rb
@@ -7,7 +7,7 @@ module Travis
       class Hosts < Base
         SUPER_USER_SAFE = true
 
-        def before_prepare
+        def before_configure
           sh.fold 'hosts' do
             sh.cmd "sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 '#{hosts}'/' -i'.bak' /etc/hosts"
             sh.cmd "sudo sed -e 's/^\\(::1.*\\)$/\\1 '#{hosts}'/' -i'.bak' /etc/hosts"

--- a/lib/travis/build/addons/hosts.rb
+++ b/lib/travis/build/addons/hosts.rb
@@ -17,7 +17,7 @@ module Travis
         private
 
           def hosts
-            Array(config).join(' ').shellescape
+            Array(config).join(' ').gsub(/[^\w_\-\. ]/, '').shellescape
           end
       end
     end

--- a/lib/travis/build/addons/postgresql.rb
+++ b/lib/travis/build/addons/postgresql.rb
@@ -19,7 +19,7 @@ module Travis
         private
 
           def version
-            config.to_s.shellescape
+            config.to_s.gsub(/[^\d\._\-]/, '').shellescape
           end
       end
     end

--- a/lib/travis/build/addons/postgresql.rb
+++ b/lib/travis/build/addons/postgresql.rb
@@ -7,7 +7,7 @@ module Travis
       class Postgresql < Base
         SUPER_USER_SAFE = true
 
-        def before_prepare
+        def before_configure
           sh.fold 'postgresql' do
             sh.export "PATH", "/usr/lib/postgresql/#{version}/bin:$PATH", echo: false
             sh.echo "Starting PostgreSQL v#{version}", ansi: :yellow

--- a/lib/travis/build/addons/postgresql.rb
+++ b/lib/travis/build/addons/postgresql.rb
@@ -7,7 +7,7 @@ module Travis
       class Postgresql < Base
         SUPER_USER_SAFE = true
 
-        def after_prepare
+        def before_prepare
           sh.fold 'postgresql' do
             sh.export "PATH", "/usr/lib/postgresql/#{version}/bin:$PATH", echo: false
             sh.echo "Starting PostgreSQL v#{version}", ansi: :yellow

--- a/lib/travis/build/addons/sauce_connect.rb
+++ b/lib/travis/build/addons/sauce_connect.rb
@@ -7,7 +7,7 @@ module Travis
         SUPER_USER_SAFE = true
         SOURCE_URL = 'https://gist.githubusercontent.com/henrikhodne/9322897/raw/sauce-connect.sh'
 
-        def after_prepare
+        def after_configure
           sh.export 'SAUCE_USERNAME', username, echo: false if username
           sh.export 'SAUCE_ACCESS_KEY', access_key, echo: false if access_key
 

--- a/lib/travis/build/addons/sauce_connect.rb
+++ b/lib/travis/build/addons/sauce_connect.rb
@@ -7,7 +7,7 @@ module Travis
         SUPER_USER_SAFE = true
         SOURCE_URL = 'https://gist.githubusercontent.com/henrikhodne/9322897/raw/sauce-connect.sh'
 
-        def before_before_script
+        def after_prepare
           sh.export 'SAUCE_USERNAME', username, echo: false if username
           sh.export 'SAUCE_ACCESS_KEY', access_key, echo: false if access_key
 

--- a/lib/travis/build/addons/ssh_known_hosts.rb
+++ b/lib/travis/build/addons/ssh_known_hosts.rb
@@ -7,7 +7,7 @@ module Travis
       class SshKnownHosts < Base
         SUPER_USER_SAFE = true
 
-        def before_prepare
+        def before_configure
           add_ssh_known_hosts unless config.empty?
         end
 

--- a/lib/travis/build/addons/ssh_known_hosts.rb
+++ b/lib/travis/build/addons/ssh_known_hosts.rb
@@ -7,7 +7,7 @@ module Travis
       class SshKnownHosts < Base
         SUPER_USER_SAFE = true
 
-        def before_checkout
+        def before_prepare
           add_ssh_known_hosts unless config.empty?
         end
 

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -78,7 +78,10 @@ module Travis
           stages.run if apply :validate
           sh.raw template('footer.sh')
           apply :deprecations
-          sh.raw template('header.sh', build_dir: BUILD_DIR), pos: 0
+        end
+
+        def header
+          sh.raw template('header.sh', build_dir: BUILD_DIR)
         end
 
         def configure

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -90,18 +90,15 @@ module Travis
           apply :checkout
         end
 
-        def export
-          apply :env
-        end
-
         def prepare
           apply :services
           apply :setup_apt_cache
           apply :fix_ps4 # TODO if this is to fix an rvm issue (as the specs say) then should this go to Rvm instead?
+          apply :disable_sudo
         end
 
-        def disable_sudo
-          apply :disable_sudo
+        def export
+          apply :env
         end
     end
   end

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -84,17 +84,14 @@ module Travis
         def configure
           apply :fix_resolv_conf
           apply :fix_etc_hosts
+          apply :fix_ps4 # TODO if this is to fix an rvm issue (as the specs say) then should this go to Rvm instead?
+          apply :setup_apt_cache
+          apply :services
+          apply :disable_sudo
         end
 
         def checkout
           apply :checkout
-        end
-
-        def prepare
-          apply :services
-          apply :setup_apt_cache
-          apply :fix_ps4 # TODO if this is to fix an rvm issue (as the specs say) then should this go to Rvm instead?
-          apply :disable_sudo
         end
 
         def export

--- a/lib/travis/build/script/shared/directory_cache.rb
+++ b/lib/travis/build/script/shared/directory_cache.rb
@@ -25,16 +25,13 @@ module Travis
           super
         end
 
-        def after_result
+        def finish
           # only publish cache from pushes to master
           return if data.pull_request
           directory_cache.fold('store build cache') do
-            prepare_cache
+            prepare_cache if respond_to?(:prepare_cache)
             directory_cache.push
           end
-        end
-
-        def prepare_cache
         end
       end
     end

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -8,7 +8,7 @@ module Travis
   module Build
     class Stages
       STAGES = [
-        :builtin,     [:configure, :prepare, :checkout, :export, :setup, :announce],
+        :builtin,     [:configure, :checkout, :export, :setup, :announce],
         :custom,      [:before_install, :install, :before_script, :script, :after_script],
         :conditional, [:after_success, :after_failure],
         :builtin,     [:finish],

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -11,7 +11,8 @@ module Travis
         :builtin,     [:configure, :prepare, :checkout, :export, :setup, :announce],
         :custom,      [:before_install, :install, :before_script, :script, :after_script],
         :conditional, [:after_success, :after_failure],
-        :builtin,     [:finish]
+        :builtin,     [:finish],
+        :addon,       [:deploy]
       ]
 
       STAGE_DEFAULT_OPTIONS = {

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -8,7 +8,7 @@ module Travis
   module Build
     class Stages
       STAGES = [
-        :builtin,     [:configure, :checkout, :prepare, :export, :setup, :announce],
+        :builtin,     [:configure, :prepare, :checkout, :export, :setup, :announce],
         :custom,      [:before_install, :install, :before_script, :script],
         :builtin,     [:after_result],
         :conditional, [:after_success],

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -9,12 +9,8 @@ module Travis
     class Stages
       STAGES = [
         :builtin,     [:configure, :prepare, :checkout, :export, :setup, :announce],
-        :custom,      [:before_install, :install, :before_script, :script],
-        :builtin,     [:after_result],
-        :conditional, [:after_success],
-        # :addon,       [:deploy_all],
-        :conditional, [:after_failure],
-        :custom,      [:after_script],
+        :custom,      [:before_install, :install, :before_script, :script, :after_script],
+        :conditional, [:after_success, :after_failure],
         :builtin,     [:finish]
       ]
 

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -8,7 +8,7 @@ module Travis
   module Build
     class Stages
       STAGES = [
-        :builtin,     [:configure, :checkout, :export, :setup, :announce],
+        :builtin,     [:header, :configure, :checkout, :export, :setup, :announce],
         :custom,      [:before_install, :install, :before_script, :script, :after_script],
         :conditional, [:after_success, :after_failure],
         :builtin,     [:finish],

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -8,7 +8,7 @@ module Travis
   module Build
     class Stages
       STAGES = [
-        :builtin,     [:configure, :checkout, :prepare, :disable_sudo, :export, :setup, :announce],
+        :builtin,     [:configure, :checkout, :prepare, :export, :setup, :announce],
         :custom,      [:before_install, :install, :before_script, :script],
         :builtin,     [:after_result],
         :conditional, [:after_success],

--- a/lib/travis/build/stages/base.rb
+++ b/lib/travis/build/stages/base.rb
@@ -10,7 +10,9 @@ module Travis
 
         def with_stage(name = nil, &block)
           @stage = name
-          sh.with_options(STAGE_DEFAULT_OPTIONS[name] || {}, &block)
+          sh.group(name) do
+            sh.with_options(STAGE_DEFAULT_OPTIONS[name] || {}, &block)
+          end
         end
 
         def run_addon_stage(name)

--- a/lib/travis/build/stages/builtin.rb
+++ b/lib/travis/build/stages/builtin.rb
@@ -5,15 +5,17 @@ module Travis
     class Stages
       class Builtin < Base
         def run
+          run_addon_stage :"before_#{name}"
+
           with_stage(name) do
-            run_addon_stage :"before_#{name}"
             run_addon_stage :script if script? # TODO for coverity_scan
             if script.respond_to?(name, true)
               script.send(name)
               result if script?
             end
-            run_addon_stage :"after_#{name}"
           end
+
+          run_addon_stage :"after_#{name}"
         end
       end
     end

--- a/lib/travis/build/stages/builtin.rb
+++ b/lib/travis/build/stages/builtin.rb
@@ -8,7 +8,6 @@ module Travis
           run_addon_stage :"before_#{name}"
 
           with_stage(name) do
-            run_addon_stage :script if script? # TODO for coverity_scan
             if script.respond_to?(name, true)
               script.send(name)
               result if script?

--- a/lib/travis/build/stages/custom.rb
+++ b/lib/travis/build/stages/custom.rb
@@ -5,16 +5,18 @@ module Travis
     class Stages
       class Custom < Base
         def run
+          run_addon_stage :"before_#{name}"
+
           with_stage(name) do
-            run_addon_stage :"before_#{name}"
             run_addon_stage :script if script? # TODO for coverity_scan
             cmds = Array(config[name])
             cmds.each_with_index do |command, ix|
               sh.cmd command.to_s, echo: true, fold: fold_for(name, cmds, ix)
               result if script?
             end
-            run_addon_stage :"after_#{name}"
           end
+
+          run_addon_stage :"after_#{name}"
         end
 
         private

--- a/lib/travis/shell/ast.rb
+++ b/lib/travis/shell/ast.rb
@@ -35,13 +35,20 @@ module Travis
       end
 
       class Group < Cmds
-        def initialize(type, options = {}, &block)
+        attr_reader :name
+
+        def initialize(type, *args, &block)
+          options = args.last.is_a?(Hash) ? args.pop : {}
           @type = type
+          @name = args.first
           super(options, &block)
         end
 
         def to_sexp
-          [type, [:cmds, nodes.map(&:to_sexp)]]
+          sexp = [type]
+          sexp << name if name
+          sexp << [:cmds, nodes.map(&:to_sexp)] unless nodes.empty?
+          sexp
         end
       end
 

--- a/lib/travis/shell/builder.rb
+++ b/lib/travis/shell/builder.rb
@@ -28,6 +28,11 @@ module Travis
         sh.nodes << Shell::Ast::Script.new(*merge_options(args), &block)
       end
 
+      def group(name, *args, &block)
+        block = with_node(&block) if block
+        sh.nodes << Shell::Ast::Group.new(:group, name, *merge_options(args), &block)
+      end
+
       def node(type, data = nil, *args)
         args = merge_options(args)
         if fold = args.last.delete(:fold)

--- a/lib/travis/shell/generator.rb
+++ b/lib/travis/shell/generator.rb
@@ -36,6 +36,10 @@ module Travis
           indent { handle_script(nodes) }
         end
 
+        def handle_group(name, cmds = nil)
+          cmds ? handle(cmds) : ''
+        end
+
         def indent(lines = nil)
           @level += 1
           lines = Array(lines || yield).flatten.map { |line| line.split("\n").map { |line| "  #{line}" }.join("\n") }

--- a/lib/travis/shell/generator.rb
+++ b/lib/travis/shell/generator.rb
@@ -9,7 +9,7 @@ module Travis
       end
 
       def generate
-        lines = Array(handle(nodes)).flatten
+        lines = Array(handle(nodes)).flatten.compact
         script = lines.join("\n").strip
         script = unindent(script)
         script = normalize_newlines(script)
@@ -31,18 +31,16 @@ module Travis
         def handle_script(nodes)
           nodes.map { |node| handle(node) }
         end
-
-        def handle_cmds(nodes)
-          indent { handle_script(nodes) }
-        end
+        alias handle_cmds handle_script
 
         def handle_group(name, cmds = nil)
-          cmds ? handle(cmds) : ''
+          cmds ? handle(cmds) : nil
         end
 
         def indent(lines = nil)
           @level += 1
-          lines = Array(lines || yield).flatten.map { |line| line.split("\n").map { |line| "  #{line}" }.join("\n") }
+          lines = Array(lines || yield).flatten.compact
+          lines = lines.map { |line| line.split("\n").map { |line| "  #{line}" }.join("\n") }
           @level -= 1
           lines
         end

--- a/lib/travis/shell/generator/bash.rb
+++ b/lib/travis/shell/generator/bash.rb
@@ -110,7 +110,7 @@ module Travis
         def handle_fold(name, cmds, options = {})
           with_margin do
             lines = ["travis_fold start #{name}"]
-            lines << handle(cmds)
+            lines << indent { handle(cmds) }
             lines << "travis_fold end #{name}"
             lines
           end
@@ -128,17 +128,17 @@ module Travis
         end
 
         def handle_then(cmds)
-          handle(cmds)
+          indent { handle(cmds) }
         end
 
         def handle_elif(condition, cmds)
           lines = ["elif [[ #{condition} ]]; then"]
-          lines += handle(cmds)
+          lines += indent { handle(cmds) }
           lines
         end
 
         def handle_else(cmds)
-          ['else', handle(cmds)]
+          ['else', indent { handle(cmds) }]
         end
       end
     end

--- a/spec/build/addons/code_climate_spec.rb
+++ b/spec/build/addons/code_climate_spec.rb
@@ -7,7 +7,7 @@ describe Travis::Build::Addons::CodeClimate, :sexp do
   let(:sh)     { Travis::Shell::Builder.new }
   let(:addon)  { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
   subject      { sh.to_sexp }
-  before       { addon.before_before_script }
+  before       { addon.after_export }
 
   let(:export_repo_token) { [:export, ['CODECLIMATE_REPO_TOKEN', '1234']] }
 

--- a/spec/build/addons/firefox_spec.rb
+++ b/spec/build/addons/firefox_spec.rb
@@ -8,7 +8,7 @@ describe Travis::Build::Addons::Firefox, :sexp do
   let(:addon)  { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
   let(:home)   { Travis::Build::HOME_DIR }
   subject      { sh.to_sexp }
-  before       { addon.before_before_install }
+  before       { addon.before_setup }
 
   it_behaves_like 'compiled script' do
     let(:code) { ['install_firefox', 'firefox.tar.bz2'] }

--- a/spec/build/addons/hosts_spec.rb
+++ b/spec/build/addons/hosts_spec.rb
@@ -7,7 +7,7 @@ describe Travis::Build::Addons::Hosts, :sexp do
   let(:sh)     { Travis::Shell::Builder.new }
   let(:addon)  { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
   subject      { sh.to_sexp }
-  before       { addon.after_prepare }
+  before       { addon.before_prepare }
 
   it_behaves_like 'compiled script' do
     let(:cmds) { ['one.local two.local'] }

--- a/spec/build/addons/hosts_spec.rb
+++ b/spec/build/addons/hosts_spec.rb
@@ -7,7 +7,7 @@ describe Travis::Build::Addons::Hosts, :sexp do
   let(:sh)     { Travis::Shell::Builder.new }
   let(:addon)  { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
   subject      { sh.to_sexp }
-  before       { addon.before_prepare }
+  before       { addon.before_configure }
 
   it_behaves_like 'compiled script' do
     let(:cmds) { ['one.local two.local'] }

--- a/spec/build/addons/postgresql_spec.rb
+++ b/spec/build/addons/postgresql_spec.rb
@@ -7,7 +7,7 @@ describe Travis::Build::Addons::Postgresql, :sexp do
   let(:sh)     { Travis::Shell::Builder.new }
   let(:addon)  { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
   subject      { sh.to_sexp }
-  before       { addon.before_prepare }
+  before       { addon.before_configure }
 
   it_behaves_like 'compiled script' do
     let(:cmds) { ['service postgresql start 9.3'] }

--- a/spec/build/addons/postgresql_spec.rb
+++ b/spec/build/addons/postgresql_spec.rb
@@ -7,7 +7,7 @@ describe Travis::Build::Addons::Postgresql, :sexp do
   let(:sh)     { Travis::Shell::Builder.new }
   let(:addon)  { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
   subject      { sh.to_sexp }
-  before       { addon.after_prepare }
+  before       { addon.before_prepare }
 
   it_behaves_like 'compiled script' do
     let(:cmds) { ['service postgresql start 9.3'] }

--- a/spec/build/addons/sauce_connect_spec.rb
+++ b/spec/build/addons/sauce_connect_spec.rb
@@ -7,7 +7,7 @@ describe Travis::Build::Addons::SauceConnect, :sexp do
   let(:sh)     { Travis::Shell::Builder.new }
   let(:addon)  { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
   subject      { sh.to_sexp }
-  before       { addon.before_before_script }
+  before       { addon.after_prepare }
 
   it_behaves_like 'compiled script' do
     let(:code) { ['sauce_connect', 'TRAVIS_SAUCE_CONNECT=true'] }

--- a/spec/build/addons/sauce_connect_spec.rb
+++ b/spec/build/addons/sauce_connect_spec.rb
@@ -7,7 +7,7 @@ describe Travis::Build::Addons::SauceConnect, :sexp do
   let(:sh)     { Travis::Shell::Builder.new }
   let(:addon)  { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
   subject      { sh.to_sexp }
-  before       { addon.after_prepare }
+  before       { addon.after_configure }
 
   it_behaves_like 'compiled script' do
     let(:code) { ['sauce_connect', 'TRAVIS_SAUCE_CONNECT=true'] }

--- a/spec/build/addons/ssh_known_hosts_spec.rb
+++ b/spec/build/addons/ssh_known_hosts_spec.rb
@@ -7,7 +7,7 @@ describe Travis::Build::Addons::SshKnownHosts, :sexp do
   let(:sh)     { Travis::Shell::Builder.new }
   let(:addon)  { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
   subject      { sh.to_sexp }
-  before       { addon.before_prepare }
+  before       { addon.before_configure }
 
   def add_host_cmd(host)
     "ssh-keyscan -t rsa,dsa -H #{host} 2>&1 | tee -a #{Travis::Build::HOME_DIR}/.ssh/known_hosts"

--- a/spec/build/addons/ssh_known_hosts_spec.rb
+++ b/spec/build/addons/ssh_known_hosts_spec.rb
@@ -7,7 +7,7 @@ describe Travis::Build::Addons::SshKnownHosts, :sexp do
   let(:sh)     { Travis::Shell::Builder.new }
   let(:addon)  { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
   subject      { sh.to_sexp }
-  before       { addon.before_checkout }
+  before       { addon.before_prepare }
 
   def add_host_cmd(host)
     "ssh-keyscan -t rsa,dsa -H #{host} 2>&1 | tee -a #{Travis::Build::HOME_DIR}/.ssh/known_hosts"

--- a/spec/build/script_spec.rb
+++ b/spec/build/script_spec.rb
@@ -13,6 +13,7 @@ describe Travis::Build::Script, :sexp do
 
   it 'runs stages in the expected order' do
     expected = [
+      :before_header, :header, :after_header,
       :before_configure, :configure, :after_configure,
       :before_checkout, :checkout, :after_checkout,
       :before_export, :export, :after_export,

--- a/spec/build/script_spec.rb
+++ b/spec/build/script_spec.rb
@@ -11,6 +11,26 @@ describe Travis::Build::Script, :sexp do
     expect(code).to match %r(cd +\$HOME/build)
   end
 
+  it 'runs stages in the expected order' do
+    expected = [
+      :before_configure, :configure, :after_configure,
+      :before_prepare, :prepare, :after_prepare,
+      :before_checkout, :checkout, :after_checkout,
+      :before_export, :export, :after_export,
+      :before_setup, :setup, :after_setup,
+      :before_announce, :announce, :after_announce,
+      :before_before_install, :before_install, :after_before_install,
+      :before_install, :install, :after_install,
+      :before_before_script, :before_script, :after_before_script,
+      :before_script, :script, :after_script,
+      :before_after_script, :after_script, :after_after_script,
+      :before_finish, :finish, :after_finish,
+      :deploy
+    ]
+    actual = sexp_filter(subject, [:group]).map { |group| group[1] }
+    expect(actual).to eq expected
+  end
+
   it 'sets up apt cache' do
     should include_sexp [:cmd, %r(tee /etc/apt/apt.conf.d/01proxy)]
   end

--- a/spec/shell/generator/bash_spec.rb
+++ b/spec/shell/generator/bash_spec.rb
@@ -215,24 +215,24 @@ describe Travis::Shell::Generator::Bash, :include_node_helpers do
 
   describe :if do
     it 'generates an if statement' do
-      @sexp = [:if, '-f Gemfile', [:cmds, [[:cmd, 'foo']]]]
+      @sexp = [:if, '-f Gemfile', [:then, [:cmds, [[:cmd, 'foo']]]]]
       expect(code).to eql("if [[ -f Gemfile ]]; then\n  foo\nfi")
     end
 
     it 'with an elif branch' do
-      @sexp = [:if, '-f Gemfile', [:cmds, [[:cmd, 'foo']]], [:elif, '-f Gemfile.lock', [:cmds, [[:cmd, 'bar']]]]]
+      @sexp = [:if, '-f Gemfile', [:then, [:cmds, [[:cmd, 'foo']]]], [:elif, '-f Gemfile.lock', [:cmds, [[:cmd, 'bar']]]]]
       expect(code).to eql("if [[ -f Gemfile ]]; then\n  foo\nelif [[ -f Gemfile.lock ]]; then\n  bar\nfi")
     end
 
     it 'with an else branch' do
-      @sexp = [:if, '-f Gemfile', [:cmds, [[:cmd, 'foo']]], [:else, [:cmds, [[:cmd, 'bar']]]]]
+      @sexp = [:if, '-f Gemfile', [:then, [:cmds, [[:cmd, 'foo']]]], [:else, [:cmds, [[:cmd, 'bar']]]]]
       expect(code).to eql("if [[ -f Gemfile ]]; then\n  foo\nelse\n  bar\nfi")
     end
   end
 
   describe :nesting do
     it 'generates a fold with an if statement' do
-      @sexp = [:fold, 'git', [:cmds, [[:if, '-f Gemfile', [:cmds, [[:cmd, 'foo']]]]]]]
+      @sexp = [:fold, 'git', [:cmds, [[:if, '-f Gemfile', [:then, [:cmds, [[:cmd, 'foo']]]]]]]]
       expect(code).to eql("travis_fold start git\n  if [[ -f Gemfile ]]; then\n    foo\n  fi\ntravis_fold end git")
     end
   end

--- a/spec/spec_helpers/sexp.rb
+++ b/spec/spec_helpers/sexp.rb
@@ -15,8 +15,8 @@ module SpecHelpers
           sexp.detect { |sexp| sexp_includes?(sexp, part) }
         when :script, :cmds, :then, :else
           sexp_includes?(sexp[1], part)
-        when :fold
-          sexp_includes?(sexp[2], part)
+        when :group, :fold
+          sexp_includes?(sexp[2] || [], part)
         when :if, :elif
           sexp_includes?(sexp[2..-1], part)
         end


### PR DESCRIPTION
Since we haven't touched the way stages are being defined and run for a really long time lots of stuff has been working around things, calling `run_stages` manually in several places. This resulted in a pretty weird execution order for our build stages.

This pull request changes the run/execution order of our stages as follows:

Before:

```
- script
- before_deploy
- deploy
- after_deploy
- after_success (if succeeded)
- cache push
- after_failure (if failed)
- after_script
```

After:

```
- script
- after_script
- after_success (if succeeded)
- after_failure (if failed)
- cache push
- before_deploy
- deploy
- after_deploy
```

I believe it makes sense to:
- run `:after_script` right after `:script`: that's what the name indicates
- run `:after_success` and `:after_failure` before cache/push and deploy

/cc @rkh do you think this might break caching or deployments in any way?

Only the `:script` stage will set `$TRAVIS_TEST_RESULT`.
