### PR TITLE
Dump /etc/hosts content before and after applying addon

### DIFF
--- a/lib/travis/build/addons/hosts.rb
+++ b/lib/travis/build/addons/hosts.rb
@@ -9,9 +9,17 @@ module Travis
         HOSTS_FILE = '/etc/hosts'
 
         def after_prepare
+          sh.fold 'hosts.before' do
+            sh.echo ""
+            sh.cmd "cat #{HOSTS_FILE}"
+          end
           sh.fold 'hosts' do
             sh.cmd "cat #{HOSTS_FILE} | sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 #{hosts}/' | sudo tee #{HOSTS_FILE} > /dev/null"
             sh.cmd "cat #{HOSTS_FILE} | sed -e 's/^\\(::1.*\\)$/\\1 #{hosts}/'             | sudo tee #{HOSTS_FILE} > /dev/null"
+          end
+          sh.fold 'hosts.after' do
+            sh.echo ""
+            sh.cmd "cat #{HOSTS_FILE}"
           end
         end
 


### PR DESCRIPTION
https://github.com/travis-ci/travis-ci/issues/3922 describes reports of problems with empty `/etc/hosts`. We are trying to figure out if the hosts addon is to blame.