### PR TITLE
Add support for .nvmrc

### DIFF
--- a/spec/build/script/node_js_spec.rb
+++ b/spec/build/script/node_js_spec.rb
@@ -17,8 +17,21 @@ describe Travis::Build::Script::NodeJs, :sexp do
     should include_sexp [:export, ['TRAVIS_NODE_VERSION', '0.10']]
   end
 
-  it 'sets up the node version' do
-    should include_sexp [:cmd, 'nvm install 0.10', echo: true, assert: true, timing: true]
+  describe 'nvm install' do
+    it 'sets the version from config :node_js' do
+      data[:config][:node_js] = 0.9
+      should include_sexp [:cmd, 'nvm install 0.9', assert: true, echo: true, timing: true]
+    end
+
+    it 'sets the version from .nvmrc' do
+      sexp = sexp_filter(subject, [:if, '-f .nvmrc'], [:then])
+      expect(sexp).to include_sexp [:cmd, 'nvm install', assert: true, echo: true, timing: true]
+    end
+
+    it 'sets the version to 0.10 otherwise' do
+      sexp = sexp_filter(subject, [:if, '-f .nvmrc'], [:else])
+      expect(sexp).to include_sexp [:cmd, 'nvm install 0.10', assert: true, echo: true, timing: true]
+    end
   end
 
   it 'announces node --version' do


### PR DESCRIPTION
If projects support ```.nvmrc``` make sure travis use it during setup. Instead of maintaining multiple manifests for nodejs/iojs projects.

if ```node_js``` property is specified in ```.travis.yml``` use that version.
if ```.nvmrc``` file is present use that version
fallback to ```nvm install stable```

This enhancement has been discussed here and accepted: https://github.com/travis-ci/travis-ci/issues/3644 - but it was never added :-(

cc: @BanzaiMan 