### PR TITLE
Fix command-line pickiness with release julia

### DIFF
--- a/lib/travis/build/script/julia.rb
+++ b/lib/travis/build/script/julia.rb
@@ -67,7 +67,7 @@ module Travis
             sh.cmd "julia --color=yes -e 'Pkg.clone(pwd())'"
             sh.cmd 'julia --color=yes -e "Pkg.build(\"${JL_PKG}\")"'
             sh.if '-f test/runtests.jl' do
-              sh.cmd 'julia --color=yes --check-bounds=yes ' \
+              sh.cmd 'julia --check-bounds=yes --color=yes ' \
                 '-e "Pkg.test(\"${JL_PKG}\", coverage=true)"'
             end
           end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/11132, regression introduced by merging https://github.com/travis-ci/travis-build/pull/411

Apparently the order of command line arguments can make a big difference. At least that's been fixed on master.