### PR TITLE
Attempt to make rust work again

### DIFF
--- a/lib/travis/build/script/rust.rb
+++ b/lib/travis/build/script/rust.rb
@@ -7,11 +7,6 @@ module Travis
           linux: 'https://static.rust-lang.org/dist/rust-%s-x86_64-unknown-linux-gnu.tar.gz'
         }
 
-        CARGO_URLS = {
-          osx:   'https://static.rust-lang.org/cargo-dist/cargo-nightly-x86_64-apple-darwin.tar.gz',
-          linux: 'https://static.rust-lang.org/cargo-dist/cargo-nightly-x86_64-unknown-linux-gnu.tar.gz'
-        }
-
         DEFAULTS = {
           rust: 'nightly',
         }
@@ -25,13 +20,14 @@ module Travis
         def setup
           super
 
-          sh.cmd 'mkdir -p ~/rust', echo: false
+          sh.cmd 'mkdir -p ~/rust-installer', echo: false
           sh.echo ''
 
           sh.fold('rust-download') do
-            sh.echo 'Installing Rust and Cargo', ansi: :yellow
-            sh.cmd "curl -sL #{rust_url} | tar --strip-components=1 -C ~/rust -xzf -"
-            sh.cmd "curl -sL #{cargo_url} | tar --strip-components=1 -C ~/rust -xzf -"
+            sh.echo 'Installing Rust', ansi: :yellow
+            sh.cmd "curl -sL #{rust_url} | tar --strip-components=1 -C ~/rust-installer -xzf -"
+            # Installing docs takes more time and space and we don't need them
+            sh.cmd "sh ~/rust-installer/install.sh --prefix=~/rust --without=rust-docs"
           end
 
           sh.cmd 'export PATH="$PATH:$HOME/rust/bin"', assert: false, echo: false
@@ -64,10 +60,6 @@ module Travis
 
           def rust_url
             RUST_URLS[os] % version.shellescape
-          end
-
-          def cargo_url
-            CARGO_URLS[os] % version.shellescape
           end
       end
     end

--- a/spec/build/script/rust_spec.rb
+++ b/spec/build/script/rust_spec.rb
@@ -17,8 +17,16 @@ describe Travis::Build::Script::Rust, :sexp do
     should include_sexp [:cmd, %r(curl .*dist/rust-nightly.*\.tar\.gz), assert: true, echo: true, timing: true]
   end
 
-  it 'downloads and installs Cargo' do
-    should include_sexp [:cmd, %r(curl .*cargo-dist/cargo-nightly.*\.tar\.gz), assert: true, echo: true, timing: true]
+  it 'announces rust version' do
+    should include_sexp [:cmd, 'rustc --version', echo: true]
+  end
+
+  it 'announces cargo version' do
+    should include_sexp [:cmd, 'cargo --version', echo: true]
+  end
+
+  it 'runs cargo test' do
+    should include_sexp [:cmd, 'cargo test --verbose', echo: true, timing: true]
   end
 
   it 'runs cargo build' do


### PR DESCRIPTION
The format of the rust installer changed recently and `language: rust` is now broken. This is my *attempt* to fix the problem by running the installer to place the Rust compiler in the ~/rust directory.

I do not know if it works correctly. The existing test case does not seem to confirm that it creates a working compiler and I don't understand Ruby enough to know how to add such a test case.