### PR TITLE
haxe: use updated download url format.

### DIFF
--- a/lib/travis/build/script/haxe.rb
+++ b/lib/travis/build/script/haxe.rb
@@ -132,7 +132,7 @@ module Travis
                 'osx'
               end
               version = config[:haxe].to_s
-              "http://haxe.org/website-content/downloads/#{version.gsub('.',',')}/downloads/haxe-#{version}-#{os}.tar.gz"
+              "http://haxe.org/website-content/downloads/#{version}/downloads/haxe-#{version}-#{os}.tar.gz"
             end
           end
 


### PR DESCRIPTION
Old version still works, but only the new version supports downloading Haxe RCs.
See https://github.com/HaxeFoundation/haxe.org/issues/111