### PR TITLE
Add verbose output option to fetching casher code

### DIFF
--- a/lib/travis/build/script/shared/directory_cache/s3.rb
+++ b/lib/travis/build/script/shared/directory_cache/s3.rb
@@ -57,7 +57,7 @@ module Travis
             sh.export 'CASHER_DIR', '$HOME/.casher'
 
             sh.mkdir '$CASHER_DIR/bin', echo: false, recursive: true
-            sh.cmd "curl #{casher_url} -L -o #{BIN_PATH} -s --fail", retry: true, echo: 'Installing caching utilities'
+            sh.cmd "curl #{casher_url} #{debug_flags} -L -o #{BIN_PATH} -s --fail", retry: true, echo: 'Installing caching utilities'
             sh.raw "[ $? -ne 0 ] && echo 'Failed to fetch casher from GitHub, disabling cache.' && echo > #{BIN_PATH}"
 
             sh.if "-f #{BIN_PATH}" do
@@ -168,6 +168,10 @@ module Travis
               else
                 data.cache?(:edge) ? 'master' : 'production'
               end
+            end
+
+            def debug_flags
+              '-v' if data.cache[:code_fetch_verbose]
             end
         end
       end

--- a/spec/build/script/directory_cache/s3_spec.rb
+++ b/spec/build/script/directory_cache/s3_spec.rb
@@ -47,7 +47,7 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
     before { cache.install }
 
     let(:url) { "https://raw.githubusercontent.com/travis-ci/casher/#{branch}/bin/casher" }
-    let(:cmd) { [:cmd,  "curl #{url} -L -o $CASHER_DIR/bin/casher -s --fail", retry: true, display: 'Installing caching utilities'] }
+    let(:cmd) { [:cmd,  "curl #{url}  -L -o $CASHER_DIR/bin/casher -s --fail", retry: true, display: 'Installing caching utilities'] }
 
     describe 'uses casher production in default mode' do
       let(:branch) { 'production' }
@@ -66,6 +66,12 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
     describe 'passing a casher branch' do
       let(:branch) { 'foo' }
       let(:config) { { cache: { branch: branch } } }
+      it { should include_sexp :cmd }
+    end
+
+    describe 'using debug flag' do
+      let(:config) { { cache: { code_fetch_verbose: true } } }
+      let(:cmd) { [:cmd,  "curl #{url} -v -L -o $CASHER_DIR/bin/casher -s --fail", retry: true, display: 'Installing caching utilities'] }
       it { should include_sexp :cmd }
     end
   end


### PR DESCRIPTION
There have been reports to indicate that sometimes we have
difficulty fetching the caching utility code.

This commit enables

```yaml
cache:
  code_fetch_verbose: true
```
to pass '-v' to 'curl' when we fetch the casher code.