### PR TITLE
Escape all values from users

### DIFF
--- a/lib/travis/build/env/config.rb
+++ b/lib/travis/build/env/config.rb
@@ -17,7 +17,8 @@ module Travis
           def env_vars
             vars = Array(config[:global_env]) + Array(config[:env])
             vars = vars.compact.reject(&:empty?)
-            vars.flat_map { |var| Var.parse(var) }
+            vars = vars.flat_map { |var| Var.parse(var) }.
+              map { |var| var[1] = var[1].shellescape; var }
           end
       end
     end

--- a/lib/travis/build/env/settings.rb
+++ b/lib/travis/build/env/settings.rb
@@ -16,7 +16,7 @@ module Travis
 
           def env_vars
             data.env_vars.map do |var|
-              [var[:name], var[:value], secure: !var[:public]]
+              [var[:name], var[:value].shellescape, secure: !var[:public]]
             end
           end
       end

--- a/spec/build/env_spec.rb
+++ b/spec/build/env_spec.rb
@@ -4,13 +4,13 @@ describe Travis::Build::Env do
   let(:payload) do
     {
       pull_request: '100',
-      config: { env: ['FOO=foo', 'SECURE BAR=bar'] },
+      config: { env: ['FOO=foo', 'SECURE BAR=bar\\'] },
       build: { id: '1', number: '1' },
       job: { id: '1', number: '1.1', branch: 'foo-(dev)', commit: '313f61b', commit_range: '313f61b..313f61a', commit_message: 'the commit message', os: 'linux' },
       repository: { slug: 'travis-ci/travis-ci' },
       env_vars: [
         { name: 'BAM', value: 'bam', public: true },
-        { name: 'BAZ', value: 'baz', public: false },
+        { name: 'BAZ', value: 'baz\\', public: false },
       ]
     }
   end
@@ -34,6 +34,10 @@ describe Travis::Build::Env do
 
     describe 'for secure env jobs' do
       before { payload[:job][:secure_env_enabled] = true }
+
+      it 'escapes values' do
+        expect(vars.last.value).to eq("bar\\\\")
+      end
 
       it 'includes secure vars' do
         expect(keys).to include('BAR')
@@ -66,6 +70,10 @@ describe Travis::Build::Env do
 
     describe 'for secure env jobs' do
       before { payload[:job][:secure_env_enabled] = true }
+
+      it 'escapes values' do
+        expect(vars.last.value).to eq("baz\\\\")
+      end
 
       it 'includes secure vars' do
         expect(keys).to include('BAZ')


### PR DESCRIPTION
From commit message:

```
Before this commit we were not escaping env vars values from users. A
big drawback of that is that our secure env vars are not "secure by
default", becasue if an unaware user sets a password with special
characters, like foo&\, bash will throw an error possibly outputting the
password.

This commit escapes all of the env values with `shellescape`.
```

Additionally, I think that we will need to somehow announce this change if we decide to merge it. Some people may already escape their env vars, which will most likely going to break stuff for them.

/cc @svenfuchs
