### PR TITLE
Revert "Hotfix for Mono 4.0 crash during installation on Travis"

### DIFF
--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -84,7 +84,7 @@ module Travis
 
         def mono_repo
           if config[:mono] == 'latest'
-            'wheezy/snapshots/3.12.0'  # FIXME: hotfix for Mono 4.0 bug on Travis, remove once fixed
+            'wheezy'
           else
             'wheezy/snapshots/' << config[:mono]
           end

--- a/spec/build/script/csharp_spec.rb
+++ b/spec/build/script/csharp_spec.rb
@@ -14,9 +14,7 @@ describe Travis::Build::Script::Csharp, :sexp do
   describe 'configure' do
     it 'sets up package repository' do
       should include_sexp [:cmd, 'sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF', assert: true]
-# FIXME: hotfix for Mono 4.0 bug on Travis, remove once fixed
-#      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian wheezy main' >> /etc/apt/sources.list.d/mono-xamarin.list\"", assert: true]
-      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian wheezy/snapshots/3.12.0 main' >> /etc/apt/sources.list.d/mono-xamarin.list\"", assert: true]
+      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian wheezy main' >> /etc/apt/sources.list.d/mono-xamarin.list\"", assert: true]
       should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian wheezy-libtiff-compat main' >> /etc/apt/sources.list.d/mono-xamarin.list\"", assert: true]
       should include_sexp [:cmd, 'sudo apt-get update -qq', timing: true, assert: true]
     end
@@ -63,11 +61,8 @@ describe Travis::Build::Script::Csharp, :sexp do
       should include_sexp [:cmd, 'sudo apt-get install -qq mono-complete mono-vbnc fsharp nuget ', timing: true, assert: true]
     end
 
-
     it 'selects latest version by default' do
-# FIXME: hotfix for Mono 4.0 bug on Travis, remove once fixed
-#      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian wheezy main' >> /etc/apt/sources.list.d/mono-xamarin.list\"", assert: true]
-      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian wheezy/snapshots/3.12.0 main' >> /etc/apt/sources.list.d/mono-xamarin.list\"", assert: true]
+      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian wheezy main' >> /etc/apt/sources.list.d/mono-xamarin.list\"", assert: true]
     end
 
     it 'selects correct version' do


### PR DESCRIPTION
Reverts travis-ci/travis-build#435
Closes https://github.com/travis-ci/travis-ci/issues/3776

The issue was fixed upstream.

/cc @BanzaiMan 

