### PR TITLE
Clone repo with tarball

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,7 @@ deploy:
   region: us-east-1
   on:
     branch: master
+
+git:
+  strategy: tarball
+  


### PR DESCRIPTION
Use tarball strategy to clone repo. The PR build will fail. See https://github.com/travis-ci/travis-ci/issues/3923