### PR TITLE
Enable code coverage data and colored output for Julia testing

### DIFF
--- a/lib/travis/build/script/julia.rb
+++ b/lib/travis/build/script/julia.rb
@@ -67,7 +67,8 @@ module Travis
             sh.cmd "julia -e 'Pkg.clone(pwd())'"
             sh.cmd 'julia -e "Pkg.build(\"${JL_PKG}\")"'
             sh.if '-f test/runtests.jl' do
-              sh.cmd 'julia --check-bounds=yes -e "Pkg.test(\"${JL_PKG}\")"'
+              sh.cmd 'julia --check-bounds=yes ' \
+                '-e "Pkg.test(\"${JL_PKG}\", coverage=true)"'
             end
           end
         end

--- a/lib/travis/build/script/julia.rb
+++ b/lib/travis/build/script/julia.rb
@@ -64,10 +64,10 @@ module Travis
             sh.if '-a .git/shallow' do
               sh.cmd 'git fetch --unshallow'
             end
-            sh.cmd "julia -e 'Pkg.clone(pwd())'"
-            sh.cmd 'julia -e "Pkg.build(\"${JL_PKG}\")"'
+            sh.cmd "julia --color=yes -e 'Pkg.clone(pwd())'"
+            sh.cmd 'julia --color=yes -e "Pkg.build(\"${JL_PKG}\")"'
             sh.if '-f test/runtests.jl' do
-              sh.cmd 'julia --check-bounds=yes ' \
+              sh.cmd 'julia --color=yes --check-bounds=yes ' \
                 '-e "Pkg.test(\"${JL_PKG}\", coverage=true)"'
             end
           end


### PR DESCRIPTION
Running a Julia package's tests with `coverage=true` generates a set of `.jl.cov` files, which can be uploaded to a service like Coveralls using a separate `after_success` snippet. This is being done pretty commonly across Julia packages, and forcing them all to manually re-create the default test script contents plus this small change.

Additionally, colored output has been requested here https://github.com/JuliaCI/TravisTest.jl/issues/1