### PR TITLE
Set a reasonable initial max heap size

### DIFF
--- a/lib/travis/build/script/shared/jdk.rb
+++ b/lib/travis/build/script/shared/jdk.rb
@@ -9,6 +9,7 @@ module Travis
 
         def setup
           super
+          sh.export '_JAVA_OPTIONS', '-Xmx512m'
           sh.cmd "jdk_switcher use #{config[:jdk]}", timing: false if uses_jdk?
           sh.if '-f build.gradle' do
             sh.export 'TERM', 'dumb'

--- a/lib/travis/build/script/shared/jdk.rb
+++ b/lib/travis/build/script/shared/jdk.rb
@@ -9,7 +9,7 @@ module Travis
 
         def setup
           super
-          sh.export '_JAVA_OPTIONS', '-Xmx512m'
+          sh.export 'JAVA_TOOL_OPTIONS', '-Xmx512m'
           sh.cmd "jdk_switcher use #{config[:jdk]}", timing: false if uses_jdk?
           sh.if '-f build.gradle' do
             sh.export 'TERM', 'dumb'

--- a/spec/build/script/shared/jdk.rb
+++ b/spec/build/script/shared/jdk.rb
@@ -21,8 +21,8 @@ shared_examples_for 'a jdk build sexp' do
       should_not include_sexp run_jdk_switcher
     end
 
-    it 'sets _JAVA_OPTIONS' do
-      should include_sexp [:export, ['_JAVA_OPTIONS', '-Xmx512m'], echo: true]
+    it 'sets JAVA_TOOL_OPTIONS' do
+      should include_sexp [:export, ['JAVA_TOOL_OPTIONS', '-Xmx512m'], echo: true]
     end
   end
 

--- a/spec/build/script/shared/jdk.rb
+++ b/spec/build/script/shared/jdk.rb
@@ -20,6 +20,10 @@ shared_examples_for 'a jdk build sexp' do
     it 'does not run jdk_switcher' do
       should_not include_sexp run_jdk_switcher
     end
+
+    it 'sets _JAVA_OPTIONS' do
+      should include_sexp [:export, ['_JAVA_OPTIONS', '-Xmx512m'], echo: true]
+    end
   end
 
   describe 'if jdk is given' do


### PR DESCRIPTION
Some users report problems with initializing JVM under
certain circumstances:

    Could not reserve enough space for object heap

(See travis-ci/travis-ci#3805)

We use `JAVA_TOOL_OPTIONS` to set the maximum heap size in the hopes
that this will eradicate the problem.

Notice that the command line options (e.g., `java -Xmx1g …`) will override `JAVA_TOOL_OPTIONS`.