### PR TITLE
git clone: add --quiet option

### DIFF
--- a/lib/travis/build/git/clone.rb
+++ b/lib/travis/build/git/clone.rb
@@ -38,7 +38,7 @@ module Travis
           end
 
           def clone_args
-            args = "--depth=#{depth}"
+            args = "--quiet --depth=#{depth}"
             args << " --branch=#{branch}" unless data.ref
             args
           end


### PR DESCRIPTION
This change avoid many useless lines in the logs:

```
remote:...
Receiving objects:...
Resolving deltas:...
```
