### PR TITLE
Add basic version switching for mono. Fixes travis-ci/travis-ci#3018.

### DIFF
--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -8,8 +8,10 @@ module Travis
     class Script
       class Csharp < Script
         DEFAULTS = {
-          csharp: 'mono',
+          mono: 'latest',
         }
+
+        MONO_VERSION_REGEXP = /^(\d{1})\.(\d{1,2})\.\d{1,2}$/
 
         def configure
           super
@@ -20,16 +22,33 @@ module Travis
 
 
           sh.fold('mono-install') do
-            if config[:csharp] == 'mono'
+            if mono_version_valid?
               sh.echo 'Installing Mono', ansi: :yellow
 
-              sh.cmd 'sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF', echo: false
-              sh.cmd "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian wheezy main' >> /etc/apt/sources.list.d/mono-xamarin.list\"", echo: false
-              sh.cmd "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian wheezy-libtiff-compat main' >> /etc/apt/sources.list.d/mono-xamarin.list\"", echo: false
-              sh.cmd 'sudo apt-get update -qq', timing: true
-              sh.cmd 'sudo apt-get install -qq mono-complete referenceassemblies-pcl nuget mono-vbnc fsharp', timing: true
+              if is_mono_2_10_8
+                sh.cmd 'sudo apt-get install -qq mono-complete mono-vbnc', timing: true, assert: true
+              elsif is_mono_3_2_8
+                sh.cmd 'sudo apt-add-repository ppa:directhex/ppa -y', assert: true # Official ppa of the mono debian maintainer
+                sh.cmd 'sudo apt-get update -qq', timing: true, assert: true
+                sh.cmd 'sudo apt-get install -qq mono-complete mono-vbnc fsharp', timing: true, assert: true
+              else
+                sh.cmd 'sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF', echo: false, assert: true
+                sh.cmd "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian #{mono_repo} main' >> /etc/apt/sources.list.d/mono-xamarin.list\"", echo: false, assert: true
+                sh.cmd "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian wheezy-libtiff-compat main' >> /etc/apt/sources.list.d/mono-xamarin.list\"", echo: false, assert: true
+                sh.cmd 'sudo apt-get update -qq', timing: true, assert: true
+                sh.cmd "sudo apt-get install -qq mono-complete mono-vbnc fsharp nuget #{'referenceassemblies-pcl' if !is_mono_3_8_0}", timing: true, assert: true
+                                                                                      # PCL Assemblies only supported on mono 3.10 and greater
+              end
+
               sh.cmd 'mozroots --import --sync --quiet', timing: true
             end
+          end
+        end
+
+        def setup
+          unless mono_version_valid?
+            sh.echo "\"#{config[:mono]}\" is not a valid version of mono.", ansi: :red
+            sh.cmd 'false', echo: false, timing: false
           end
         end
 
@@ -48,16 +67,46 @@ module Travis
         end
 
         def install
-          sh.cmd "nuget restore #{config[:solution]}", retry: true if config[:solution]
+          sh.cmd "nuget restore #{config[:solution]}", retry: true if config[:solution] && !is_mono_2_10_8 && !is_mono_3_2_8
         end
 
         def script
           if config[:solution]
-            sh.cmd "xbuild /p:Configuration=Release #{config[:solution]}", timing: true if config[:solution]
+            sh.cmd "xbuild /p:Configuration=Release #{config[:solution]}", timing: true
           else
             sh.echo 'No solution or script defined, exiting', ansi: :red
             sh.cmd 'false', echo: false, timing: false
           end
+        end
+
+        def mono_repo
+          if config[:mono] == 'latest'
+            'wheezy'
+          else
+            'wheezy/snapshots/' << config[:mono]
+          end
+        end
+
+        def mono_version_valid?
+          return true if config[:mono] == 'latest'
+          return false unless MONO_VERSION_REGEXP === config[:mono]
+
+          return false if MONO_VERSION_REGEXP.match(config[:mono])[1] == '2' && !is_mono_2_10_8
+          return false if MONO_VERSION_REGEXP.match(config[:mono])[1].to_i < 2
+
+          true
+        end
+
+        def is_mono_2_10_8
+          config[:mono] == '2.10.8'
+        end
+
+        def is_mono_3_2_8
+          config[:mono] == '3.2.8'
+        end
+
+        def is_mono_3_8_0
+          config[:mono] == '3.8.0'
         end
       end
     end


### PR DESCRIPTION
Can be used like this:

```
language: csharp
mono:
  - latest
  - "3.12.0"
```

Please scrutinize this regexp ` /^(\d{1}\.)\d{1,2}\.\d{1,2}$/` very carefully, because I'm no regexp master and I don't want to introduce a command injection vulnerability.