### PR TITLE
git clone: add an optional --quiet option

### DIFF
--- a/lib/travis/build/git.rb
+++ b/lib/travis/build/git.rb
@@ -7,7 +7,7 @@ module Travis
   module Build
     class Git
       DEFAULTS = {
-        git: { depth: 50, submodules: true, strategy: 'clone' }
+        git: { depth: 50, submodules: true, strategy: 'clone', quiet: false }
       }
 
       attr_reader :sh, :data

--- a/lib/travis/build/git/clone.rb
+++ b/lib/travis/build/git/clone.rb
@@ -40,6 +40,7 @@ module Travis
           def clone_args
             args = "--depth=#{depth}"
             args << " --branch=#{branch}" unless data.ref
+	    args << " #{quiet_o}"
             args
           end
 
@@ -49,6 +50,14 @@ module Travis
 
           def branch
             data.branch.shellescape
+          end
+
+          def quiet_o
+            "--quiet" if quiet?
+          end
+
+          def quiet?
+            config[:git][:quiet]
           end
 
           def dir

--- a/spec/build/git/clone_spec.rb
+++ b/spec/build/git/clone_spec.rb
@@ -9,13 +9,15 @@ describe Travis::Build::Git::Clone, :sexp do
   let(:dir)    { 'travis-ci/travis-ci' }
   let(:depth)  { Travis::Build::Git::DEFAULTS[:git][:depth] }
   let(:branch) { payload[:job][:branch] || 'master' }
+  let(:quiet)  { Travis::Build::Git::DEFAULTS[:git][:quiet] }
+  let(:quiet_o){ '' }
 
   before :each do
     payload[:config][:git] = { strategy: 'clone' }
   end
 
   describe 'when the repository is cloned not yet' do
-    let(:args) { "--depth=#{depth} --branch=#{branch.shellescape}" }
+    let(:args) { "--depth=#{depth} --branch=#{branch.shellescape} #{quiet_o}" }
     let(:cmd)  { "git clone #{args} #{url} #{dir}" }
     subject    { sexp_find(sexp, [:if, "! -d #{dir}/.git"]) }
 


### PR DESCRIPTION
This can be turned on by setting (in the .travis.yml)
git:
  quiet: true

This change allows to avoid many useless lines in the logs:
remote:...
[...]
Receiving objects:...
[...]
Resolving deltas:...
[...]