### PR TITLE
Do not assert bundle clean

### DIFF
--- a/lib/travis/build/script/shared/bundler.rb
+++ b/lib/travis/build/script/shared/bundler.rb
@@ -36,7 +36,7 @@ module Travis
         end
 
         def prepare_cache
-          sh.cmd 'bundle clean' if bundler_path and data.cache?(:bundler)
+          sh.cmd 'bundle clean', assert: false, timing: false if bundler_path and data.cache?(:bundler)
         end
 
         def cache_slug

--- a/spec/build/script/directory_cache_spec.rb
+++ b/spec/build/script/directory_cache_spec.rb
@@ -1,10 +1,11 @@
 require 'spec_helper'
 
-describe Travis::Build::Script::DirectoryCache do
+describe Travis::Build::Script::DirectoryCache, :sexp do
   let(:options) { { fetch_timeout: 20, push_timeout: 30, type: 's3', s3: { bucket: 's3_bucket', secret_access_key: 's3_secret_access_key', access_key_id: 's3_access_key_id' } } }
-  let(:data)    { payload_for(:push, :erlang, config: { cache: config }, cache_options: options) }
+  let(:data)    { payload_for(:push, :ruby, config: { cache: config, bundler_args: '--path=foo/bar' }, cache_options: options) }
   let(:sh)      { Travis::Shell::Builder.new }
-  let(:script)  { Struct.new(:sh, :data, :cache_slug) { include(Travis::Build::Script::DirectoryCache) }.new(sh, Travis::Build::Data.new(data)) }
+  let(:sexp)    { script.sexp }
+  let(:script)  { Travis::Build.script(data) }
   let(:cache)   { script.directory_cache }
 
   it_behaves_like 'compiled script' do
@@ -22,5 +23,12 @@ describe Travis::Build::Script::DirectoryCache do
     let(:config) { { directories: ['foo'] } }
     it { expect(script).to be_use_directory_cache }
     it { expect(cache).to be_a(Travis::Build::Script::DirectoryCache::S3) }
+  end
+
+  # not quite sure where to put this atm, but there probably should be tests
+  # specific to bundler caching
+  describe 'with bundler caching enabled' do
+    let(:config) { 'bundler' }
+    it { expect(sexp).to include_sexp [:cmd, 'bundle clean', echo: true] }
   end
 end


### PR DESCRIPTION
Asserting `bundle clean` would error the build. Unfortunately we didn't have any tests for this. OTOH erroring the build when the cache can't be pushed might even be debatable as the correct behaviour.

Thoughts?
