### PR TITLE
Drop '--jobs' from bundler args when running on Rubinius

### DIFF
--- a/lib/travis/build/script/shared/bundler.rb
+++ b/lib/travis/build/script/shared/bundler.rb
@@ -3,6 +3,7 @@ module Travis
     class Script
       module Bundler
         DEFAULT_BUNDLER_ARGS = "--jobs=3 --retry=3"
+        DEFAULT_BUNDLER_ARGS_RBX = '--retry=3'
 
         def use_directory_cache?
           super || data.cache?(:bundler)
@@ -65,13 +66,21 @@ module Travis
           end
 
           def bundler_install(args = nil)
-            args = bundler_args || [DEFAULT_BUNDLER_ARGS, args].compact
+            args = bundler_args || [default_bundler_args, args].compact
             args = [args].flatten << "--path=#{bundler_path}" if data.cache?(:bundler) && !bundler_args_path
             ['bundle install', *args].compact.join(' ')
           end
 
           def bundler_args
             config[:bundler_args]
+          end
+
+          def rbx?
+            config.fetch(:rvm, '').to_s.include?('rbx') || config.fetch(:ruby, '').to_s.include?('rbx')
+          end
+
+          def default_bundler_args
+            rbx? ? DEFAULT_BUNDLER_ARGS_RBX : DEFAULT_BUNDLER_ARGS
           end
       end
     end

--- a/spec/build/script/ruby_spec.rb
+++ b/spec/build/script/ruby_spec.rb
@@ -63,6 +63,17 @@ describe Travis::Build::Script::Ruby, :sexp do
     end
   end
 
+  context 'when running on Rubinius' do
+    before :each do
+      data[:config][:rvm] = 'rbx'
+    end
+
+    it "runs bundle install without '--jobs' if a Gemfile exists" do
+      sexp = sexp_find(sexp_filter(subject, [:if, '-f Gemfile'])[1], [:if, '-f Gemfile.lock'], [:else])
+      should include_sexp [:cmd, 'bundle install --retry=3', assert: true, echo: true, timing: true, retry: true]
+    end
+  end
+
   it 'sets BUNDLE_GEMFILE if a gemfile exists' do
     sexp = sexp_find(subject, [:if, '-f Gemfile'], [:then])
     expect(sexp).to include_sexp [:export, ['BUNDLE_GEMFILE', '$PWD/Gemfile'], echo: true]


### PR DESCRIPTION
This closes https://github.com/travis-ci/travis-ci/issues/2952
and provides a workaround for https://github.com/travis-ci/travis-ci/issues/2821
