### PR TITLE
Set the default version of rust to stable

### DIFF
--- a/lib/travis/build/script/rust.rb
+++ b/lib/travis/build/script/rust.rb
@@ -5,7 +5,7 @@ module Travis
         RUST_RUSTUP = 'https://static.rust-lang.org/rustup.sh'
 
         DEFAULTS = {
-          rust: 'nightly',
+          rust: 'stable',
         }
 
         def export


### PR DESCRIPTION
Rust 1.0.0 is out! :smile: Time to use that version as default.