### PR TITLE
CSharp: Revert most of the features added in #354

### DIFF
--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -53,7 +53,7 @@ module Travis
 
         def script
           if config[:solution]
-            sh.cmd "xbuild /p:Configuration=#{config[:configuration] || 'Release'} /p:Platform=\"#{config[:platform] || 'x64'}\" #{config[:solution]}", timing: true if config[:solution]
+            sh.cmd "xbuild /p:Configuration=Release #{config[:solution]}", timing: true if config[:solution]
           else
             sh.echo 'No solution or script defined, exiting', ansi: :red
             sh.cmd 'false', echo: false, timing: false

--- a/spec/build/script/csharp_spec.rb
+++ b/spec/build/script/csharp_spec.rb
@@ -56,14 +56,7 @@ describe Travis::Build::Script::Csharp, :sexp do
 
     it 'builds specified solution' do
       data[:config][:solution] = 'foo.sln'
-      should include_sexp [:cmd, 'xbuild /p:Configuration=Release /p:Platform="x64" foo.sln', echo: true, timing: true]
-    end
-
-    it 'configuration and platform work' do
-      data[:config][:solution] = 'foo.sln'
-      data[:config][:configuration] = 'Debug'
-      data[:config][:platform] = 'x86'
-      should include_sexp [:cmd, 'xbuild /p:Configuration=Debug /p:Platform="x86" foo.sln', echo: true, timing: true]
+      should include_sexp [:cmd, 'xbuild /p:Configuration=Release foo.sln', echo: true, timing: true]
     end
   end
 end


### PR DESCRIPTION
Sorry, @akoeplinger and @BanzaiMan for the trouble.

This removes the `platform` and `configuration` options but keeps the default configuration as Release.
