### PR TITLE
R-lang: Fail, but not abort the build if R CMD check fails

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -143,7 +143,13 @@ module Travis
           sh.echo 'Testing with: R CMD check "${PKG_TARBALL}" ' +
                   "#{config[:r_check_args]}"
           sh.cmd "R CMD check \"${PKG_TARBALL}\" #{config[:r_check_args]}",
-                 assert: true
+                 assert: false
+          # Build fails if R CMD check fails
+          sh.if '$? -neq 0' do
+            sh.echo 'R CMD check failed, dumping logs'
+            dump_logs
+            sh.failure 'R CMD check failed'
+          end
 
           # Turn warnings into errors, if requested.
           if config[:warnings_are_errors]
@@ -170,11 +176,6 @@ module Travis
             sh.cmd "Rscript -e '#{revdep_script}'", assert: true
           end
 
-        end
-
-        def after_failure
-          dump_logs
-          super
         end
 
         private

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -25,7 +25,7 @@ describe Travis::Build::Script::R, :sexp do
     should include_sexp [:cmd, /.*R CMD build.*/,
                          assert: true, echo: true, timing: true]
     should include_sexp [:cmd, /.*R CMD check.*/,
-                         assert: true, echo: true, timing: true]
+                         echo: true, timing: true]
   end
 
   describe 'bioc configuration is optional' do


### PR DESCRIPTION
Previously failing `R CMD check` resulted in the entire travis build
aborting, which prevented any `after_failure` commands to be executed.

This change will automatically dump the check log files if the check
fails and will also fail rather than abort the build, so `after_failure`
commands will still occur.

Fixes travis-ci#3312