### PR TITLE
Set MYSQL_HOST env var to use TCP instead

### DIFF
--- a/lib/travis/build/appliances/restart_mysql.rb
+++ b/lib/travis/build/appliances/restart_mysql.rb
@@ -6,6 +6,7 @@ module Travis
       class RestartMysql < Base
         def apply
           sh.cmd 'test -S /var/run/mysqld/mysqld.sock || sudo service mysql restart'
+          sh.export 'MYSQL_HOST', '127.0.0.1', echo: false
         end
       end
     end

--- a/spec/build/script_spec.rb
+++ b/spec/build/script_spec.rb
@@ -37,6 +37,10 @@ describe Travis::Build::Script, :sexp do
     should include_sexp [:cmd, 'test -S /var/run/mysqld/mysqld.sock || sudo service mysql restart']
   end
 
+  it 'sets MYSQL_HOST' do
+    should include_sexp [:export, ['MYSQL_HOST', '127.0.0.1']]
+  end
+
   it 'disables sudo' do
     should include_sexp [:cmd, %r(rm -f /etc/sudoers.d/travis)]
   end


### PR DESCRIPTION
This is a followup hot fix to
https://github.com/travis-ci/travis-build/pull/431

Note that if a Rails app connects to MySQL over a socket instead,
(as defined in config/database.yml) it may still have problems connecting
to the database.