### PR TITLE
Switch go version management to gimme

### DIFF
--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -14,7 +14,8 @@ module Travis
 
         def prepare
           super
-          sh.if '! command -v gimme' do
+          # TODO: remove this bit once we're shipping gimme via chef (?)
+          sh.if "! -x '#{HOME_DIR}/bin/gimme' && ! -x '/usr/local/bin/gimme'" do
             sh.cmd "curl -sLo #{HOME_DIR}/bin/gimme '#{gimme_url}'"
             sh.cmd "chmod +x #{HOME_DIR}/bin/gimme"
             sh.export 'PATH', "#{HOME_DIR}/bin:$PATH", retry: false, echo: false

--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -16,7 +16,9 @@ module Travis
           super
           # TODO: remove this bit once we're shipping gimme via chef (?)
           sh.cmd 'unset gvm', echo: false
-          sh.mv "#{HOME_DIR}/.gvm", "#{HOME_DIR}/.gvm.disabled", echo: false
+          sh.if "-d #{HOME_DIR}/.gvm" do
+            sh.mv "#{HOME_DIR}/.gvm", "#{HOME_DIR}/.gvm.disabled", echo: false
+          end
           sh.if "! -x '#{HOME_DIR}/bin/gimme' && ! -x '/usr/local/bin/gimme'" do
             sh.mkdir "#{HOME_DIR}/bin", echo: false
             sh.cmd "curl -sL -o #{HOME_DIR}/bin/gimme '#{gimme_url}'", echo: false

--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -22,6 +22,8 @@ module Travis
             sh.cmd "curl -sL -o #{HOME_DIR}/bin/gimme '#{gimme_url}'", echo: false
             sh.cmd "chmod +x #{HOME_DIR}/bin/gimme", echo: false
             sh.export 'PATH', "#{HOME_DIR}/bin:$PATH", retry: false, echo: false
+            # install bootstrap version so that tip/master/whatever can be used immediately
+            sh.cmd %Q'gimme 1.4.1 >/dev/null 2>&1'
           end
         end
 

--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -36,7 +36,7 @@ module Travis
           super
           sh.cmd %Q'eval "$(gimme #{go_version})"'
 
-          sh.export 'GOPATH', "#{HOME_DIR}/gopath:$GOPATH", echo: true
+          sh.export 'GOPATH', "#{HOME_DIR}/gopath:", echo: true
           sh.export 'PATH', "#{HOME_DIR}/gopath/bin:$PATH", echo: true
 
           sh.mkdir "#{HOME_DIR}/gopath/src/#{data.source_host}/#{data.slug}", recursive: true, assert: false, timing: false
@@ -119,7 +119,7 @@ module Travis
           def gimme_url
             @gimme_url ||= ENV.fetch(
               'TRAVIS_BUILD_GIMME_URL',
-              'https://raw.githubusercontent.com/meatballhat/gimme/v0.2.1/gimme'
+              'https://raw.githubusercontent.com/meatballhat/gimme/v0.2.2/gimme'
             )
           end
       end

--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -16,6 +16,7 @@ module Travis
           super
           # TODO: remove this bit once we're shipping gimme via chef (?)
           sh.if "! -x '#{HOME_DIR}/bin/gimme' && ! -x '/usr/local/bin/gimme'" do
+            sh.mkdir "#{HOME_DIR}/bin"
             sh.cmd "curl -sL -o #{HOME_DIR}/bin/gimme '#{gimme_url}'", echo: true
             sh.cmd "chmod +x #{HOME_DIR}/bin/gimme", echo: true
             sh.export 'PATH', "#{HOME_DIR}/bin:$PATH", retry: false, echo: true

--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -16,9 +16,9 @@ module Travis
           super
           # TODO: remove this bit once we're shipping gimme via chef (?)
           sh.if "! -x '#{HOME_DIR}/bin/gimme' && ! -x '/usr/local/bin/gimme'" do
-            sh.cmd "curl -sLo #{HOME_DIR}/bin/gimme '#{gimme_url}'"
-            sh.cmd "chmod +x #{HOME_DIR}/bin/gimme"
-            sh.export 'PATH', "#{HOME_DIR}/bin:$PATH", retry: false, echo: false
+            sh.cmd "curl -sL -o #{HOME_DIR}/bin/gimme '#{gimme_url}'", echo: true
+            sh.cmd "chmod +x #{HOME_DIR}/bin/gimme", echo: true
+            sh.export 'PATH', "#{HOME_DIR}/bin:$PATH", retry: false, echo: true
           end
         end
 

--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -15,6 +15,8 @@ module Travis
         def prepare
           super
           # TODO: remove this bit once we're shipping gimme via chef (?)
+          sh.cmd 'unset gvm', echo: false
+          sh.mv "#{HOME_DIR}/.gvm", "#{HOME_DIR}/.gvm.disabled", echo: false
           sh.if "! -x '#{HOME_DIR}/bin/gimme' && ! -x '/usr/local/bin/gimme'" do
             sh.mkdir "#{HOME_DIR}/bin"
             sh.cmd "curl -sL -o #{HOME_DIR}/bin/gimme '#{gimme_url}'", echo: true
@@ -32,8 +34,6 @@ module Travis
 
         def setup
           super
-          sh.cmd "gimme #{go_version} | source /dev/stdin", fold: 'gimme.install'
-
           sh.export 'GOPATH', "#{HOME_DIR}/gopath:$GOPATH", echo: true
           sh.export 'PATH', "#{HOME_DIR}/gopath/bin:$PATH", echo: true
 
@@ -42,6 +42,8 @@ module Travis
 
           sh.export "TRAVIS_BUILD_DIR", "#{HOME_DIR}/gopath/src/#{data.source_host}/#{data.slug}"
           sh.cd "#{HOME_DIR}/gopath/src/#{data.source_host}/#{data.slug}", assert: true
+
+          sh.cmd %Q'eval "$(gimme #{go_version})"'
         end
 
         def install

--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -34,6 +34,8 @@ module Travis
 
         def setup
           super
+          sh.cmd %Q'eval "$(gimme #{go_version})"'
+
           sh.export 'GOPATH', "#{HOME_DIR}/gopath:$GOPATH", echo: true
           sh.export 'PATH', "#{HOME_DIR}/gopath/bin:$PATH", echo: true
 
@@ -42,8 +44,6 @@ module Travis
 
           sh.export "TRAVIS_BUILD_DIR", "#{HOME_DIR}/gopath/src/#{data.source_host}/#{data.slug}"
           sh.cd "#{HOME_DIR}/gopath/src/#{data.source_host}/#{data.slug}", assert: true
-
-          sh.cmd %Q'eval "$(gimme #{go_version})"'
         end
 
         def install

--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -18,10 +18,10 @@ module Travis
           sh.cmd 'unset gvm', echo: false
           sh.mv "#{HOME_DIR}/.gvm", "#{HOME_DIR}/.gvm.disabled", echo: false
           sh.if "! -x '#{HOME_DIR}/bin/gimme' && ! -x '/usr/local/bin/gimme'" do
-            sh.mkdir "#{HOME_DIR}/bin"
-            sh.cmd "curl -sL -o #{HOME_DIR}/bin/gimme '#{gimme_url}'", echo: true
-            sh.cmd "chmod +x #{HOME_DIR}/bin/gimme", echo: true
-            sh.export 'PATH', "#{HOME_DIR}/bin:$PATH", retry: false, echo: true
+            sh.mkdir "#{HOME_DIR}/bin", echo: false
+            sh.cmd "curl -sL -o #{HOME_DIR}/bin/gimme '#{gimme_url}'", echo: false
+            sh.cmd "chmod +x #{HOME_DIR}/bin/gimme", echo: false
+            sh.export 'PATH', "#{HOME_DIR}/bin:$PATH", retry: false, echo: false
           end
         end
 

--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -4,27 +4,33 @@ module Travis
       class Go < Script
         DEFAULTS = {
           gobuild_args: '-v',
-          go: '1.3.3'
+          go: '1.4.1'
         }
 
         def export
           super
-          sh.export 'TRAVIS_GO_VERSION', version, echo: false
+          sh.export 'TRAVIS_GO_VERSION', go_version, echo: false
+        end
+
+        def prepare
+          super
+          sh.if '! command -v gimme' do
+            sh.cmd "curl -sLo #{HOME_DIR}/bin/gimme '#{gimme_url}'"
+            sh.cmd "chmod +x #{HOME_DIR}/bin/gimme"
+            sh.export 'PATH', "#{HOME_DIR}/bin:$PATH", retry: false, echo: false
+          end
         end
 
         def announce
           super
-          sh.cmd 'gvm version'
+          sh.cmd 'gimme version'
           sh.cmd 'go version'
           sh.cmd 'go env', fold: 'go.env'
         end
 
         def setup
           super
-          sh.cmd 'gvm get', fold: 'gvm.get'
-          sh.cmd "gvm update && source #{HOME_DIR}/.gvm/scripts/gvm", fold: 'gvm.update'
-          sh.cmd "gvm install #{version} --binary || gvm install #{version}", fold: 'gvm.install'
-          sh.cmd "gvm use #{version}"
+          sh.cmd "gimme #{go_version} | source /dev/stdin", fold: 'gimme.install'
 
           sh.export 'GOPATH', "#{HOME_DIR}/gopath:$GOPATH", echo: true
           sh.export 'PATH', "#{HOME_DIR}/gopath/bin:$PATH", echo: true
@@ -41,7 +47,7 @@ module Travis
             sh.export 'GOPATH', '${TRAVIS_BUILD_DIR}/Godeps/_workspace:$GOPATH', retry: false
             sh.export 'PATH', '${TRAVIS_BUILD_DIR}/Godeps/_workspace/bin:$PATH', retry: false
 
-            if version >= 'go1.1'
+            if go_version >= '1.1'
               sh.if '! -d Godeps/_workspace/src' do
                 sh.cmd "#{go_get_cmd} github.com/tools/godep", echo: true, retry: true, timing: true, assert: true
                 sh.cmd 'godep restore', retry: true, timing: true, assert: true, echo: true
@@ -67,7 +73,7 @@ module Travis
         end
 
         def cache_slug
-          super << '--go-' << config[:go].to_s # TODO should this not be version?
+          super << '--go-' << go_version
         end
 
         private
@@ -76,47 +82,41 @@ module Travis
             '-f GNUmakefile || -f makefile || -f Makefile || -f BSDmakefile'
           end
 
-          def version
-            case version = config[:go].to_s
-            when '1'
-              'go1.3.3'
-            when '1.0'
-              'go1.0.3'
-            when '1.2'
-              'go1.2.2'
-            when '1.3'
-              'go1.3.3'
-            when /^[0-9]\.[0-9\.]+/
-              "go#{version}"
-            else
-              version
-            end
-          end
-
           def gobuild_args
             config[:gobuild_args]
           end
 
           def go_version
-            version = config[:go].to_s
-            case version
+            @go_version ||= normalized_go_version
+          end
+
+          def normalized_go_version
+            v = config[:go].to_s
+            case v
             when '1'
-              'go1.3.3'
+              '1.4.1'
             when '1.0'
-              'go1.0.3'
+              '1.0.3'
             when '1.2'
-              'go1.2.2'
-            when '1.3'
-              'go1.3.3'
-            when /^[0-9]\.[0-9\.]+/
-              "go#{config[:go]}"
+              '1.2.2'
+            when 'go1'
+              v
+            when /^go/
+              v.sub(/^go/, '')
             else
-              config[:go]
+              v
             end
           end
 
           def go_get_cmd
-            version < 'go1.2' ? 'go get' : 'go get -t'
+            go_version < '1.2' ? 'go get' : 'go get -t'
+          end
+
+          def gimme_url
+            @gimme_url ||= ENV.fetch(
+              'TRAVIS_BUILD_GIMME_URL',
+              'https://raw.githubusercontent.com/meatballhat/gimme/v0.2.1/gimme'
+            )
           end
       end
     end

--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -113,7 +113,7 @@ module Travis
           end
 
           def go_get_cmd
-            go_version < '1.2' ? 'go get' : 'go get -t'
+            (go_version < '1.2' || go_version == 'go1') ? 'go get' : 'go get -t'
           end
 
           def gimme_url

--- a/spec/build/script/go_spec.rb
+++ b/spec/build/script/go_spec.rb
@@ -18,24 +18,16 @@ describe Travis::Build::Script::Go, :sexp do
   end
 
   it 'sets TRAVIS_GO_VERSION' do
-    should include_sexp [:export, ['TRAVIS_GO_VERSION', 'go1.3.3']]
-  end
-
-  it 'updates GVM' do
-    should include_sexp [:cmd, 'gvm get', assert: true, echo: true, timing: true]
-  end
-
-  it 'fetches the latest Go code' do
-    should include_sexp [:cmd, 'gvm update && source $HOME/.gvm/scripts/gvm', assert: true, echo: true, timing: true]
+    should include_sexp [:export, ['TRAVIS_GO_VERSION', '1.4.1']]
   end
 
   it 'sets the default go version if not :go config given' do
-    should include_sexp [:cmd, 'gvm use go1.3.3', assert: true, echo: true, timing: true]
+    should include_sexp [:cmd, 'gimme 1.4.1 | source /dev/stdin', assert: true, echo: true, timing: true]
   end
 
   it 'sets the go version from config :go' do
-    data[:config][:go] = 'go1.1'
-    should include_sexp [:cmd, 'gvm use go1.1', assert: true, echo: true, timing: true]
+    data[:config][:go] = 'go1.2'
+    should include_sexp [:cmd, 'gimme 1.2 | source /dev/stdin', assert: true, echo: true, timing: true]
   end
 
   shared_examples 'gopath fix' do
@@ -60,30 +52,30 @@ describe Travis::Build::Script::Go, :sexp do
     it_behaves_like 'gopath fix'
   end
 
-  it 'installs the gvm version' do
+  it 'installs the go version' do
     data[:config][:go] = 'go1.1'
-    should include_sexp [:cmd, 'gvm install go1.1 --binary || gvm install go1.1', assert: true, echo: true, timing: true]
+    should include_sexp [:cmd, 'gimme 1.1 | source /dev/stdin', assert: true, echo: true, timing: true]
   end
 
-  versions = { '1.1' => 'go1.1', '1' => 'go1.3.3', '1.2' => 'go1.2.2', '1.0' => 'go1.0.3', '1.2.2' => 'go1.2.2', '1.0.2' => 'go1.0.2' }
+  versions = { '1' => '1.4.1', '1.0' => '1.0.3', 'go1' => 'go1', 'go1.4.1' => '1.4.1' }
   versions.each do |version_alias, version|
     it "sets version #{version.inspect} for alias #{version_alias.inspect}" do
       data[:config][:go] = version_alias
-      should include_sexp [:cmd, "gvm install #{version} --binary || gvm install #{version}", assert: true, echo: true, timing: true]
+      should include_sexp [:cmd, "gimme #{version} | source /dev/stdin", assert: true, echo: true, timing: true]
     end
   end
 
   it 'passes through arbitrary tag versions' do
     data[:config][:go] = 'release9000'
-    should include_sexp [:cmd, 'gvm install release9000 --binary || gvm install release9000', assert: true, echo: true, timing: true]
+    should include_sexp [:cmd, 'gimme release9000 | source /dev/stdin', assert: true, echo: true, timing: true]
   end
 
   it 'announces go version' do
     should include_sexp [:cmd, 'go version', echo: true]
   end
 
-  it 'announces gvm version' do
-    should include_sexp [:cmd, 'gvm version', echo: true]
+  it 'announces gimme version' do
+    should include_sexp [:cmd, 'gimme version', echo: true]
   end
 
   it 'announces go env' do

--- a/spec/build/script/go_spec.rb
+++ b/spec/build/script/go_spec.rb
@@ -14,7 +14,7 @@ describe Travis::Build::Script::Go, :sexp do
   it_behaves_like 'a build script sexp'
 
   it 'sets GOPATH' do
-    should include_sexp [:export, ['GOPATH', '$HOME/gopath:$GOPATH'], echo: true]
+    should include_sexp [:export, ['GOPATH', '$HOME/gopath:'], echo: true]
   end
 
   it 'sets TRAVIS_GO_VERSION' do
@@ -22,12 +22,12 @@ describe Travis::Build::Script::Go, :sexp do
   end
 
   it 'sets the default go version if not :go config given' do
-    should include_sexp [:cmd, 'gimme 1.4.1 | source /dev/stdin', assert: true, echo: true, timing: true]
+    should include_sexp [:cmd, 'eval "$(gimme 1.4.1)"', assert: true, echo: true, timing: true]
   end
 
   it 'sets the go version from config :go' do
     data[:config][:go] = 'go1.2'
-    should include_sexp [:cmd, 'gimme 1.2 | source /dev/stdin', assert: true, echo: true, timing: true]
+    should include_sexp [:cmd, 'eval "$(gimme 1.2)"', assert: true, echo: true, timing: true]
   end
 
   shared_examples 'gopath fix' do
@@ -54,20 +54,20 @@ describe Travis::Build::Script::Go, :sexp do
 
   it 'installs the go version' do
     data[:config][:go] = 'go1.1'
-    should include_sexp [:cmd, 'gimme 1.1 | source /dev/stdin', assert: true, echo: true, timing: true]
+    should include_sexp [:cmd, 'eval "$(gimme 1.1)"', assert: true, echo: true, timing: true]
   end
 
   versions = { '1' => '1.4.1', '1.0' => '1.0.3', 'go1' => 'go1', 'go1.4.1' => '1.4.1' }
   versions.each do |version_alias, version|
     it "sets version #{version.inspect} for alias #{version_alias.inspect}" do
       data[:config][:go] = version_alias
-      should include_sexp [:cmd, "gimme #{version} | source /dev/stdin", assert: true, echo: true, timing: true]
+      should include_sexp [:cmd, %Q'eval "$(gimme #{version})"', assert: true, echo: true, timing: true]
     end
   end
 
   it 'passes through arbitrary tag versions' do
     data[:config][:go] = 'release9000'
-    should include_sexp [:cmd, 'gimme release9000 | source /dev/stdin', assert: true, echo: true, timing: true]
+    should include_sexp [:cmd, 'eval "$(gimme release9000)"', assert: true, echo: true, timing: true]
   end
 
   it 'announces go version' do


### PR DESCRIPTION
This implementation aims to be independent of build env updates, although once gimme is shipped with the build image(s) we can then remove the presence check + download.  The disabling of gvm was required in order to have the correct go version activated, which I'm guessing will mean we may have to remove gvm entirely from the build env as well.

It's worth noting that the aliasing logic changes with this PR such that point releases such as `1.0` and `1.3` are now left alone rather than being "upgraded" to `1.0.3` and `1.3.3`, respectively.  The reasoning here is that such point releases are legitimate binary releases, whereas version `1.2` will still be "upgraded" to `1.2.2` as there is no `1.2` binary release available (at least in the well-known download locations).

Example build in staging: https://staging.travis-ci.org/travis-repos/go-test-staging/builds/405600