### PR TITLE
Correctly silence rustup.sh's progressbar

### DIFF
--- a/lib/travis/build/script/rust.rb
+++ b/lib/travis/build/script/rust.rb
@@ -23,9 +23,8 @@ module Travis
           sh.fold('rust-download') do
             sh.echo 'Installing Rust', ansi: :yellow
             sh.cmd "curl -sL #{RUST_RUSTUP} -o ~/rust-installer/rustup.sh"
-            # We silence rustup.sh for now, as it has a very verbose progress bar
-            sh.echo 'Running rustup.sh'
-            sh.cmd "sh ~/rust-installer/rustup.sh #{rustup_args}", echo: false
+            # We silence the stderr of rustup.sh for now, as it has a very verbose progress bar
+            sh.cmd "sh ~/rust-installer/rustup.sh #{rustup_args} 2> /dev/null"
           end
 
           sh.cmd 'export PATH="$PATH:$HOME/rust/bin"', assert: false, echo: false


### PR DESCRIPTION
The echo parameter did not do what I thought it did. (see #433)
By sending the stderr of rustup.sh to /dev/null, it will not display the progressbar.
Unfortunately this will also silence potential errors, but they are very uncommon.