### PR TITLE
add upload_pull_request option to artifacts addon

### DIFF
--- a/lib/travis/build/addons/artifacts/validator.rb
+++ b/lib/travis/build/addons/artifacts/validator.rb
@@ -36,11 +36,15 @@ module Travis
             end
 
             def validate_push_request
-              error :pull_request if pull_request?
+              error :pull_request if pull_request? and not upload_pull_request?
             end
 
             def validate_branch
               error :branch_disabled, data.branch unless branch_runnable?
+            end
+
+            def upload_pull_request?
+              config[:upload_pull_request]
             end
 
             def pull_request?

--- a/spec/build/addons/artifacts/validator_spec.rb
+++ b/spec/build/addons/artifacts/validator_spec.rb
@@ -38,6 +38,12 @@ describe Travis::Build::Addons::Artifacts::Validator do
       expect(subject).not_to be_valid
     end
 
+    it 'returns true for a pull request if upload_pull_request is enabled' do
+      config[:upload_pull_request] = true
+      data.stubs(:pull_request).returns '123'
+      expect(subject).to be_valid
+    end
+
     it 'adds an error message about pull requests being rejected' do
       data.stubs(:pull_request).returns '123'
       expect(errors).to eql([described_class::MSGS[:pull_request]])


### PR DESCRIPTION
Currently artefacts are never uploaded for PR builds. If a project has a PR focused workflow and uses artifacts to upload for instance extended build logs, then the artefacts feature is more or less unusable without an option like this.

Not sure `upload_pull_request` is the best name for the option.

Current syntax would be:

``` yaml
addons:
  artifacts:
    key: "YOUR AWS ACCESS KEY"
    secret: "YOUR AWS SECRET KEY"
    bucket: "S3 Bucket"
    upload_pull_request: true
```
