### PR TITLE
Add retry to NuGet. Fixes travis-ci/travis-ci#3077

### DIFF
--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -48,7 +48,7 @@ module Travis
         end
 
         def install
-          sh.cmd "nuget restore #{config[:solution]}" if config[:solution]
+          sh.cmd "nuget restore #{config[:solution]}", retry: true if config[:solution]
         end
 
         def script

--- a/spec/build/script/csharp_spec.rb
+++ b/spec/build/script/csharp_spec.rb
@@ -45,7 +45,7 @@ describe Travis::Build::Script::Csharp, :sexp do
   describe 'install' do
     it 'restores nuget from solution' do
       data[:config][:solution] = 'foo.sln'
-      should include_sexp [:cmd, 'nuget restore foo.sln', assert: true, echo: true, timing: true]
+      should include_sexp [:cmd, 'nuget restore foo.sln', assert: true, echo: true, timing: true, retry: true]
     end
   end
 


### PR DESCRIPTION
As with other package managers, NuGet is affected by the timeouts on the travis-ci infrastructure, so I added retrying.