### PR TITLE
Improvements to Haxe support

### DIFF
--- a/lib/travis/build/script/haxe.rb
+++ b/lib/travis/build/script/haxe.rb
@@ -95,6 +95,8 @@ module Travis
             config[:hxml].each do |hxml|
               sh.cmd "haxe \"#{hxml}\""
             end
+          else
+            sh.failure 'No "hxml:" and "script:" is specified. Please specify at least one of them in your .travis.yml to run tests.'
           end
         end
 

--- a/lib/travis/build/script/haxe.rb
+++ b/lib/travis/build/script/haxe.rb
@@ -26,8 +26,8 @@ module Travis
 
           case config[:os]
           when 'linux'
-            sh.cmd 'sudo apt-get update -qq'
-            sh.cmd 'sudo apt-get install libgc1c2 -qq' # required by neko
+            sh.cmd 'sudo apt-get update -qq', retry: true
+            sh.cmd 'sudo apt-get install libgc1c2 -qq', retry: true # required by neko
           when 'osx'
             # pass
           end

--- a/lib/travis/build/script/haxe.rb
+++ b/lib/travis/build/script/haxe.rb
@@ -85,7 +85,7 @@ module Travis
         def install
           if config[:hxml]
             config[:hxml].each do |hxml|
-              sh.cmd "yes | haxelib install '#{hxml}'", retry: true
+              sh.cmd "yes | haxelib install \"#{hxml}\"", retry: true
             end
           end
         end
@@ -93,7 +93,7 @@ module Travis
         def script
           if config[:hxml]
             config[:hxml].each do |hxml|
-              sh.cmd "haxe '#{hxml}'"
+              sh.cmd "haxe \"#{hxml}\""
             end
           end
         end


### PR DESCRIPTION
 * `retry: true` for each `apt-get` cmd.
 * Use double quotes for hxmls when running the haxe compiler. Such that ppl can use env variables for the `hxml:` keys in yaml.
 * Fail the build if no test can be run, similar to the python builds.