### PR TITLE
appliances: make fix_ forms able to disable appliances

### DIFF
--- a/lib/travis/build/appliances/fix_etc_hosts.rb
+++ b/lib/travis/build/appliances/fix_etc_hosts.rb
@@ -9,7 +9,11 @@ module Travis
         end
 
         def apply?
-          data[:fix_etc_hosts] || !data[:skip_etc_hosts_fix]
+          if data.key?(:fix_etc_hosts)
+            data[:fix_etc_hosts]
+          else
+            !data[:skip_etc_hosts_fix]
+          end
         end
       end
     end

--- a/lib/travis/build/appliances/fix_resolv_conf.rb
+++ b/lib/travis/build/appliances/fix_resolv_conf.rb
@@ -23,7 +23,11 @@ nameserver 208.67.220.220
         end
 
         def apply?
-          data[:fix_resolv_conf] || !data[:skip_resolv_updates]
+          if data.key?(:fix_resolv_conf)
+            data[:fix_resolv_conf]
+          else
+            !data[:skip_resolv_updates]
+          end
         end
       end
     end

--- a/lib/travis/build/data.rb
+++ b/lib/travis/build/data.rb
@@ -30,6 +30,10 @@ module Travis
         data[key]
       end
 
+      def key?(key)
+        data.key?(key)
+      end
+
       def language
         config[:language]
       end

--- a/spec/build/script/shared/appliances/fix_etc_hosts.rb
+++ b/spec/build/script/shared/appliances/fix_etc_hosts.rb
@@ -9,4 +9,9 @@ shared_examples_for 'fix etc/hosts' do
     data[:skip_etc_hosts_fix] = true
     should_not include_sexp [:raw, fix_etc_hosts]
   end
+
+  it 'skips adding an entry to /etc/hosts for localhost if fix_etc_hosts=false' do
+    data[:fix_etc_hosts] = false
+    should_not include_sexp [:raw, fix_etc_hosts]
+  end
 end

--- a/spec/build/script/shared/appliances/fix_resolv_conf.rb
+++ b/spec/build/script/shared/appliances/fix_resolv_conf.rb
@@ -18,4 +18,9 @@ nameserver 208.67.220.220
     data[:skip_resolv_updates] = true
     should_not include_sexp [:raw, fix_resolv_conf]
   end
+
+  it 'skips fixing the DNS entries in /etc/resolv.conf if fix_resolv_conf=false' do
+    data[:fix_resolv_conf] = false
+    should_not include_sexp [:raw, fix_resolv_conf]
+  end
 end


### PR DESCRIPTION
Previously, if you wanted to skip an appliance, you'd have to pass the `skip_` form.

I'd like to switch the Go worker to only use the `fix_` forms of the attributes, but that requires this change.