### PR TITLE
Add Elixir managment with kiex

### DIFF
--- a/lib/travis/build/script/erlang.rb
+++ b/lib/travis/build/script/erlang.rb
@@ -9,11 +9,17 @@ module Travis
         def export
           super
           sh.export 'TRAVIS_OTP_RELEASE', otp_release, echo: false
+          sh.export 'TRAVIS_ELIXIR_VERSION', elixir, echo: false
         end
 
-        def setup
+        def announce
           super
-          sh.cmd "source #{HOME_DIR}/otp/#{otp_release}/activate"
+          sh.cmd "source #{HOME_DIR}/otp/#{otp_release}/activate", assert: true
+          if !elixir.empty?
+            sh.if has_elixir(elixir) do
+              sh.cmd "source #{HOME_DIR}/.kiex/elixirs/elixir-#{elixir}.env", assert: true
+            end
+          end
         end
 
         def install
@@ -47,8 +53,20 @@ module Travis
             config[:otp_release].to_s
           end
 
+          def elixir
+            config[:elixir].to_s
+          end
+
           def rebar_configured
             '(-f rebar.config || -f Rebar.config)'
+          end
+
+          def has_elixir(version)
+            "-f #{exlixir_env_file(version)}"
+          end
+
+          def exlixir_env_file(version)
+            "#{HOME_DIR}/.kiex/elixirs/elixir-#{version}.env"
           end
       end
     end

--- a/lib/travis/build/script/erlang.rb
+++ b/lib/travis/build/script/erlang.rb
@@ -9,15 +9,15 @@ module Travis
         def export
           super
           sh.export 'TRAVIS_OTP_RELEASE', otp_release, echo: false
-          sh.export 'TRAVIS_ELIXIR_VERSION', elixir, echo: false
+          sh.export 'TRAVIS_ELIXIR_VERSION', elixir_version, echo: false
         end
 
         def announce
           super
           sh.cmd "source #{HOME_DIR}/otp/#{otp_release}/activate", assert: true
-          if !elixir.empty?
-            sh.if has_elixir(elixir) do
-              sh.cmd "source #{HOME_DIR}/.kiex/elixirs/elixir-#{elixir}.env", assert: true
+          if !elixir_version.empty?
+            sh.if has_elixir(elixir_version) do
+              sh.cmd "source #{exlixir_env_file(elixir_version)}", assert: true
             end
           end
         end
@@ -53,7 +53,7 @@ module Travis
             config[:otp_release].to_s
           end
 
-          def elixir
+          def elixir_version
             config[:elixir].to_s
           end
 

--- a/spec/build/script/erlang_spec.rb
+++ b/spec/build/script/erlang_spec.rb
@@ -18,7 +18,7 @@ describe Travis::Build::Script::Erlang, :sexp do
   end
 
   it 'activates otp' do
-    should include_sexp [:cmd, 'source $HOME/otp/R14B04/activate', assert: true, echo: true, timing: true]
+    should include_sexp [:cmd, 'source $HOME/otp/R14B04/activate', assert: true, echo: true]
   end
 
   describe 'install' do
@@ -58,6 +58,16 @@ describe Travis::Build::Script::Erlang, :sexp do
   describe '#cache_slug' do
     subject { described_class.new(data).cache_slug }
     it { is_expected.to eq('cache--otp-R14B04') }
+  end
+
+  context 'when elixir is defined' do
+    it { store_example 'elixir config' }
+
+    before(:each) { data[:config][:elixir] = '1.0.2' }
+
+    it 'activates elixir' do
+      should include_sexp [:cmd, 'source $HOME/.kiex/elixirs/elixir-1.0.2.env', echo: true, assert: true]
+    end
   end
 end
 


### PR DESCRIPTION
Assuming https://github.com/travis-ci/travis-cookbooks/pull/430, we source
the kiex env file to activate the desired version of Elixir during the build.

Here, as well as in the cookbooks PR, there is no safeguard for the user who
attempts to run Elixir while an unsupported Erlang version is active.