### PR TITLE
Added regex support for optional revision number on mono version

### DIFF
--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -11,7 +11,7 @@ module Travis
           mono: 'latest',
         }
 
-        MONO_VERSION_REGEXP = /^(\d{1})\.(\d{1,2})\.\d{1,2}$/
+        MONO_VERSION_REGEXP = /^(\d{1})\.(\d{1,2})\.\d{1,2}(\.(\d{1,3}))?$/
 
         def configure
           super


### PR DESCRIPTION
Mono version numbers sometimes contain revisions.

Example: `4.0.1.44`

resolves https://github.com/travis-ci/travis-ci/issues/4045