### PR TITLE
Redo https://github.com/travis-ci/travis-build/pull/298

### DIFF
--- a/lib/travis/build/addons/postgresql.rb
+++ b/lib/travis/build/addons/postgresql.rb
@@ -12,6 +12,9 @@ module Travis
             sh.export "PATH", "/usr/lib/postgresql/#{version}/bin:$PATH", echo: false
             sh.echo "Starting PostgreSQL v#{version}", ansi: :yellow
             sh.cmd "service postgresql stop", assert: false, sudo: true, echo: true, timing: true
+            sh.if "-d /var/ramfs && ! -d /var/ramfs/postgresql/#{version}", echo: false do
+              sh.cmd "cp -rp /var/lib/postgresql/#{version} /var/ramfs/postgresql/#{version}", sudo: true, assert: false, echo: false, timing: false
+            end
             sh.cmd "service postgresql start #{version}", assert: false, sudo: true, echo: true, timing: true
           end
         end

--- a/spec/build/addons/postgresql_spec.rb
+++ b/spec/build/addons/postgresql_spec.rb
@@ -16,5 +16,6 @@ describe Travis::Build::Addons::Postgresql, :sexp do
   it { should include_sexp [:export, ['PATH', '/usr/lib/postgresql/9.3/bin:$PATH']] }
   it { should include_sexp [:echo, 'Starting PostgreSQL v9.3', ansi: :yellow] }
   it { should include_sexp [:cmd, 'service postgresql stop', sudo: true, echo: true, timing: true] }
+  it { should include_sexp [:cmd, 'cp -rp /var/lib/postgresql/9.3 /var/ramfs/postgresql/9.3', sudo: true] }
   it { should include_sexp [:cmd, 'service postgresql start 9.3', sudo: true, echo: true, timing: true] }
 end


### PR DESCRIPTION
While the corresponding cookbooks change should be deployed,
we continue to receive reports of
https://github.com/travis-ci/travis-ci/issues/2514.

The PR bit to travis-build was missed during the sexp refactoring,
so we redo it with this commit.
