### PR TITLE
Edit /etc/hosts in situ in hosts addon

### DIFF
--- a/lib/travis/build/addons/hosts.rb
+++ b/lib/travis/build/addons/hosts.rb
@@ -6,11 +6,12 @@ module Travis
     class Addons
       class Hosts < Base
         SUPER_USER_SAFE = true
+        HOSTS_FILE = '/etc/hosts'
 
         def after_prepare
           sh.fold 'hosts' do
-            sh.cmd "sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 '#{hosts}'/' -i'.bak' /etc/hosts"
-            sh.cmd "sudo sed -e 's/^\\(::1.*\\)$/\\1 '#{hosts}'/' -i'.bak' /etc/hosts"
+            sh.cmd "cat #{HOSTS_FILE} | sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 #{hosts}/' | sudo tee #{HOSTS_FILE} > /dev/null"
+            sh.cmd "cat #{HOSTS_FILE} | sed -e 's/^\\(::1.*\\)$/\\1 #{hosts}/'             | sudo tee #{HOSTS_FILE} > /dev/null"
           end
         end
 

--- a/spec/build/addons/hosts_spec.rb
+++ b/spec/build/addons/hosts_spec.rb
@@ -17,7 +17,7 @@ describe Travis::Build::Addons::Hosts, :sexp do
 
   # it { should include_sexp [:cmd, "sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 'one.local\\ two.local'/' -i'.bak' /etc/hosts", sudo: true] }
   # it { should include_sexp [:cmd, "sed -e 's/^\\(::1.*\\)$/\\1 'one.local\\ two.local'/' -i'.bak' /etc/hosts", sudo: true] }
-  it { should include_sexp [:cmd, "sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 'one.local\\ two.local'/' -i'.bak' /etc/hosts"] }
-  it { should include_sexp [:cmd, "sudo sed -e 's/^\\(::1.*\\)$/\\1 'one.local\\ two.local'/' -i'.bak' /etc/hosts"] }
+  it { should include_sexp [:cmd, "cat /etc/hosts | sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 one.local\\ two.local/' | sudo tee /etc/hosts > /dev/null"] }
+  it { should include_sexp [:cmd, "cat /etc/hosts | sed -e 's/^\\(::1.*\\)$/\\1 one.local\\ two.local/'             | sudo tee /etc/hosts > /dev/null"] }
 end
 


### PR DESCRIPTION
Docker does not allow `/etc/hosts` to be moved, so we devise a
way to edit the content of the file in situ.

This fixes travis-ci/travis-ci#2969.

It's been tested on staging: https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/428811#L95