### PR TITLE
Fix directory_cache to not raise if s3 config is missing

### DIFF
--- a/lib/travis/build/script/shared/directory_cache/s3.rb
+++ b/lib/travis/build/script/shared/directory_cache/s3.rb
@@ -7,6 +7,16 @@ module Travis
     class Script
       module DirectoryCache
         class S3
+          MSGS = {
+            config_missing: 'Worker S3 config missing: %s'
+          }
+
+          VALIDATE = {
+            bucket:            'bucket name',
+            access_key_id:     'access key id',
+            secret_access_key: 'secret access key'
+          }
+
           KeyPair = Struct.new(:id, :secret)
 
           Location = Struct.new(:scheme, :region, :bucket, :path) do
@@ -20,13 +30,19 @@ module Travis
           USE_RUBY   = '1.9.3'
           BIN_PATH   = '$CASHER_DIR/bin/casher'
 
-          attr_reader :sh, :data, :slug, :start
+          attr_reader :sh, :data, :slug, :start, :msgs
 
           def initialize(sh, data, slug, start = Time.now)
             @sh = sh
             @data = data
             @slug = slug
             @start = start
+            @msgs = []
+          end
+
+          def valid?
+            validate
+            msgs.empty?
           end
 
           def setup
@@ -84,6 +100,11 @@ module Travis
 
           private
 
+            def validate
+              VALIDATE.each { |key, msg| msgs << msg unless s3_options[key] }
+              sh.echo MSGS[:config_missing] % msgs.join(', '), ansi: :red unless msgs.empty?
+            end
+
             def run(command, args, options = {})
               sh.if "-f #{BIN_PATH}" do
                 sh.cmd "rvm #{USE_RUBY} --fuzzy do #{BIN_PATH} #{command} #{Array(args).join(' ')}", options.merge(echo: false)
@@ -130,7 +151,7 @@ module Travis
             end
 
             def s3_options
-              options.fetch(:s3)
+              options[:s3] || {}
             end
 
             def options

--- a/spec/build/script/directory_cache/s3_spec.rb
+++ b/spec/build/script/directory_cache/s3_spec.rb
@@ -30,6 +30,19 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
   let(:cache)         { described_class.new(sh, Travis::Build::Data.new(data), 'ex a/mple', Time.at(10)) }
   let(:subject)       { sh.to_sexp }
 
+  describe 'validate' do
+    before { cache.valid? }
+
+    describe 'with valid s3' do
+      it { should_not include_sexp [:echo, 'Worker S3 config missing: bucket name, access key id, secret access key', ansi: :red] }
+    end
+
+    describe 'with s3 config missing' do
+      let(:s3_options)  { nil }
+      it { should include_sexp [:echo, 'Worker S3 config missing: bucket name, access key id, secret access key', ansi: :red] }
+    end
+  end
+
   describe 'install' do
     before { cache.install }
 

--- a/spec/build/script/directory_cache_spec.rb
+++ b/spec/build/script/directory_cache_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 describe Travis::Build::Script::DirectoryCache, :sexp do
   let(:options) { { fetch_timeout: 20, push_timeout: 30, type: 's3', s3: { bucket: 's3_bucket', secret_access_key: 's3_secret_access_key', access_key_id: 's3_access_key_id' } } }
-  let(:data)    { payload_for(:push, :ruby, config: { cache: config, bundler_args: '--path=foo/bar' }, cache_options: options) }
+  let(:data)    { payload_for(:push, :ruby, config: config, cache_options: options) }
   let(:sh)      { Travis::Shell::Builder.new }
   let(:sexp)    { script.sexp }
   let(:script)  { Travis::Build.script(data) }
   let(:cache)   { script.directory_cache }
 
   it_behaves_like 'compiled script' do
-    let(:config) { { directories: ['foo'] } }
+    let(:config) { { cache: { directories: ['foo'] } } }
     let(:cmds)   { ['cache.1', 'cache.2', 'casher fetch', 'casher add', 'casher push'] }
   end
 
@@ -19,8 +19,14 @@ describe Travis::Build::Script::DirectoryCache, :sexp do
     it { expect(cache).to be_a(Travis::Build::Script::DirectoryCache::Noop) }
   end
 
+  describe 'with caching enabled, but config missing' do
+    let(:config)  { { cache: { directories: ['foo'] } } }
+    let(:options) { { type: 's3' } }
+    it { expect(cache).to be_a(Travis::Build::Script::DirectoryCache::Noop) }
+  end
+
   describe 'uses S3 with caching enabled' do
-    let(:config) { { directories: ['foo'] } }
+    let(:config) { { cache: { directories: ['foo'] } } }
     it { expect(script).to be_use_directory_cache }
     it { expect(cache).to be_a(Travis::Build::Script::DirectoryCache::S3) }
   end
@@ -28,7 +34,7 @@ describe Travis::Build::Script::DirectoryCache, :sexp do
   # not quite sure where to put this atm, but there probably should be tests
   # specific to bundler caching
   describe 'with bundler caching enabled' do
-    let(:config) { 'bundler' }
+    let(:config) { { cache: 'bundler', bundler_args: '--path=foo/bar' } }
     it { expect(sexp).to include_sexp [:cmd, 'bundle clean', echo: true] }
   end
 end


### PR DESCRIPTION
We currently set `type: s3` by default in `worker.yml` for enterprise. This means that builds that opt into caching, while te-worker has not properly been configured for this, will run around in circles, raising an exception during script compile time, and retrying forever.
