### PR TITLE
Fix OS X Rust Builds

### DIFF
--- a/lib/travis/build/script/rust.rb
+++ b/lib/travis/build/script/rust.rb
@@ -36,6 +36,7 @@ module Travis
 
           sh.cmd 'export PATH="$PATH:$HOME/rust/bin"', assert: false, echo: false
           sh.cmd 'export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$HOME/rust/lib"', assert: false, echo: false
+          sh.cmd 'export DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH:$HOME/rust/lib"', assert: false, echo: false
         end
 
         def announce


### PR DESCRIPTION
This change should allow Rust projects to build on OS X - builds currently fail with the following error:
```
$ rustc --version
dyld: Library not loaded: x86_64-apple-darwin/stage1/lib/rustlib/x86_64-apple-darwin/lib/librustc_driver-4e7c5e5c.dylib
Referenced from: /Users/travis/rust/bin/rustc
Reason: image not found
/Users/travis/build.sh: line 41: 954 Trace/BPT trap: 5 rustc --version
$ cargo --version
Process didn't exit successfully: `rustc -v verbose` (status=5)
--- stderr
dyld: Library not loaded: x86_64-apple-darwin/stage1/lib/rustlib/x86_64-apple-darwin/lib/librustc_driver-4e7c5e5c.dylib
Referenced from: /Users/travis/rust/bin/rustc
Reason: image not found
```