### PR TITLE
Coverity: Handle '"upload_permitted":false' as a warning, not an error

### DIFF
--- a/lib/travis/build/addons/coverity_scan.rb
+++ b/lib/travis/build/addons/coverity_scan.rb
@@ -51,7 +51,7 @@ else
   else
     WHEN=`echo $AUTH_RES | ruby -e "require 'rubygems'; require 'json'; puts JSON[STDIN.read]['next_upload_permitted_at']"`
     echo -e "\033[33;1mCoverity Scan analysis NOT authorized until $WHEN.\033[0m"
-    exit 1
+    exit 0
   fi
 fi
 SH


### PR DESCRIPTION
Using matrix of builds can give errors because when a job uploaded
analysis results, the curl command status (line 43) change from
`{"upload_permitted":true}` to
`{"upload_permitted":false,"next_upload_permitted_at":"<date>"}`

For some jobs of the same build, the status can be set to failed (`exit 1`),
so the build status is failed, same for the project.

To avoid this, it would be useful to handle `"upload_permitted":false` as a
warning, changing `exit 1` to `exit 0`.

The results of Coverity analysis is given via Coverity postprocessing.