### PR TITLE
Better handling for R package build/test failures.

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -129,7 +129,8 @@ module Travis
         def script
           # Build the package
           sh.echo "Building with: R CMD build ${R_BUILD_ARGS}"
-          sh.cmd "R CMD build #{config[:r_build_args]} ."
+          sh.cmd "R CMD build #{config[:r_build_args]} .",
+                 assert: true
           tarball_script = [
             'pkg <- devtools::as.package(".")',
             'cat(paste0(pkg$package, "_", pkg$version, ".tar.gz"))',
@@ -139,7 +140,8 @@ module Travis
           # Test the package
           sh.echo 'Testing with: R CMD check "${PKG_TARBALL}" ' +
                   "#{config[:r_check_args]}"
-          sh.cmd "R CMD check \"${PKG_TARBALL}\" #{config[:r_check_args]}"
+          sh.cmd "R CMD check \"${PKG_TARBALL}\" #{config[:r_check_args]}",
+                 assert: true
 
           # Turn warnings into errors, if requested.
           if config[:warnings_are_errors]
@@ -163,7 +165,7 @@ module Travis
               ' q(status = 1, save = "no");',
               '}',
             ].join(' ')
-            sh.cmd "Rscript -e '#{revdep_script}'"
+            sh.cmd "Rscript -e '#{revdep_script}'", assert: true
           end
 
         end

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -21,6 +21,13 @@ describe Travis::Build::Script::R, :sexp do
                          assert: true, echo: true, timing: true]
   end
 
+  it 'fails on package build and test failures' do
+    should include_sexp [:cmd, /.*R CMD build.*/,
+                         assert: true, echo: true, timing: true]
+    should include_sexp [:cmd, /.*R CMD check.*/,
+                         assert: true, echo: true, timing: true]
+  end
+
   describe 'bioc configuration is optional' do
     it 'does not install bioc if not required' do
       should_not include_sexp [:cmd, /.*biocLite.*/,


### PR DESCRIPTION
This change forces any failures in `R CMD build` or `R CMD check` to become
failures for the entire Travis build.

Fixes travis-ci/travis-ci#3305.

PTAL @BanzaiMan 