### PR TITLE
Use pushd/popd in Firefox plugin

### DIFF
--- a/lib/travis/build/addons/firefox.rb
+++ b/lib/travis/build/addons/firefox.rb
@@ -13,11 +13,11 @@ module Travis
             sh.echo "Installing Firefox v#{version}", ansi: :yellow
             sh.mkdir install_dir, echo: false, recursive: true
             sh.chown 'travis', install_dir, recursive: true
-            sh.cd install_dir, echo: false
+            sh.cd install_dir, echo: false, stack: true
             sh.cmd "wget -O /tmp/#{filename} #{source_url}", echo: true, timing: true, retry: true
             sh.cmd "tar xf /tmp/#{filename}"
             sh.export 'PATH', "#{install_dir}/firefox:\$PATH", echo: false
-            sh.cd HOME_DIR, echo: false
+            sh.cd :back, echo: false, stack: true
           end
         end
 

--- a/spec/build/addons/firefox_spec.rb
+++ b/spec/build/addons/firefox_spec.rb
@@ -17,10 +17,10 @@ describe Travis::Build::Addons::Firefox, :sexp do
   it { should include_sexp [:echo, 'Installing Firefox v20.0', ansi: :yellow] }
   it { should include_sexp [:mkdir, '$HOME/firefox-20.0', recursive: true] }
   it { should include_sexp [:chown, ['travis', '$HOME/firefox-20.0'], recursive: true] }
-  it { should include_sexp [:cd, '$HOME/firefox-20.0'] }
+  it { should include_sexp [:cd, '$HOME/firefox-20.0', stack: true] }
   it { should include_sexp [:cmd, 'wget -O /tmp/firefox-20.0.tar.bz2 http://releases.mozilla.org/pub/firefox/releases/20.0/linux-x86_64/en-US/firefox-20.0.tar.bz2', echo: true, timing: true, retry: true] }
   it { should include_sexp [:cmd, 'tar xf /tmp/firefox-20.0.tar.bz2'] }
   it { should include_sexp [:export, ['PATH', '$HOME/firefox-20.0/firefox:$PATH']] }
-  it { should include_sexp [:cd, '$HOME'] }
+  it { should include_sexp [:cd, :back, stack: true] }
 end
 


### PR DESCRIPTION
To ensure that the build returns to the correct location at
the end of the addon execution.
