### PR TITLE
D: Fix DMD binary path on OS X

### DIFF
--- a/lib/travis/build/script/d.rb
+++ b/lib/travis/build/script/d.rb
@@ -37,7 +37,7 @@ module Travis
             when 'dmd'
               binpath, libpath = {
                 'linux' => ['dmd2/linux/bin64', 'dmd2/linux/lib64'],
-                'osx' => ['dmd2/linux/bin', 'dmd2/linux/lib'] }[os]
+                'osx' => ['dmd2/osx/bin', 'dmd2/osx/lib'] }[os]
 
               sh.cmd "curl #{compiler_url} > ~/dmd.zip"
               sh.cmd 'unzip -q -d ~ ~/dmd.zip'


### PR DESCRIPTION
See travis-ci/travis-ci#3033.

Just a quick-and-dirty fix for an obvious typo; don't have a VM set up on this machine right now. Pinging @MartinNowak.
