### PR TITLE
Fix an invalid OS name (mac instead of osx) in some case statements.

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -335,7 +335,7 @@ module Travis
             sh.cmd 'sudo apt-get install --no-install-recommends ' +
                    "#{latex_packages.join(' ')}",
                    retry: true
-          when 'mac'
+          when 'osx'
             # We use mactex-basic due to disk space constraints.
             mactex = 'mactex-basic.pkg'
             # TODO(craigcitro): Confirm that this will route us to the
@@ -358,7 +358,7 @@ module Travis
           case config[:os]
           when 'linux'
             os_path = 'linux/debian/x86_64'
-          when 'mac'
+          when 'osx'
             os_path = 'mac'
           end
 


### PR DESCRIPTION
PTAL @BanzaiMan 

(Hiro, I keep sending all these PRs your way because you merged the original R support -- if you want me to spread it around a bit, just let me know. :smile: )