### PR TITLE
apt-get install addon

### DIFF
--- a/lib/travis/build/addons.rb
+++ b/lib/travis/build/addons.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/string/inflections.rb'
+require 'travis/build/addons/apt_packages'
 require 'travis/build/addons/artifacts'
 require 'travis/build/addons/code_climate'
 require 'travis/build/addons/coverity_scan'

--- a/lib/travis/build/addons/apt_packages.rb
+++ b/lib/travis/build/addons/apt_packages.rb
@@ -35,7 +35,7 @@ module Travis
           end
 
           def whitelist
-            @whitelist ||= ENV['TRAVIS_BUILD_APT_WHITELIST'].to_s.split(/\s*,\s*/)
+            @whitelist ||= ENV['TRAVIS_BUILD_APT_WHITELIST'].to_s.split(/\s*,\s*/).map(&:strip)
           end
       end
     end

--- a/lib/travis/build/addons/apt_packages.rb
+++ b/lib/travis/build/addons/apt_packages.rb
@@ -11,12 +11,23 @@ module Travis
             sh.echo "Installing APT Packages (BETA)", ansi: :yellow
 
             whitelisted = []
+            disallowed = []
+
             config.each do |package|
               if whitelist.include?(package)
                 whitelisted << package
               else
-                sh.echo "Ignoring unknown/disallowed package #{package.inspect}"
+                disallowed << package
               end
+            end
+
+            unless disallowed.empty?
+              sh.echo "Disallowing packages: #{disallowed.join(', ')}", ansi: :red
+              sh.echo 'If you require these packages, please submit them for ' \
+                      'review in a new issue:'
+              sh.echo '    https://github.com/travis-ci/travis-ci/issues/new' \
+                          '?labels[]=apt-whitelist&labels[]=travis-build' \
+                          "&title=APT+whitelist+request+for+#{disallowed.join(',+')}"
             end
 
             unless whitelisted.empty?

--- a/lib/travis/build/addons/apt_packages.rb
+++ b/lib/travis/build/addons/apt_packages.rb
@@ -18,8 +18,11 @@ module Travis
               end
             end
 
-            sh.export 'DEBIAN_FRONTEND', 'noninteractive', echo: true
-            sh.cmd "sudo -E apt-get -yq install #{whitelisted.join(' ')}", echo: true, timing: true
+            unless whitelisted.empty?
+              sh.export 'DEBIAN_FRONTEND', 'noninteractive', echo: true
+              sh.cmd "sudo -E apt-get -yq update", echo: true, timing: true
+              sh.cmd "sudo -E apt-get -yq install #{whitelisted.join(' ')}", echo: true, timing: true
+            end
           end
         end
 

--- a/lib/travis/build/addons/apt_packages.rb
+++ b/lib/travis/build/addons/apt_packages.rb
@@ -14,12 +14,12 @@ module Travis
               if whitelist.include?(package)
                 whitelisted << package
               else
-                sh.echo "Ignoring unknown or disallowed package #{package.inspect}"
+                sh.echo "Ignoring unknown/disallowed package #{package.inspect}"
               end
             end
 
             sh.export 'DEBIAN_FRONTEND', 'noninteractive', echo: true
-            sh.cmd "apt-get -yq install #{whitelisted.join(' ')}"
+            sh.cmd "apt-get -yq install #{whitelisted.join(' ')}", echo: true, timing: true
           end
         end
 

--- a/lib/travis/build/addons/apt_packages.rb
+++ b/lib/travis/build/addons/apt_packages.rb
@@ -26,8 +26,7 @@ module Travis
               sh.echo 'If you require these packages, please submit them for ' \
                       'review in a new issue:'
               sh.echo '    https://github.com/travis-ci/travis-ci/issues/new' \
-                          '?labels[]=apt-whitelist&labels[]=travis-build' \
-                          "&title=APT+whitelist+request+for+#{disallowed.join(',+')}"
+                          "?title=APT+whitelist+request+for+#{disallowed.join(',+')}"
             end
 
             unless whitelisted.empty?

--- a/lib/travis/build/addons/apt_packages.rb
+++ b/lib/travis/build/addons/apt_packages.rb
@@ -21,7 +21,8 @@ module Travis
             unless whitelisted.empty?
               sh.export 'DEBIAN_FRONTEND', 'noninteractive', echo: true
               sh.cmd "sudo -E apt-get -yq update", echo: true, timing: true
-              sh.cmd "sudo -E apt-get -yq install #{whitelisted.join(' ')}", echo: true, timing: true
+              sh.cmd 'sudo -E apt-get -yq --no-install-suggests --no-install-recommends ' \
+                     "install #{whitelisted.join(' ')}", echo: true, timing: true
             end
           end
         end

--- a/lib/travis/build/addons/apt_packages.rb
+++ b/lib/travis/build/addons/apt_packages.rb
@@ -7,7 +7,7 @@ module Travis
         SUPER_USER_SAFE = true
 
         def after_prepare
-          sh.fold 'apt_packages.0' do
+          sh.fold 'apt_packages' do
             sh.echo "Installing APT Packages (BETA)", ansi: :yellow
 
             whitelisted = []

--- a/lib/travis/build/addons/apt_packages.rb
+++ b/lib/travis/build/addons/apt_packages.rb
@@ -1,0 +1,38 @@
+require 'travis/build/addons/base'
+
+module Travis
+  module Build
+    class Addons
+      class AptPackages < Base
+        SUPER_USER_SAFE = true
+
+        def after_prepare
+          sh.echo "Installing APT Packages (BETA)", ansi: :yellow
+          sh.fold 'apt_packages.0' do
+            whitelisted = []
+            config.each do |package|
+              if whitelist.include?(package)
+                whitelisted << package
+              else
+                sh.echo "Ignoring unknown or disallowed package #{package.inspect}"
+              end
+            end
+
+            sh.export 'DEBIAN_FRONTEND', 'noninteractive', echo: true
+            sh.cmd "apt-get -yq install #{whitelisted.join(' ')}"
+          end
+        end
+
+        private
+
+          def config
+            Array(super)
+          end
+
+          def whitelist
+            @whitelist ||= ENV['TRAVIS_BUILD_APT_WHITELIST'].to_s.split(/\s*,\s*/)
+          end
+      end
+    end
+  end
+end

--- a/lib/travis/build/addons/apt_packages.rb
+++ b/lib/travis/build/addons/apt_packages.rb
@@ -19,7 +19,7 @@ module Travis
             end
 
             sh.export 'DEBIAN_FRONTEND', 'noninteractive', echo: true
-            sh.cmd "apt-get -yq install #{whitelisted.join(' ')}", echo: true, timing: true
+            sh.cmd "sudo -E apt-get -yq install #{whitelisted.join(' ')}", echo: true, timing: true
           end
         end
 

--- a/lib/travis/build/addons/apt_packages.rb
+++ b/lib/travis/build/addons/apt_packages.rb
@@ -7,8 +7,9 @@ module Travis
         SUPER_USER_SAFE = true
 
         def after_prepare
-          sh.echo "Installing APT Packages (BETA)", ansi: :yellow
           sh.fold 'apt_packages.0' do
+            sh.echo "Installing APT Packages (BETA)", ansi: :yellow
+
             whitelisted = []
             config.each do |package|
               if whitelist.include?(package)

--- a/spec/build/addons/apt_packages_spec.rb
+++ b/spec/build/addons/apt_packages_spec.rb
@@ -15,7 +15,7 @@ describe Travis::Build::Addons::AptPackages, :sexp do
   end
 
   def apt_get_install_command(*packages)
-    "sudo -E apt-get -yq install #{packages.join(' ')}"
+    "sudo -E apt-get -yq --no-install-suggests --no-install-recommends install #{packages.join(' ')}"
   end
 
   context 'with multiple whitelisted packages' do

--- a/spec/build/addons/apt_packages_spec.rb
+++ b/spec/build/addons/apt_packages_spec.rb
@@ -15,7 +15,7 @@ describe Travis::Build::Addons::AptPackages, :sexp do
   end
 
   def apt_get_install_command(*packages)
-    "apt-get -yq install #{packages.join(' ')}"
+    "sudo -E apt-get -yq install #{packages.join(' ')}"
   end
 
   context 'with multiple whitelisted packages' do

--- a/spec/build/addons/apt_packages_spec.rb
+++ b/spec/build/addons/apt_packages_spec.rb
@@ -1,0 +1,44 @@
+require 'ostruct'
+require 'spec_helper'
+
+describe Travis::Build::Addons::AptPackages, :sexp do
+  let(:script)    { stub('script') }
+  let(:data)      { payload_for(:push, :ruby, config: { addons: { apt_packages: config } }) }
+  let(:sh)        { Travis::Shell::Builder.new }
+  let(:addon)     { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
+  let(:whitelist) { ['curl', 'git'] }
+  subject         { sh.to_sexp }
+
+  before do
+    addon.stubs(:whitelist).returns(whitelist)
+    addon.after_prepare
+  end
+
+  def apt_get_install_command(*packages)
+    "apt-get -yq install #{packages.join(' ')}"
+  end
+
+  context 'with multiple whitelisted packages' do
+    let(:config) { ['git', 'curl'] }
+
+    it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true] }
+  end
+
+  context 'with multiple packages, some whitelisted' do
+    let(:config) { ['git', 'curl', 'darkcoin'] }
+
+    it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true] }
+  end
+
+  context 'with singular whitelisted package' do
+    let(:config) { 'git' }
+
+    it { should include_sexp [:cmd, apt_get_install_command('git'), echo: true, timing: true] }
+  end
+
+  context 'with no whitelisted packages' do
+    let(:config) { nil }
+
+    it { should_not include_sexp [:cmd, apt_get_install_command('git'), echo: true, timing: true] }
+  end
+end


### PR DESCRIPTION
specifically so that anybody running on container-based infrastructure has a formalized method for requesting a given package to be whitelisted.  This is a stop-gap until we have a suitable solution for allowing passwordless sudo within the container-based infrastructure.