### PR TITLE
C#: run apt-get update for Mono 2.10.8 as well

### DIFF
--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -26,6 +26,7 @@ module Travis
               sh.echo 'Installing Mono', ansi: :yellow
 
               if is_mono_2_10_8
+                sh.cmd 'sudo apt-get update -qq', timing: true, assert: true
                 sh.cmd 'sudo apt-get install -qq mono-complete mono-vbnc', timing: true, assert: true
               elsif is_mono_3_2_8
                 sh.cmd 'sudo apt-add-repository ppa:directhex/ppa -y', assert: true # Official ppa of the mono debian maintainer


### PR DESCRIPTION
This fixes a recent error that occurred because the package versions changed on Ubuntu's side and the version embedded in the image isn't found anymore.