### PR TITLE
Fix: untaint s3 cache urls since they are output to the script

### DIFF
--- a/lib/travis/build/script/shared/directory_cache/s3.rb
+++ b/lib/travis/build/script/shared/directory_cache/s3.rb
@@ -122,7 +122,7 @@ module Travis
             end
 
             def url(verb, path, options = {})
-              AWS4Signature.new(key_pair, verb, location(path), options[:expires], start).to_uri
+              AWS4Signature.new(key_pair, verb, location(path), options[:expires], start).to_uri.to_s.untaint
             end
 
             def key_pair

--- a/spec/build/script_spec.rb
+++ b/spec/build/script_spec.rb
@@ -50,5 +50,10 @@ describe Travis::Build::Script, :sexp do
       payload[:config][:script] = true
       expect { subject }.to_not raise_error
     end
+
+    it 'if s3_options are tainted' do
+      payload['cache_options']['s3']['access_key_id'].taint
+      expect { code }.to_not raise_error
+    end
   end
 end


### PR DESCRIPTION
It seems config values that are passed from the worker (when the script is generated inline) are tainted. This makes the enterprise worker fail to compile the script.

I believe the only options that eventually end up in a string that is output to the script are used to generate the S3 cache urls. This change fixed this problem.

I don't quite understand why the travis-build service doesn't also blow up on this, but I think this change is safe to be merged anway.
