### PR TITLE
Untaint the gimme url

### DIFF
--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -121,10 +121,10 @@ module Travis
           end
 
           def gimme_url
-            @gimme_url ||= ENV.fetch(
+            @gimme_url ||= "#{ENV.fetch(
               'TRAVIS_BUILD_GIMME_URL',
               'https://raw.githubusercontent.com/meatballhat/gimme/v0.2.2/gimme'
-            )
+            )}".untaint
           end
       end
     end


### PR DESCRIPTION
so that it does not cause explosions in builds that use it.