### PR TITLE
Pass -y --disable-sudo to the rustup.sh script when installing Rust

### DIFF
--- a/lib/travis/build/script/rust.rb
+++ b/lib/travis/build/script/rust.rb
@@ -52,7 +52,7 @@ module Travis
           end
 
           def rustup_args
-            "--prefix=~/rust --spec=%s" % version.shellescape
+            "--prefix=~/rust --spec=%s -y --disable-sudo" % version.shellescape
           end
       end
     end


### PR DESCRIPTION
This script is soon going to become interactive, running sudo by
default. These flags, which are a no-op now, will make the script
non-interactive when the new script is deployed.