### PR TITLE
Run composer self-update when applicable

### DIFF
--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -20,6 +20,11 @@ module Travis
         def setup
           super
           sh.cmd "phpenv global #{version}", assert: true
+          unless version == '5.2'
+            sh.if '-f composer.json' do
+              sh.cmd 'composer self-update', echo: false
+            end
+          end
         end
 
         def announce

--- a/spec/build/script/php_spec.rb
+++ b/spec/build/script/php_spec.rb
@@ -21,6 +21,14 @@ describe Travis::Build::Script::Php, :sexp do
     should include_sexp [:cmd, 'phpenv global 5.5', echo: true, timing: true, assert: true]
   end
 
+  describe '#setup' do
+    subject { sexp_filter(sexp, [:if, '-f composer.json'])[0] }
+
+    it 'runs composer self-update silently if composer.json exists' do
+      should include_sexp [:cmd, 'composer self-update', assert: true, timing: true]
+    end
+  end
+
   it 'announces php --version' do
     should include_sexp [:cmd, 'php --version', echo: true]
   end


### PR DESCRIPTION
Composer can flag itself "old" after 30 days, and it can
be quite noisy for the user.

Assuming that Composer doesn't break stuff unexpectedly, perhaps
we should guard against such aging.

Fixes https://github.com/travis-ci/travis-ci/issues/3154