### PR TITLE
Silence rustup output

### DIFF
--- a/lib/travis/build/script/rust.rb
+++ b/lib/travis/build/script/rust.rb
@@ -23,7 +23,9 @@ module Travis
           sh.fold('rust-download') do
             sh.echo 'Installing Rust', ansi: :yellow
             sh.cmd "curl -sL #{RUST_RUSTUP} -o ~/rust-installer/rustup.sh"
-            sh.cmd "sh ~/rust-installer/rustup.sh #{rustup_args}"
+            # We silence rustup.sh for now, as it has a very verbose progress bar
+            sh.echo 'Running rustup.sh'
+            sh.cmd "sh ~/rust-installer/rustup.sh #{rustup_args}", echo: false
           end
 
           sh.cmd 'export PATH="$PATH:$HOME/rust/bin"', assert: false, echo: false


### PR DESCRIPTION
The current rustup.sh is very verbose in its progress meter.
Today this caused the following error: `The log length has exceeded the limit of 4 Megabytes (this usually means that test suite is raising the same exception over and over).`.

I already filed the issue rust-lang/rustup#10, but thought that this would be a good fix in the meantime.


