### PR TITLE
git clone: add --quiet option

### DIFF
--- a/lib/travis/build/git/clone.rb
+++ b/lib/travis/build/git/clone.rb
@@ -38,7 +38,7 @@ module Travis
           end
 
           def clone_args
-            args = "--depth=#{depth}"
+            args = "--quiet --depth=#{depth}"
             args << " --branch=#{branch}" unless data.ref
             args
           end

--- a/spec/build/git/clone_spec.rb
+++ b/spec/build/git/clone_spec.rb
@@ -15,7 +15,7 @@ describe Travis::Build::Git::Clone, :sexp do
   end
 
   describe 'when the repository is cloned not yet' do
-    let(:args) { "--depth=#{depth} --branch=#{branch.shellescape}" }
+    let(:args) { "--quiet --depth=#{depth} --branch=#{branch.shellescape}" }
     let(:cmd)  { "git clone #{args} #{url} #{dir}" }
     subject    { sexp_find(sexp, [:if, "! -d #{dir}/.git"]) }
 


### PR DESCRIPTION
This change avoid many useless lines in the logs:
```
remote:...
[...]
Receiving objects:...
[...]
Resolving deltas:...
[...]
```