### PR TITLE
haxe: default to the latest release (3.2.0)

### DIFF
--- a/lib/travis/build/script/haxe.rb
+++ b/lib/travis/build/script/haxe.rb
@@ -17,7 +17,7 @@ module Travis
     class Script
       class Haxe < Script
         DEFAULTS = {
-          haxe: '3.1.3',
+          haxe: '3.2.0',
           neko: '2.0.0'
         }
 


### PR DESCRIPTION
Haxe 3.2.0 [has just been released](http://haxe.org/download/).