### PR TITLE
Warn if no Android build-tools is specified in .travis.yml

### DIFF
--- a/lib/travis/build/script/android.rb
+++ b/lib/travis/build/script/android.rb
@@ -15,7 +15,7 @@ module Travis
             sh.echo "No build-tools version is specified in android.components. Consider adding one of:", ansi: :yellow
             sh.cmd  "android list sdk --extended --no-ui --all | awk -F\\\" '/^id.*build-tools/ {print $2}'", echo: false, timing: false
             sh.echo "The following versions are pre-installed:", ansi: :yellow
-            sh.cmd  "for v in $(ls /usr/local/android-sdk/build-tools/ | sort -r 2>/dev/null); do echo build-tools-$v; done", echo: false, timing: false
+            sh.cmd  "for v in $(ls /usr/local/android-sdk/build-tools/ | sort -r 2>/dev/null); do echo build-tools-$v; done; echo", echo: false, timing: false
           end
 
           install_sdk_components unless components.empty?

--- a/lib/travis/build/script/android.rb
+++ b/lib/travis/build/script/android.rb
@@ -13,9 +13,9 @@ module Travis
 
           if build_tools_desired.empty?
             sh.echo "No build-tools version is specified in android.components. Consider adding one of:", ansi: :yellow
-            sh.cmd  "android list sdk --extended --no-ui --all | awk -F\\\" '/^id.*build-tools/ {print $2}'", echo: false
+            sh.cmd  "android list sdk --extended --no-ui --all | awk -F\\\" '/^id.*build-tools/ {print $2}'", echo: false, timing: false
             sh.echo "The following versions are pre-installed:", ansi: :yellow
-            sh.cmd  "for v in $(ls /usr/local/android-sdk/build-tools/ | sort -r 2>/dev/null); do echo build-tools-$v; done", echo: false
+            sh.cmd  "for v in $(ls /usr/local/android-sdk/build-tools/ | sort -r 2>/dev/null); do echo build-tools-$v; done", echo: false, timing: false
           end
 
           install_sdk_components unless components.empty?

--- a/lib/travis/build/script/android.rb
+++ b/lib/travis/build/script/android.rb
@@ -54,7 +54,7 @@ module Travis
           end
 
           def build_tools_desired
-            config.fetch(:android, {}).fetch(:components, {}).map { |component|
+            components.map { |component|
               match = /build-tools-(?<version>[\d\.]+)/.match(component)
               match[:version] if match
             }


### PR DESCRIPTION
This PR supersedes #285.