### PR TITLE
Dart Support: Use HTTPS Download URLs

### DIFF
--- a/lib/travis/build/script/dart.rb
+++ b/lib/travis/build/script/dart.rb
@@ -106,7 +106,7 @@ module Travis
             if not ["stable", "dev"].include?(config[:dart])
               sh.failure "Only 'stable' and 'dev' can be used as dart version for now"
             end
-            "http://storage.googleapis.com/dart-archive/channels/#{config[:dart]}/release/latest"
+            "https://storage.googleapis.com/dart-archive/channels/#{config[:dart]}/release/latest"
           end
 
           def with_content_shell


### PR DESCRIPTION
- Use HTTPS Download URLs