### PR TITLE
Update url of firefox

### DIFF
--- a/lib/travis/build/addons/firefox.rb
+++ b/lib/travis/build/addons/firefox.rb
@@ -36,7 +36,7 @@ module Travis
           end
 
           def source_url
-            "http://releases.mozilla.org/pub/firefox/releases/#{version}/linux-x86_64/en-US/#{filename}"
+            "http://download.cdn.mozilla.net/pub/firefox/releases/#{version}/linux-x86_64/en-US/#{filename}"
           end
 
           def tmp_file

--- a/spec/build/addons/firefox_spec.rb
+++ b/spec/build/addons/firefox_spec.rb
@@ -18,7 +18,7 @@ describe Travis::Build::Addons::Firefox, :sexp do
   it { should include_sexp [:mkdir, '$HOME/firefox-20.0', recursive: true] }
   it { should include_sexp [:chown, ['travis', '$HOME/firefox-20.0'], recursive: true] }
   it { should include_sexp [:cd, '$HOME/firefox-20.0', stack: true] }
-  it { should include_sexp [:cmd, 'wget -O /tmp/firefox-20.0.tar.bz2 http://releases.mozilla.org/pub/firefox/releases/20.0/linux-x86_64/en-US/firefox-20.0.tar.bz2', echo: true, timing: true, retry: true] }
+  it { should include_sexp [:cmd, 'wget -O /tmp/firefox-20.0.tar.bz2 http://download.cdn.mozilla.net/pub/firefox/releases/20.0/linux-x86_64/en-US/firefox-20.0.tar.bz2', echo: true, timing: true, retry: true] }
   it { should include_sexp [:cmd, 'tar xf /tmp/firefox-20.0.tar.bz2'] }
   it { should include_sexp [:export, ['PATH', '$HOME/firefox-20.0/firefox:$PATH']] }
   it { should include_sexp [:cd, :back, stack: true] }


### PR DESCRIPTION
http://releases.mozilla.org/pub/firefox/releases has moved http://download.cdn.mozilla.net/pub/firefox/releases permanently
