### PR TITLE
Bypass rbx dependency install checks

### DIFF
--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -37,6 +37,10 @@ module Travis
 
         private
 
+          def version
+            config[:rvm].to_s
+          end
+
           def rvm?
             !!config[:rvm]
           end
@@ -92,9 +96,18 @@ module Travis
           end
 
           def use_ruby_version
+            skip_deps_install if rbx?
             sh.fold('rvm') do
               sh.cmd "rvm use #{ruby_version} --install --binary --fuzzy"
             end
+          end
+
+          def rbx?
+            /^(rbx\S*)/.match(version)
+          end
+
+          def skip_deps_install
+            sh.cmd "rvm autolibs disable", echo: false, timing: false
           end
       end
     end

--- a/spec/build/script/ruby_spec.rb
+++ b/spec/build/script/ruby_spec.rb
@@ -136,4 +136,14 @@ describe Travis::Build::Script::Ruby, :sexp do
       it { is_expected.to eq('cache--jdk-openjdk7--rvm-jruby--gemfile-Gemfile') }
     end
   end
+
+  context 'when testing with rbx' do
+    before :each do
+      data[:config][:rvm] = 'rbx'
+    end
+
+    it 'sets autolibs to disable' do
+      should include_sexp [:cmd, "rvm autolibs disable", assert: true]
+    end
+  end
 end


### PR DESCRIPTION
This fixes https://github.com/travis-ci/travis-ci/issues/3056
