### PR TITLE
Allow perl builds to continue even if switching versions fails

### DIFF
--- a/lib/travis/build/script/perl.rb
+++ b/lib/travis/build/script/perl.rb
@@ -13,7 +13,7 @@ module Travis
 
         def setup
           super
-          sh.cmd "perlbrew use #{version}"
+          sh.cmd "perlbrew use #{version} || true"
         end
 
         def announce

--- a/spec/build/script/perl_spec.rb
+++ b/spec/build/script/perl_spec.rb
@@ -18,17 +18,17 @@ describe Travis::Build::Script::Perl, :sexp do
   end
 
   it 'sets up the perl version' do
-    should include_sexp [:cmd, 'perlbrew use 5.14', echo: true, timing: true, assert: true]
+    should include_sexp [:cmd, 'perlbrew use 5.14 || true', echo: true, timing: true, assert: true]
   end
 
   it 'converts 5.1 to 5.10' do
     data[:config][:perl] = 5.1
-    should include_sexp [:cmd, 'perlbrew use 5.10', echo: true, timing: true, assert: true]
+    should include_sexp [:cmd, 'perlbrew use 5.10 || true', echo: true, timing: true, assert: true]
   end
 
   it 'converts 5.2 to 5.20' do
     data[:config][:perl] = 5.2
-    should include_sexp [:cmd, 'perlbrew use 5.20', echo: true, timing: true, assert: true]
+    should include_sexp [:cmd, 'perlbrew use 5.20 || true', echo: true, timing: true, assert: true]
   end
 
   it 'announces perl --version' do


### PR DESCRIPTION
Up until recently, if you listed a perl version in your build matrix that was not installed, the build would continue running.  This allowed code in the other phases to handle the issue in a more useful way than aborting immediately.  I have [a project](https://github.com/travis-perl/helpers) that is used by many perl projects which relies on this to compile the requested perl version, or sometimes download a pre-built version.

The latest update of the build environment has updated perlbrew, and the `perlbrew use $version` line now exits with an error if the version is not already available.  This has broken a good number of perl projects using my helper scripts.

I know that this is kind of a hack, but until I create an alternate solution, I would like to see the previous behavior restored.