### PR TITLE
Use rustup.sh for downloading rust toolchain

### DIFF
--- a/lib/travis/build/script/rust.rb
+++ b/lib/travis/build/script/rust.rb
@@ -2,10 +2,7 @@ module Travis
   module Build
     class Script
       class Rust < Script
-        RUST_URLS = {
-          osx:   'https://static.rust-lang.org/dist/rust-%s-x86_64-apple-darwin.tar.gz',
-          linux: 'https://static.rust-lang.org/dist/rust-%s-x86_64-unknown-linux-gnu.tar.gz'
-        }
+        RUST_RUSTUP = 'https://static.rust-lang.org/rustup.sh'
 
         DEFAULTS = {
           rust: 'nightly',
@@ -25,9 +22,8 @@ module Travis
 
           sh.fold('rust-download') do
             sh.echo 'Installing Rust', ansi: :yellow
-            sh.cmd "curl -sL #{rust_url} | tar --strip-components=1 -C ~/rust-installer -xzf -"
             # Installing docs takes more time and space and we don't need them
-            sh.cmd "sh ~/rust-installer/install.sh --prefix=~/rust --without=rust-docs"
+            sh.cmd ("curl -sL #{RUST_RUSTUP} | sh --prefix=~/rust --spec=%s --without=rust-docs" % version.shellescape)
           end
 
           sh.cmd 'export PATH="$PATH:$HOME/rust/bin"', assert: false, echo: false
@@ -52,14 +48,6 @@ module Travis
 
           def version
             config[:rust].to_s
-          end
-
-          def os
-            config[:os] == 'osx' ? :osx : :linux
-          end
-
-          def rust_url
-            RUST_URLS[os] % version.shellescape
           end
       end
     end

--- a/lib/travis/build/script/rust.rb
+++ b/lib/travis/build/script/rust.rb
@@ -22,8 +22,8 @@ module Travis
 
           sh.fold('rust-download') do
             sh.echo 'Installing Rust', ansi: :yellow
-            # Installing docs takes more time and space and we don't need them
-            sh.cmd ("curl -sL #{RUST_RUSTUP} | sh --prefix=~/rust --spec=%s --without=rust-docs" % version.shellescape)
+            sh.cmd "curl -sL #{RUST_RUSTUP} -o ~/rust-installer/rustup.sh"
+            sh.cmd "sh ~/rust-installer/rustup.sh #{rustup_args}"
           end
 
           sh.cmd 'export PATH="$PATH:$HOME/rust/bin"', assert: false, echo: false
@@ -48,6 +48,10 @@ module Travis
 
           def version
             config[:rust].to_s
+          end
+
+          def rustup_args
+            "--prefix=~/rust --spec=%s" % version.shellescape
           end
       end
     end

--- a/spec/build/script/rust_spec.rb
+++ b/spec/build/script/rust_spec.rb
@@ -14,7 +14,7 @@ describe Travis::Build::Script::Rust, :sexp do
   it_behaves_like 'a build script sexp'
 
   it 'downloads and installs Rust' do
-    should include_sexp [:cmd, %r(curl .*dist/rust-nightly.*\.tar\.gz), assert: true, echo: true, timing: true]
+    should include_sexp [:cmd, %r(curl .*rustup.sh), assert: true, echo: true, timing: true]
   end
 
   it 'announces rust version' do


### PR DESCRIPTION
Using the official `rustup.sh` script, we get a more versatile download.

Using this, a  branch such as `beta` is also a supported version for rust. Previously you had to use the explicit version `1.0.0-beta.2`.

All versions previously supported should still work aswell.