### PR TITLE
allow domain-related arguments for sauce connect addon

### DIFF
--- a/lib/travis/build/addons/sauce_connect.rb
+++ b/lib/travis/build/addons/sauce_connect.rb
@@ -15,6 +15,18 @@ module Travis
           sh.export 'SAUCE_USERNAME', username, echo: false if username
           sh.export 'SAUCE_ACCESS_KEY', access_key, echo: false if access_key
 
+          if direct_domains
+            sh.export 'SAUCE_DIRECT_DOMAINS', "-D #{direct_domains}", echo: false
+          end
+
+          if no_ssl_bump_domains
+            sh.export 'SAUCE_NO_SSL_BUMP_DOMAINS', "-B #{no_ssl_bump_domains}", echo: false
+          end
+
+          if tunnel_domains
+            sh.export 'SAUCE_TUNNEL_DOMAINS', "-t #{tunnel_domains}", echo: false
+          end
+
           sh.fold 'sauce_connect.start' do
             sh.echo 'Starting Sauce Connect', echo: false, ansi: :yellow
             sh.cmd 'travis_start_sauce_connect', assert: false, echo: true, timing: true
@@ -37,6 +49,18 @@ module Travis
 
           def access_key
             config[:access_key]
+          end
+
+          def direct_domains
+            config[:direct_domains]
+          end
+
+          def no_ssl_bump_domains
+            config[:no_ssl_bump_domains]
+          end
+
+          def tunnel_domains
+            config[:tunnel_domains]
           end
       end
     end

--- a/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh
+++ b/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh
@@ -53,7 +53,10 @@ function travis_start_sauce_connect() {
   ${sc_dir}/bin/sc \
     ${sc_tunnel_id_arg} \
     -f ${sc_readyfile} \
-    -l ${sc_logfile} &
+    -l ${sc_logfile} \
+    ${SAUCE_NO_SSL_BUMP_DOMAINS} \
+    ${SAUCE_DIRECT_DOMAINS} \
+    ${SAUCE_TUNNEL_DOMAINS} &
   _SC_PID="$!"
 
   echo "Waiting for Sauce Connect readyfile"

--- a/spec/build/addons/sauce_connect_spec.rb
+++ b/spec/build/addons/sauce_connect_spec.rb
@@ -37,5 +37,16 @@ describe Travis::Build::Addons::SauceConnect, :sexp do
     it_behaves_like 'starts sauce connect'
     it { store_example }
   end
+
+  describe 'with domain arguments' do
+    let(:config) { { :direct_domains => 'travis-ci.org', :no_ssl_bump_domains=> 'travis-ci.org', :tunnel_domains => 'localhost' } }
+
+    it { should include_sexp [:export, ['SAUCE_DIRECT_DOMAINS', '-D travis-ci.org']] }
+    it { should include_sexp [:export, ['SAUCE_NO_SSL_BUMP_DOMAINS', '-B travis-ci.org']] }
+    it { should include_sexp [:export, ['SAUCE_TUNNEL_DOMAINS', '-t localhost']] }
+
+    it_behaves_like 'starts sauce connect'
+    it { store_example }
+  end
 end
 


### PR DESCRIPTION
Hey from Mozilla,

We got a use case where we want to tunnel the ```localhost``` domain with Sauce Connect, but the Travis Sauce Connect addon doesn't allow for many arguments. 

To only pass the arguments in when they're defined, I had Ruby build the argstrings. If the arguments are not defined, the argstrings are empty strings and don't affect the Sauce Connect command. 

```bash
$ export TRAVISTEST=""
$ sc/bin/sc -u MYUSER -k MYKEY $TRAVISTEST
27 May 13:38:13 - Command line arguments: sc/bin/sc -u MYUSER -k ****

$ export TRAVISTEST="-B localhost"
$ sc/bin/sc -u MYUSER -k MYKEY $TRAVISTEST
27 May 13:38:36 - Command line arguments: sc/bin/sc -u MYUSER -k **** -B localhost
```

r? @meatballhat 
