### PR TITLE
2-step hosts file modification for hosts addon

### DIFF
--- a/lib/travis/build/addons/hosts.rb
+++ b/lib/travis/build/addons/hosts.rb
@@ -14,8 +14,8 @@ module Travis
             sh.cmd "cat #{HOSTS_FILE}"
           end
           sh.fold 'hosts' do
-            sh.cmd "cat #{HOSTS_FILE} | sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 #{hosts}/' | sudo tee #{HOSTS_FILE} > /dev/null"
-            sh.cmd "cat #{HOSTS_FILE} | sed -e 's/^\\(::1.*\\)$/\\1 #{hosts}/'             | sudo tee #{HOSTS_FILE} > /dev/null"
+            sh.cmd "HOSTS_FILE_CONTENT=$(sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 #{hosts}/' #{HOSTS_FILE} | sed -e 's/^\\(::1.*\\)$/\\1 #{hosts}/')"
+            sh.cmd "echo $HOSTS_FILE_CONTENT | sudo tee #{HOSTS_FILE} > /dev/null"
           end
           sh.fold 'hosts.after' do
             sh.echo ""

--- a/lib/travis/build/addons/hosts.rb
+++ b/lib/travis/build/addons/hosts.rb
@@ -7,6 +7,7 @@ module Travis
       class Hosts < Base
         SUPER_USER_SAFE = true
         HOSTS_FILE = '/etc/hosts'
+        TEMP_HOSTS_FILE = '/tmp/hosts'
 
         def after_prepare
           sh.fold 'hosts.before' do
@@ -14,8 +15,8 @@ module Travis
             sh.cmd "cat #{HOSTS_FILE}"
           end
           sh.fold 'hosts' do
-            sh.cmd "HOSTS_FILE_CONTENT=$(sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 #{hosts}/' #{HOSTS_FILE} | sed -e 's/^\\(::1.*\\)$/\\1 #{hosts}/')"
-            sh.cmd "echo $HOSTS_FILE_CONTENT | sudo tee #{HOSTS_FILE} > /dev/null"
+            sh.cmd "sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 #{hosts}/' #{HOSTS_FILE} | sed -e 's/^\\(::1.*\\)$/\\1 #{hosts}/' > #{TEMP_HOSTS_FILE}"
+            sh.cmd "cat #{TEMP_HOSTS_FILE} | sudo tee #{HOSTS_FILE} > /dev/null"
           end
           sh.fold 'hosts.after' do
             sh.echo ""

--- a/spec/build/addons/hosts_spec.rb
+++ b/spec/build/addons/hosts_spec.rb
@@ -17,7 +17,7 @@ describe Travis::Build::Addons::Hosts, :sexp do
 
   # it { should include_sexp [:cmd, "sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 'one.local\\ two.local'/' -i'.bak' /etc/hosts", sudo: true] }
   # it { should include_sexp [:cmd, "sed -e 's/^\\(::1.*\\)$/\\1 'one.local\\ two.local'/' -i'.bak' /etc/hosts", sudo: true] }
-  it { should include_sexp [:cmd, "HOSTS_FILE_CONTENT=$(sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 one.local\\ two.local/' /etc/hosts | sed -e 's/^\\(::1.*\\)$/\\1 one.local\\ two.local/')"] }
-  it { should include_sexp [:cmd, "echo $HOSTS_FILE_CONTENT | sudo tee /etc/hosts > /dev/null"] }
+  it { should include_sexp [:cmd, "sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 one.local\\ two.local/' /etc/hosts | sed -e 's/^\\(::1.*\\)$/\\1 one.local\\ two.local/' > /tmp/hosts"] }
+  it { should include_sexp [:cmd, "cat /tmp/hosts | sudo tee /etc/hosts > /dev/null"] }
 end
 

--- a/spec/build/addons/hosts_spec.rb
+++ b/spec/build/addons/hosts_spec.rb
@@ -17,7 +17,7 @@ describe Travis::Build::Addons::Hosts, :sexp do
 
   # it { should include_sexp [:cmd, "sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 'one.local\\ two.local'/' -i'.bak' /etc/hosts", sudo: true] }
   # it { should include_sexp [:cmd, "sed -e 's/^\\(::1.*\\)$/\\1 'one.local\\ two.local'/' -i'.bak' /etc/hosts", sudo: true] }
-  it { should include_sexp [:cmd, "cat /etc/hosts | sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 one.local\\ two.local/' | sudo tee /etc/hosts > /dev/null"] }
-  it { should include_sexp [:cmd, "cat /etc/hosts | sed -e 's/^\\(::1.*\\)$/\\1 one.local\\ two.local/'             | sudo tee /etc/hosts > /dev/null"] }
+  it { should include_sexp [:cmd, "HOSTS_FILE_CONTENT=$(sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 one.local\\ two.local/' /etc/hosts | sed -e 's/^\\(::1.*\\)$/\\1 one.local\\ two.local/')"] }
+  it { should include_sexp [:cmd, "echo $HOSTS_FILE_CONTENT | sudo tee /etc/hosts > /dev/null"] }
 end
 


### PR DESCRIPTION
This PR breaks down the hosts addon into 2 steps; one to construct the content and another to actually overwrite the content of `/etc/hosts`. My theory here is that the race condition exists in the current 2 single pipeline in stu editing of `/etc/hosts` that manifests in an empty file.

See https://github.com/travis-ci/travis-ci/issues/3922.