### PR TITLE
Run an Elixir test-env compile before running tests

### DIFF
--- a/lib/travis/build/script/elixir.rb
+++ b/lib/travis/build/script/elixir.rb
@@ -30,6 +30,7 @@ module Travis
         def install
           sh.cmd 'mix local.hex --force'
           sh.cmd 'mix deps.get'
+          sh.cmd 'MIX_ENV=test mix compile'
         end
 
         def script


### PR DESCRIPTION
This avoids cluttering `mix test` up with compilation output, and also folds the compile output into its own section.

# Before

![screen shot 2015-05-01 at 10 38 05](https://cloud.githubusercontent.com/assets/342081/7431607/2fcdc690-efee-11e4-94b8-6ba3a9eacf29.png)

# After

![screen shot 2015-05-01 at 10 34 25](https://cloud.githubusercontent.com/assets/342081/7431585/03f81c6e-efee-11e4-8ac2-5ebc5df7c9f5.png)