### PR TITLE
Allow apt.* addons to accept nested arrays

### DIFF
--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -132,11 +132,11 @@ module Travis
           end
 
           def config_sources
-            Array(config[:sources])
+            @config_sources ||= Array(config[:sources]).flatten.compact
           end
 
           def config_packages
-            Array(config[:packages])
+            @config_packages ||= Array(config[:packages]).flatten.compact
           end
 
           def package_whitelist

--- a/spec/build/addons/apt_spec.rb
+++ b/spec/build/addons/apt_spec.rb
@@ -121,6 +121,12 @@ describe Travis::Build::Addons::Apt, :sexp do
 
       it { should_not include_sexp [:cmd, apt_get_install_command('git'), echo: true, timing: true] }
     end
+
+    context 'with nested arrays of packages' do
+      let(:config) { { packages: [%w(git curl)] } }
+
+      it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true] }
+    end
   end
 
   context 'with sources' do


### PR DESCRIPTION
so that yaml references may be used for more complex configurations.

Closes travis-ci/travis-ci#3505