### PR TITLE
Make the warning message for C# less dramatic

### DIFF
--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -17,7 +17,7 @@ module Travis
           super
 
           sh.echo ''
-          sh.echo 'BETA Warning: Travis-CI C# support is in beta and may be changed or removed at any time.', ansi: :red
+          sh.echo 'C# support for Travis-CI is community maintained.', ansi: :red
           sh.echo 'Please open any issues at https://github.com/travis-ci/travis-ci/issues/new and cc @joshua-anderson @akoeplinger @nterry', ansi: :red
 
 


### PR DESCRIPTION
I got some feedback that "may be removed at any time" is pretty off-putting and makes people hesitant to switch to `language: csharp`.

We don't have plans to drop this, so let's make this message a bit more welcoming.

/cc @Joshua-Anderson @nterry

PS: afaik we copied that text from one of the other community languages initially, but both [Julia](https://github.com/travis-ci/travis-build/blob/d1c3be0b6aec5989872f9c534185585108125d0d/lib/travis/build/script/julia.rb#L27) and [D](https://github.com/travis-ci/travis-build/blob/d1c3be0b6aec5989872f9c534185585108125d0d/lib/travis/build/script/d.rb#L26) have more moderate messages now so we should do the same :)