### PR TITLE
Fix `edge: local`

### DIFF
--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -108,8 +108,8 @@ module Travis
 
             def install(edge = config[:edge])
               command = "gem install dpl"
+              command << "-*.gem --local" if edge == 'local'
               command << " --pre" if edge
-              command << " --local" if edge == 'local'
               cmd(command, echo: false, assert: !allow_failure, timing: true)
             end
 


### PR DESCRIPTION
Ruby gems v1.x the `--local` flag would scan the current working directory for gems of any version. However ruby gems v2.x no longer does this and requires you to use the file name of the gem.

This change modifies the command to

    gem install dpl-*.gem --local --pre

For more information see the question [How can I run a custom version of dpl on Travis-CI?](http://stackoverflow.com/questions/30584467/how-can-i-run-a-custom-version-of-dpl-on-travis-ci) on Stack Overflow.