### PR TITLE
Installing NUnit for C# builds

### DIFF
--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -27,7 +27,7 @@ module Travis
               sh.cmd "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian wheezy main' >> /etc/apt/sources.list.d/mono-xamarin.list\"", echo: false
               sh.cmd "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian wheezy-libtiff-compat main' >> /etc/apt/sources.list.d/mono-xamarin.list\"", echo: false
               sh.cmd 'sudo apt-get update -qq', timing: true
-              sh.cmd 'sudo apt-get install -qq mono-complete nuget mono-vbnc fsharp', timing: true
+              sh.cmd 'sudo apt-get install -qq mono-complete nuget nunit-console mono-vbnc fsharp', timing: true
               sh.cmd 'mozroots --import --sync --quiet', timing: true
             end
           end

--- a/spec/build/script/csharp_spec.rb
+++ b/spec/build/script/csharp_spec.rb
@@ -20,7 +20,7 @@ describe Travis::Build::Script::Csharp, :sexp do
     end
 
     it 'installs mono' do
-      should include_sexp [:cmd, 'sudo apt-get install -qq mono-complete nuget mono-vbnc fsharp', timing: true]
+      should include_sexp [:cmd, 'sudo apt-get install -qq mono-complete nuget nunit-console mono-vbnc fsharp', timing: true]
       should include_sexp [:cmd, 'mozroots --import --sync --quiet', timing: true]
     end
   end


### PR DESCRIPTION
I'm wondering whether NUnit should be installed as default for C# builds to support unit testing. Having NUnit pre-installed would also allow the use of the new docker based build infra.

The core nunit  libraries already come with the `mono-complete` package, however the `nunit-console` is missing.

I know it is possible to install NUnit with NuGet, however invoking it from bash like `mono Mpdeimos.Playground.Templating/packages/NUnit.Runners.2.6.3/tools/nunit-console.exe $(find . -path "*/test-src/bin/*_Test.dll")` is not straight forward and the nunit runner is usually no project dependency.

/cc @joshua-anderson @akoeplinger @nterry.
