### PR TITLE
JWT addon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby File.read(File.expand_path('../.ruby-version', __FILE__)).strip if ENV.key?
 
 gem 'activesupport', '~> 4.0'
 gem 'addressable', '~> 2.3'
+gem 'jwt'
 gem 'coder'
 gem 'jemalloc'
 gem 'metriks', '0.9.9.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,7 @@ GEM
     i18n (0.7.0)
     jemalloc (1.0.1)
     json (1.8.3)
+    jwt (1.5.4)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -116,6 +117,7 @@ DEPENDENCIES
   codeclimate-test-reporter
   coder
   jemalloc
+  jwt
   metriks (= 0.9.9.6)
   metriks-librato_metrics!
   mocha (~> 0.10.0)

--- a/lib/travis/build/addons.rb
+++ b/lib/travis/build/addons.rb
@@ -11,6 +11,7 @@ require 'travis/build/addons/hosts'
 require 'travis/build/addons/mariadb'
 require 'travis/build/addons/postgresql'
 require 'travis/build/addons/sauce_connect'
+require 'travis/build/addons/jwt'
 require 'travis/build/addons/ssh_known_hosts'
 require 'travis/build/addons/sonarqube'
 

--- a/lib/travis/build/addons/jwt.rb
+++ b/lib/travis/build/addons/jwt.rb
@@ -1,0 +1,38 @@
+require 'travis/build/addons/base'
+require 'jwt'
+
+module Travis
+  module Build
+    class Addons
+      class Jwt < Base
+        SUPER_USER_SAFE = true
+
+        def before_before_script
+          secrets = nil
+          if config.is_a?(String)
+            secrets = [config]
+          else
+            secrets = config.values
+          end
+
+          tokens = {}
+          secrets.each do |secret|
+            key, secret = secret.split('=').map(&:strip)
+            pull_request = self.data.pull_request ? self.data.pull_request : ""
+            payload = {"slug" => self.data.slug,
+                      "pull-request" => pull_request,
+                      "iat" => Time.now.to_i()}
+            token = JWT.encode(payload, secret)
+            tokens[key] = token
+          end
+          sh.fold 'addons_jwt' do
+            sh.echo 'Initializing JWT', ansi: :yellow
+            tokens.each do |key, val|
+              sh.export key, val, echo: false
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/build/addons/jwt.rb
+++ b/lib/travis/build/addons/jwt.rb
@@ -19,9 +19,11 @@ module Travis
           secrets.each do |secret|
             key, secret = secret.split('=').map(&:strip)
             pull_request = self.data.pull_request ? self.data.pull_request : ""
+            now = Time.now.to_i()
             payload = {"slug" => self.data.slug,
                       "pull-request" => pull_request,
-                      "iat" => Time.now.to_i()}
+                      "exp" => now+5400,
+                      "iat" => now}
             token = JWT.encode(payload, secret)
             tokens[key] = token
           end

--- a/lib/travis/build/addons/jwt.rb
+++ b/lib/travis/build/addons/jwt.rb
@@ -20,7 +20,8 @@ module Travis
             key, secret = secret.split('=').map(&:strip)
             pull_request = self.data.pull_request ? self.data.pull_request : ""
             now = Time.now.to_i()
-            payload = {"slug" => self.data.slug,
+            payload = {"iss" => "travis-ci.org",
+                      "slug" => self.data.slug,
                       "pull-request" => pull_request,
                       "exp" => now+5400,
                       "iat" => now}

--- a/lib/travis/build/addons/jwt.rb
+++ b/lib/travis/build/addons/jwt.rb
@@ -11,6 +11,8 @@ module Travis
           secrets = nil
           if config.is_a?(String)
             secrets = [config]
+          elsif config.is_a?(Array)
+            secrets = config
           else
             secrets = config.values
           end

--- a/lib/travis/build/addons/jwt.rb
+++ b/lib/travis/build/addons/jwt.rb
@@ -23,8 +23,7 @@ module Travis
             begin
               tokens[key] = JWT.encode(payload, secret)
             rescue Exception => e
-              sh.echo "JWT Encode Error: #{e.message}", ansi: :red
-              warn e
+              sh.failure "JWT Encode Error: #{e.message}"
               []
             end
           end

--- a/spec/build/addons/jwt_spec.rb
+++ b/spec/build/addons/jwt_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe Travis::Build::Addons::Jwt, :sexp do
+  let(:script) { stub('script') }
+  let(:data)   { payload_for(:push, :ruby, config: { addons: { jwt: config } }) }
+  let(:sh)     { Travis::Shell::Builder.new }
+  let(:addon)  { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
+  subject      { sh.to_sexp }
+  before       { Time.stubs(:now).returns(Time.mktime(1970,1,1)) }
+  before       { addon.before_before_script }
+
+  describe 'jwt token, one secret' do
+    let(:config) { 'MY_ACCESS_KEY=987654321' }
+    it "should work" do
+      subject.should include_sexp [:echo, 'Initializing JWT', ansi: :yellow]
+      expected = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzbHVnIjoidHJhdmlzLWNpL3RyYXZpcy1jaSIsInB1bGwtcmVxdWVzdCI6IiIsImlhdCI6MH0.vHZdjuxQt6CdFmWPEJLAsVbI_KCxbwJVbgT7jaTxkK4"
+      subject.should include_sexp [:export, ['MY_ACCESS_KEY', expected]]
+    end
+  end
+
+  describe 'jwt token, several secrets' do
+    let(:config) { {
+      secret1: 'MY_ACCESS_KEY_1=123456789',
+      secret2: 'MY_ACCESS_KEY_2=ABCDEF'
+    } }
+    it "should work" do
+      subject.should include_sexp [:echo, 'Initializing JWT', ansi: :yellow]
+      expected1 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzbHVnIjoidHJhdmlzLWNpL3RyYXZpcy1jaSIsInB1bGwtcmVxdWVzdCI6IiIsImlhdCI6MH0.iO-I8CNXhQlgw_dL8R9CDaDPplSC3yf9J399Uumn6CE"
+      subject.should include_sexp [:export, ['MY_ACCESS_KEY_1', expected1]]
+      expected2 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzbHVnIjoidHJhdmlzLWNpL3RyYXZpcy1jaSIsInB1bGwtcmVxdWVzdCI6IiIsImlhdCI6MH0.p1B9HnYCh-z5Igek5tr_QVPb1zV1ucwcPZNvY039WKg"
+      subject.should include_sexp [:export, ['MY_ACCESS_KEY_2', expected2]]
+    end
+  end
+end
+

--- a/spec/build/addons/jwt_spec.rb
+++ b/spec/build/addons/jwt_spec.rb
@@ -33,7 +33,7 @@ describe Travis::Build::Addons::Jwt, :sexp do
       end
     end
 
-    describe 'handle malformed secret/key' do
+    describe 'handle raising an exception on 100%' do
       let(:config) { ["JUSTKEY"]; }
 
       it "should output warning about bad data" do
@@ -41,16 +41,8 @@ describe Travis::Build::Addons::Jwt, :sexp do
       end
     end
 
-    describe 'handle raising an exception on 100%' do
-      let(:config) { [nil]; }
-
-      it "should output warning about bad data" do
-        expect(subject).to include_sexp [:echo, "There was an error while encoding JWT. If the secret is encrypted, ensure that it is encrypted correctly.", {:ansi=>:yellow}]
-      end
-    end
-
     describe 'handle raising an exception on 50%' do
-      let(:config) { [nil, 'BAD_ACCESS_KEY=abc123']; }
+      let(:config) { ["JUSTKEY", 'BAD_ACCESS_KEY=abc123']; }
 
       it "should output warning about bad data" do
         # first one throws an exception

--- a/spec/build/addons/jwt_spec.rb
+++ b/spec/build/addons/jwt_spec.rb
@@ -13,7 +13,7 @@ describe Travis::Build::Addons::Jwt, :sexp do
     let(:config) { 'MY_ACCESS_KEY=987654321' }
     it "should work" do
       subject.should include_sexp [:echo, 'Initializing JWT', ansi: :yellow]
-      expected = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0cmF2aXMtY2kub3JnIiwic2x1ZyI6InRyYXZpcy1jaS90cmF2aXMtY2kiLCJwdWxsLXJlcXVlc3QiOiIiLCJleHAiOjU0MDAsImlhdCI6MH0.soQJgHR6cGNr9Lj_N6yL2Nk5SQug-hXGUPenJy1QTVc"
+      expected = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0cmF2aXMtY2kub3JnIiwic2x1ZyI6InRyYXZpcy1jaS90cmF2aXMtY2kiLCJwdWxsLXJlcXVlc3QiOiIiLCJleHAiOjM0MjAwLCJpYXQiOjI4ODAwfQ.NQLflEZgXkZY80frfSPfUQVYk0chvStFseUrU1HDRJk"
       subject.should include_sexp [:export, ['MY_ACCESS_KEY', expected]]
     end
   end
@@ -25,9 +25,9 @@ describe Travis::Build::Addons::Jwt, :sexp do
     } }
     it "should work" do
       subject.should include_sexp [:echo, 'Initializing JWT', ansi: :yellow]
-      expected1 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0cmF2aXMtY2kub3JnIiwic2x1ZyI6InRyYXZpcy1jaS90cmF2aXMtY2kiLCJwdWxsLXJlcXVlc3QiOiIiLCJleHAiOjU0MDAsImlhdCI6MH0.ISnBTj5MYXAMhvG2P_3JkSCql1Vx1xptlTJMNQsGAPU"
+      expected1 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0cmF2aXMtY2kub3JnIiwic2x1ZyI6InRyYXZpcy1jaS90cmF2aXMtY2kiLCJwdWxsLXJlcXVlc3QiOiIiLCJleHAiOjM0MjAwLCJpYXQiOjI4ODAwfQ.ZuZEGlQZF_XVIxqatj17kxJ0byoKYJRbcO2yrLjaFTM"
       subject.should include_sexp [:export, ['MY_ACCESS_KEY_1', expected1]]
-      expected2 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0cmF2aXMtY2kub3JnIiwic2x1ZyI6InRyYXZpcy1jaS90cmF2aXMtY2kiLCJwdWxsLXJlcXVlc3QiOiIiLCJleHAiOjU0MDAsImlhdCI6MH0.xC_e3O9-bsNDxI61fFudUUrWyVOeLNN1XFPux_aRRto"
+      expected2 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0cmF2aXMtY2kub3JnIiwic2x1ZyI6InRyYXZpcy1jaS90cmF2aXMtY2kiLCJwdWxsLXJlcXVlc3QiOiIiLCJleHAiOjM0MjAwLCJpYXQiOjI4ODAwfQ.vwir6OH5mdnvzucyuc5wR4d_17tF1aNDw29_AXJVDr4"
       subject.should include_sexp [:export, ['MY_ACCESS_KEY_2', expected2]]
     end
   end

--- a/spec/build/addons/jwt_spec.rb
+++ b/spec/build/addons/jwt_spec.rb
@@ -12,9 +12,9 @@ describe Travis::Build::Addons::Jwt, :sexp do
   describe 'jwt token, one secret' do
     let(:config) { 'MY_ACCESS_KEY=987654321' }
     it "should work" do
-      subject.should include_sexp [:echo, 'Initializing JWT', ansi: :yellow]
+      expect(subject).to include_sexp [:echo, 'Initializing JWT', ansi: :yellow]
       expected = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0cmF2aXMtY2kub3JnIiwic2x1ZyI6InRyYXZpcy1jaS90cmF2aXMtY2kiLCJwdWxsLXJlcXVlc3QiOiIiLCJleHAiOjM0MjAwLCJpYXQiOjI4ODAwfQ.NQLflEZgXkZY80frfSPfUQVYk0chvStFseUrU1HDRJk"
-      subject.should include_sexp [:export, ['MY_ACCESS_KEY', expected]]
+      expect(subject).to include_sexp [:export, ['MY_ACCESS_KEY', expected]]
     end
   end
 
@@ -24,11 +24,11 @@ describe Travis::Build::Addons::Jwt, :sexp do
       secret2: 'MY_ACCESS_KEY_2=ABCDEF'
     } }
     it "should work" do
-      subject.should include_sexp [:echo, 'Initializing JWT', ansi: :yellow]
+      expect(subject).to include_sexp [:echo, 'Initializing JWT', ansi: :yellow]
       expected1 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0cmF2aXMtY2kub3JnIiwic2x1ZyI6InRyYXZpcy1jaS90cmF2aXMtY2kiLCJwdWxsLXJlcXVlc3QiOiIiLCJleHAiOjM0MjAwLCJpYXQiOjI4ODAwfQ.ZuZEGlQZF_XVIxqatj17kxJ0byoKYJRbcO2yrLjaFTM"
-      subject.should include_sexp [:export, ['MY_ACCESS_KEY_1', expected1]]
+      expect(subject).to include_sexp [:export, ['MY_ACCESS_KEY_1', expected1]]
       expected2 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0cmF2aXMtY2kub3JnIiwic2x1ZyI6InRyYXZpcy1jaS90cmF2aXMtY2kiLCJwdWxsLXJlcXVlc3QiOiIiLCJleHAiOjM0MjAwLCJpYXQiOjI4ODAwfQ.vwir6OH5mdnvzucyuc5wR4d_17tF1aNDw29_AXJVDr4"
-      subject.should include_sexp [:export, ['MY_ACCESS_KEY_2', expected2]]
+      expect(subject).to include_sexp [:export, ['MY_ACCESS_KEY_2', expected2]]
     end
   end
 end

--- a/spec/build/addons/jwt_spec.rb
+++ b/spec/build/addons/jwt_spec.rb
@@ -13,7 +13,7 @@ describe Travis::Build::Addons::Jwt, :sexp do
     let(:config) { 'MY_ACCESS_KEY=987654321' }
     it "should work" do
       subject.should include_sexp [:echo, 'Initializing JWT', ansi: :yellow]
-      expected = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzbHVnIjoidHJhdmlzLWNpL3RyYXZpcy1jaSIsInB1bGwtcmVxdWVzdCI6IiIsImV4cCI6NTQwMCwiaWF0IjowfQ.SEfKPH4IxXp3c1FheGVd6poMULkfHRZ9YFMBYpquIFs"
+      expected = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0cmF2aXMtY2kub3JnIiwic2x1ZyI6InRyYXZpcy1jaS90cmF2aXMtY2kiLCJwdWxsLXJlcXVlc3QiOiIiLCJleHAiOjU0MDAsImlhdCI6MH0.soQJgHR6cGNr9Lj_N6yL2Nk5SQug-hXGUPenJy1QTVc"
       subject.should include_sexp [:export, ['MY_ACCESS_KEY', expected]]
     end
   end
@@ -25,9 +25,9 @@ describe Travis::Build::Addons::Jwt, :sexp do
     } }
     it "should work" do
       subject.should include_sexp [:echo, 'Initializing JWT', ansi: :yellow]
-      expected1 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzbHVnIjoidHJhdmlzLWNpL3RyYXZpcy1jaSIsInB1bGwtcmVxdWVzdCI6IiIsImV4cCI6NTQwMCwiaWF0IjowfQ.ZNsODFURduRtDw2IyuC9_fZGF-fb4b4EW_aXZ1ZZHFs"
+      expected1 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0cmF2aXMtY2kub3JnIiwic2x1ZyI6InRyYXZpcy1jaS90cmF2aXMtY2kiLCJwdWxsLXJlcXVlc3QiOiIiLCJleHAiOjU0MDAsImlhdCI6MH0.ISnBTj5MYXAMhvG2P_3JkSCql1Vx1xptlTJMNQsGAPU"
       subject.should include_sexp [:export, ['MY_ACCESS_KEY_1', expected1]]
-      expected2 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzbHVnIjoidHJhdmlzLWNpL3RyYXZpcy1jaSIsInB1bGwtcmVxdWVzdCI6IiIsImV4cCI6NTQwMCwiaWF0IjowfQ.mmnY9xdgMAR0yTfnIaZMOAB4QE0J1HiT0XBFJGKnLxs"
+      expected2 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0cmF2aXMtY2kub3JnIiwic2x1ZyI6InRyYXZpcy1jaS90cmF2aXMtY2kiLCJwdWxsLXJlcXVlc3QiOiIiLCJleHAiOjU0MDAsImlhdCI6MH0.xC_e3O9-bsNDxI61fFudUUrWyVOeLNN1XFPux_aRRto"
       subject.should include_sexp [:export, ['MY_ACCESS_KEY_2', expected2]]
     end
   end

--- a/spec/build/addons/jwt_spec.rb
+++ b/spec/build/addons/jwt_spec.rb
@@ -41,7 +41,7 @@ describe Travis::Build::Addons::Jwt, :sexp do
 
       it "should work" do
         expect(subject).to include_sexp [:echo, 'Initializing JWT', ansi: :yellow]
-        expect(subject).to include_sexp [:echo, 'JWT Encode Error: Bad body', ansi: :red]
+        expect(subject).to include_sexp [:echo, 'JWT Encode Error: Bad body']
       end
     end
   end

--- a/spec/build/addons/jwt_spec.rb
+++ b/spec/build/addons/jwt_spec.rb
@@ -6,7 +6,7 @@ describe Travis::Build::Addons::Jwt, :sexp do
   let(:sh)     { Travis::Shell::Builder.new }
   let(:addon)  { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
   subject      { sh.to_sexp }
-  before       { Time.stubs(:now).returns(Time.mktime(1970,1,1)) }
+  before       { Time.stubs(:now).returns(Time.at(28800)) }
   before       { addon.before_before_script }
 
   describe 'jwt token, one secret' do

--- a/spec/build/addons/jwt_spec.rb
+++ b/spec/build/addons/jwt_spec.rb
@@ -9,26 +9,41 @@ describe Travis::Build::Addons::Jwt, :sexp do
   before       { Time.stubs(:now).returns(Time.at(28800)) }
   before       { addon.before_before_script }
 
-  describe 'jwt token, one secret' do
-    let(:config) { 'MY_ACCESS_KEY=987654321' }
-    it "should work" do
-      expect(subject).to include_sexp [:echo, 'Initializing JWT', ansi: :yellow]
-      expected = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0cmF2aXMtY2kub3JnIiwic2x1ZyI6InRyYXZpcy1jaS90cmF2aXMtY2kiLCJwdWxsLXJlcXVlc3QiOiIiLCJleHAiOjM0MjAwLCJpYXQiOjI4ODAwfQ.NQLflEZgXkZY80frfSPfUQVYk0chvStFseUrU1HDRJk"
-      expect(subject).to include_sexp [:export, ['MY_ACCESS_KEY', expected]]
+  describe 'jwt token' do
+    describe 'one secret' do
+      let(:config) { 'MY_ACCESS_KEY=987654321' }
+      it "should work" do
+        expect(subject).to include_sexp [:echo, 'Initializing JWT', ansi: :yellow]
+        expected = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0cmF2aXMtY2kub3JnIiwic2x1ZyI6InRyYXZpcy1jaS90cmF2aXMtY2kiLCJwdWxsLXJlcXVlc3QiOiIiLCJleHAiOjM0MjAwLCJpYXQiOjI4ODAwfQ.NQLflEZgXkZY80frfSPfUQVYk0chvStFseUrU1HDRJk"
+        expect(subject).to include_sexp [:export, ['MY_ACCESS_KEY', expected]]
+      end
     end
-  end
 
-  describe 'jwt token, several secrets' do
-    let(:config) { {
-      secret1: 'MY_ACCESS_KEY_1=123456789',
-      secret2: 'MY_ACCESS_KEY_2=ABCDEF'
-    } }
-    it "should work" do
-      expect(subject).to include_sexp [:echo, 'Initializing JWT', ansi: :yellow]
-      expected1 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0cmF2aXMtY2kub3JnIiwic2x1ZyI6InRyYXZpcy1jaS90cmF2aXMtY2kiLCJwdWxsLXJlcXVlc3QiOiIiLCJleHAiOjM0MjAwLCJpYXQiOjI4ODAwfQ.ZuZEGlQZF_XVIxqatj17kxJ0byoKYJRbcO2yrLjaFTM"
-      expect(subject).to include_sexp [:export, ['MY_ACCESS_KEY_1', expected1]]
-      expected2 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0cmF2aXMtY2kub3JnIiwic2x1ZyI6InRyYXZpcy1jaS90cmF2aXMtY2kiLCJwdWxsLXJlcXVlc3QiOiIiLCJleHAiOjM0MjAwLCJpYXQiOjI4ODAwfQ.vwir6OH5mdnvzucyuc5wR4d_17tF1aNDw29_AXJVDr4"
-      expect(subject).to include_sexp [:export, ['MY_ACCESS_KEY_2', expected2]]
+    describe 'several named secrets' do
+      let(:config) { {
+        secret1: 'MY_ACCESS_KEY_1=123456789',
+        secret2: 'MY_ACCESS_KEY_2=ABCDEF'
+      } }
+      it "should work" do
+        expect(subject).to include_sexp [:echo, 'Initializing JWT', ansi: :yellow]
+        expected1 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0cmF2aXMtY2kub3JnIiwic2x1ZyI6InRyYXZpcy1jaS90cmF2aXMtY2kiLCJwdWxsLXJlcXVlc3QiOiIiLCJleHAiOjM0MjAwLCJpYXQiOjI4ODAwfQ.ZuZEGlQZF_XVIxqatj17kxJ0byoKYJRbcO2yrLjaFTM"
+        expect(subject).to include_sexp [:export, ['MY_ACCESS_KEY_1', expected1]]
+        expected2 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0cmF2aXMtY2kub3JnIiwic2x1ZyI6InRyYXZpcy1jaS90cmF2aXMtY2kiLCJwdWxsLXJlcXVlc3QiOiIiLCJleHAiOjM0MjAwLCJpYXQiOjI4ODAwfQ.vwir6OH5mdnvzucyuc5wR4d_17tF1aNDw29_AXJVDr4"
+        expect(subject).to include_sexp [:export, ['MY_ACCESS_KEY_2', expected2]]
+      end
+    end
+    describe 'several secrets' do
+      let(:config) { [
+        'MY_ACCESS_KEY_3=123456789',
+        'MY_ACCESS_KEY_4=ABCDEF'
+      ] }
+      it "should work" do
+        expect(subject).to include_sexp [:echo, 'Initializing JWT', ansi: :yellow]
+        expected1 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0cmF2aXMtY2kub3JnIiwic2x1ZyI6InRyYXZpcy1jaS90cmF2aXMtY2kiLCJwdWxsLXJlcXVlc3QiOiIiLCJleHAiOjM0MjAwLCJpYXQiOjI4ODAwfQ.ZuZEGlQZF_XVIxqatj17kxJ0byoKYJRbcO2yrLjaFTM"
+        expect(subject).to include_sexp [:export, ['MY_ACCESS_KEY_3', expected1]]
+        expected2 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0cmF2aXMtY2kub3JnIiwic2x1ZyI6InRyYXZpcy1jaS90cmF2aXMtY2kiLCJwdWxsLXJlcXVlc3QiOiIiLCJleHAiOjM0MjAwLCJpYXQiOjI4ODAwfQ.vwir6OH5mdnvzucyuc5wR4d_17tF1aNDw29_AXJVDr4"
+        expect(subject).to include_sexp [:export, ['MY_ACCESS_KEY_4', expected2]]
+      end
     end
   end
 end

--- a/spec/build/addons/jwt_spec.rb
+++ b/spec/build/addons/jwt_spec.rb
@@ -13,7 +13,7 @@ describe Travis::Build::Addons::Jwt, :sexp do
     let(:config) { 'MY_ACCESS_KEY=987654321' }
     it "should work" do
       subject.should include_sexp [:echo, 'Initializing JWT', ansi: :yellow]
-      expected = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzbHVnIjoidHJhdmlzLWNpL3RyYXZpcy1jaSIsInB1bGwtcmVxdWVzdCI6IiIsImlhdCI6MH0.vHZdjuxQt6CdFmWPEJLAsVbI_KCxbwJVbgT7jaTxkK4"
+      expected = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzbHVnIjoidHJhdmlzLWNpL3RyYXZpcy1jaSIsInB1bGwtcmVxdWVzdCI6IiIsImV4cCI6NTQwMCwiaWF0IjowfQ.SEfKPH4IxXp3c1FheGVd6poMULkfHRZ9YFMBYpquIFs"
       subject.should include_sexp [:export, ['MY_ACCESS_KEY', expected]]
     end
   end
@@ -25,9 +25,9 @@ describe Travis::Build::Addons::Jwt, :sexp do
     } }
     it "should work" do
       subject.should include_sexp [:echo, 'Initializing JWT', ansi: :yellow]
-      expected1 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzbHVnIjoidHJhdmlzLWNpL3RyYXZpcy1jaSIsInB1bGwtcmVxdWVzdCI6IiIsImlhdCI6MH0.iO-I8CNXhQlgw_dL8R9CDaDPplSC3yf9J399Uumn6CE"
+      expected1 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzbHVnIjoidHJhdmlzLWNpL3RyYXZpcy1jaSIsInB1bGwtcmVxdWVzdCI6IiIsImV4cCI6NTQwMCwiaWF0IjowfQ.ZNsODFURduRtDw2IyuC9_fZGF-fb4b4EW_aXZ1ZZHFs"
       subject.should include_sexp [:export, ['MY_ACCESS_KEY_1', expected1]]
-      expected2 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzbHVnIjoidHJhdmlzLWNpL3RyYXZpcy1jaSIsInB1bGwtcmVxdWVzdCI6IiIsImlhdCI6MH0.p1B9HnYCh-z5Igek5tr_QVPb1zV1ucwcPZNvY039WKg"
+      expected2 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzbHVnIjoidHJhdmlzLWNpL3RyYXZpcy1jaSIsInB1bGwtcmVxdWVzdCI6IiIsImV4cCI6NTQwMCwiaWF0IjowfQ.mmnY9xdgMAR0yTfnIaZMOAB4QE0J1HiT0XBFJGKnLxs"
       subject.should include_sexp [:export, ['MY_ACCESS_KEY_2', expected2]]
     end
   end

--- a/spec/build/addons/jwt_spec.rb
+++ b/spec/build/addons/jwt_spec.rb
@@ -7,42 +7,41 @@ describe Travis::Build::Addons::Jwt, :sexp do
   let(:addon)  { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
   subject      { sh.to_sexp }
   before       { Time.stubs(:now).returns(Time.at(28800)) }
-  before       { addon.before_before_script }
 
   describe 'jwt token' do
     describe 'one secret' do
-      let(:config) { 'MY_ACCESS_KEY=987654321' }
+      before { addon.before_before_script }
+      let(:config) { ['MY_ACCESS_KEY=987654321'] }
       it "should work" do
         expect(subject).to include_sexp [:echo, 'Initializing JWT', ansi: :yellow]
-        expected = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0cmF2aXMtY2kub3JnIiwic2x1ZyI6InRyYXZpcy1jaS90cmF2aXMtY2kiLCJwdWxsLXJlcXVlc3QiOiIiLCJleHAiOjM0MjAwLCJpYXQiOjI4ODAwfQ.NQLflEZgXkZY80frfSPfUQVYk0chvStFseUrU1HDRJk"
+        expected = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJUcmF2aXMgQ0ksIEdtYkgiLCJzbHVnIjoidHJhdmlzLWNpL3RyYXZpcy1jaSIsInB1bGwtcmVxdWVzdCI6IiIsImV4cCI6MzQyMDAsImlhdCI6Mjg4MDB9.xFz1U8eEulqkvy_odV0hxDbMLmaeZWgIuM7Oj-NWQ-0"
         expect(subject).to include_sexp [:export, ['MY_ACCESS_KEY', expected]]
       end
     end
 
-    describe 'several named secrets' do
-      let(:config) { {
-        secret1: 'MY_ACCESS_KEY_1=123456789',
-        secret2: 'MY_ACCESS_KEY_2=ABCDEF'
-      } }
-      it "should work" do
-        expect(subject).to include_sexp [:echo, 'Initializing JWT', ansi: :yellow]
-        expected1 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0cmF2aXMtY2kub3JnIiwic2x1ZyI6InRyYXZpcy1jaS90cmF2aXMtY2kiLCJwdWxsLXJlcXVlc3QiOiIiLCJleHAiOjM0MjAwLCJpYXQiOjI4ODAwfQ.ZuZEGlQZF_XVIxqatj17kxJ0byoKYJRbcO2yrLjaFTM"
-        expect(subject).to include_sexp [:export, ['MY_ACCESS_KEY_1', expected1]]
-        expected2 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0cmF2aXMtY2kub3JnIiwic2x1ZyI6InRyYXZpcy1jaS90cmF2aXMtY2kiLCJwdWxsLXJlcXVlc3QiOiIiLCJleHAiOjM0MjAwLCJpYXQiOjI4ODAwfQ.vwir6OH5mdnvzucyuc5wR4d_17tF1aNDw29_AXJVDr4"
-        expect(subject).to include_sexp [:export, ['MY_ACCESS_KEY_2', expected2]]
-      end
-    end
     describe 'several secrets' do
+      before { addon.before_before_script }
       let(:config) { [
         'MY_ACCESS_KEY_3=123456789',
         'MY_ACCESS_KEY_4=ABCDEF'
       ] }
       it "should work" do
         expect(subject).to include_sexp [:echo, 'Initializing JWT', ansi: :yellow]
-        expected1 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0cmF2aXMtY2kub3JnIiwic2x1ZyI6InRyYXZpcy1jaS90cmF2aXMtY2kiLCJwdWxsLXJlcXVlc3QiOiIiLCJleHAiOjM0MjAwLCJpYXQiOjI4ODAwfQ.ZuZEGlQZF_XVIxqatj17kxJ0byoKYJRbcO2yrLjaFTM"
+        expected1 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJUcmF2aXMgQ0ksIEdtYkgiLCJzbHVnIjoidHJhdmlzLWNpL3RyYXZpcy1jaSIsInB1bGwtcmVxdWVzdCI6IiIsImV4cCI6MzQyMDAsImlhdCI6Mjg4MDB9.LHFaZc1YZATFKCmZv9f-7FYyA_jdE3Toh48iTDz2m1o"
         expect(subject).to include_sexp [:export, ['MY_ACCESS_KEY_3', expected1]]
-        expected2 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0cmF2aXMtY2kub3JnIiwic2x1ZyI6InRyYXZpcy1jaS90cmF2aXMtY2kiLCJwdWxsLXJlcXVlc3QiOiIiLCJleHAiOjM0MjAwLCJpYXQiOjI4ODAwfQ.vwir6OH5mdnvzucyuc5wR4d_17tF1aNDw29_AXJVDr4"
+        expected2 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJUcmF2aXMgQ0ksIEdtYkgiLCJzbHVnIjoidHJhdmlzLWNpL3RyYXZpcy1jaSIsInB1bGwtcmVxdWVzdCI6IiIsImV4cCI6MzQyMDAsImlhdCI6Mjg4MDB9.e2m4CvKHVJn_UjiZL2BkKF45VVC0IgAeW5FaEhH2gWM"
         expect(subject).to include_sexp [:export, ['MY_ACCESS_KEY_4', expected2]]
+      end
+    end
+
+    describe 'handle raising an exception' do
+      before { JWT.stubs(:encode).raises(Exception, "Bad body") }
+      before { addon.before_before_script }
+      let(:config) { ['BAD_ACCESS_KEY']; }
+
+      it "should work" do
+        expect(subject).to include_sexp [:echo, 'Initializing JWT', ansi: :yellow]
+        expect(subject).to include_sexp [:echo, 'JWT Encode Error: Bad body', ansi: :red]
       end
     end
   end


### PR DESCRIPTION
JWT token authentication for PR.

Users need to add this to `.travis.yml`.

```
addons:
  jwt: 
     secure: <SAUCE_ACCESS_KEY=123456789 encrypted> 
```

The JWT addon will then create a time-limited JWT token and export it to the SAUCE_ACCESS_KEY environment variable.

This is not specific to sauce labs several services may be configured, for instance:
```
addons:
  jwt:
     saucelabs:
        secure: <SAUCE_ACCESS_KEY=123456789 encrypted>
     moonwalk:
        secure: <MOONWALK_SECRET=123456789 encrypted>
```
In this case 2 tokens will be generated, one in the SAUCE_ACCESS_KEY env variable, the other in MOONWALK_SECRET.
