### PR TITLE
Install OTP Release on demand

### DIFF
--- a/lib/travis/build/script/erlang.rb
+++ b/lib/travis/build/script/erlang.rb
@@ -13,7 +13,17 @@ module Travis
 
         def setup
           super
-          sh.cmd "source #{HOME_DIR}/otp/#{otp_release}/activate"
+          sh.if "-f #{activate_file}" do
+            sh.cmd "source #{activate_file}"
+          end
+          sh.else do
+            sh.echo "#{otp_release} is not installed. Downloading and installing pre-build binary.", ansi: :yellow
+            sh.cmd "kerl update releases"
+            sh.cmd "wget #{erlang_archive_url(otp_release)}"
+            sh.cmd "tar xf #{archive_name(otp_release)} -C ~/otp/"
+            sh.cmd "echo '#{otp_release},#{otp_release}' >> ~/.kerl/otp_builds", echo: false
+            sh.cmd "echo '#{otp_release} #{HOME_DIR}/otp/#{otp_release}' >> ~/.kerl/otp_builds", echo: false
+          end
         end
 
         def install
@@ -49,6 +59,18 @@ module Travis
 
           def rebar_configured
             '(-f rebar.config || -f Rebar.config)'
+          end
+
+          def activate_file
+            "#{HOME_DIR}/otp/#{otp_release}/activate"
+          end
+
+          def erlang_archive_url(release)
+            "https://s3.amazonaws.com/travis-otp-releases/ubuntu/$(lsb_release -rs)/erlang-#{release}-x86_64.tar.bz2"
+          end
+
+          def archive_name(release)
+            "erlang-#{release}-x86_64.tar.bz2"
           end
       end
     end

--- a/lib/travis/build/script/erlang.rb
+++ b/lib/travis/build/script/erlang.rb
@@ -14,12 +14,7 @@ module Travis
         def setup
           super
           sh.if "! -f #{activate_file}" do
-            sh.echo "#{otp_release} is not installed. Downloading and installing pre-build binary.", ansi: :yellow
-            sh.cmd "kerl update releases"
-            sh.cmd "wget #{erlang_archive_url(otp_release)}"
-            sh.cmd "tar xf #{archive_name(otp_release)} -C ~/otp/"
-            sh.cmd "echo '#{otp_release},#{otp_release}' >> ~/.kerl/otp_builds", echo: false
-            sh.cmd "echo '#{otp_release} #{HOME_DIR}/otp/#{otp_release}' >> ~/.kerl/otp_builds", echo: false
+            install_erlang otp_release
           end
           sh.cmd "source #{activate_file}"
         end
@@ -69,6 +64,15 @@ module Travis
 
           def archive_name(release)
             "erlang-#{release}-x86_64.tar.bz2"
+          end
+
+          def install_erlang(release)
+            sh.echo "#{release} is not installed. Downloading and installing pre-build binary.", ansi: :yellow
+            sh.cmd "kerl update releases"
+            sh.cmd "wget #{erlang_archive_url(release)}"
+            sh.cmd "tar xf #{archive_name(release)} -C ~/otp/"
+            sh.cmd "echo '#{release},#{release}' >> ~/.kerl/otp_builds", echo: false
+            sh.cmd "echo '#{release} #{HOME_DIR}/otp/#{release}' >> ~/.kerl/otp_builds", echo: false
           end
       end
     end

--- a/lib/travis/build/script/erlang.rb
+++ b/lib/travis/build/script/erlang.rb
@@ -13,10 +13,7 @@ module Travis
 
         def setup
           super
-          sh.if "-f #{activate_file}" do
-            sh.cmd "source #{activate_file}"
-          end
-          sh.else do
+          sh.if "! -f #{activate_file}" do
             sh.echo "#{otp_release} is not installed. Downloading and installing pre-build binary.", ansi: :yellow
             sh.cmd "kerl update releases"
             sh.cmd "wget #{erlang_archive_url(otp_release)}"
@@ -24,6 +21,7 @@ module Travis
             sh.cmd "echo '#{otp_release},#{otp_release}' >> ~/.kerl/otp_builds", echo: false
             sh.cmd "echo '#{otp_release} #{HOME_DIR}/otp/#{otp_release}' >> ~/.kerl/otp_builds", echo: false
           end
+          sh.cmd "source #{activate_file}"
         end
 
         def install

--- a/spec/build/script/erlang_spec.rb
+++ b/spec/build/script/erlang_spec.rb
@@ -18,16 +18,12 @@ describe Travis::Build::Script::Erlang, :sexp do
   end
 
   describe 'setup' do
-    let(:cond) { '-f $HOME/otp/R14B04/activate' }
-    let(:sexp) { sexp_find(subject, [:if, cond]) }
-
     it 'activates otp' do
-      branch = sexp_find(sexp, [:then])
-      expect(branch).to include_sexp [:cmd, 'source $HOME/otp/R14B04/activate', assert: true, echo: true, timing: true]
+      should include_sexp [:cmd, 'source $HOME/otp/R14B04/activate', assert: true, echo: true, timing: true]
     end
 
     it 'downloads OTP archive on demand when the desired release is not pre-installed' do
-      branch = sexp_find(sexp, [:else])
+      branch = sexp_find(subject, [:if, '! -f $HOME/otp/R14B04/activate'])
       expect(branch).to include_sexp [:cmd, 'wget https://s3.amazonaws.com/travis-otp-releases/ubuntu/$(lsb_release -rs)/erlang-R14B04-x86_64.tar.bz2', assert: true, echo: true, timing: true]
     end
   end

--- a/spec/build/script/erlang_spec.rb
+++ b/spec/build/script/erlang_spec.rb
@@ -17,8 +17,19 @@ describe Travis::Build::Script::Erlang, :sexp do
     should include_sexp [:export, ['TRAVIS_OTP_RELEASE', 'R14B04']] #, echo: true
   end
 
-  it 'activates otp' do
-    should include_sexp [:cmd, 'source $HOME/otp/R14B04/activate', assert: true, echo: true, timing: true]
+  describe 'setup' do
+    let(:cond) { '-f $HOME/otp/R14B04/activate' }
+    let(:sexp) { sexp_find(subject, [:if, cond]) }
+
+    it 'activates otp' do
+      branch = sexp_find(sexp, [:then])
+      expect(branch).to include_sexp [:cmd, 'source $HOME/otp/R14B04/activate', assert: true, echo: true, timing: true]
+    end
+
+    it 'downloads OTP archive on demand when the desired release is not pre-installed' do
+      branch = sexp_find(sexp, [:else])
+      expect(branch).to include_sexp [:cmd, 'wget https://s3.amazonaws.com/travis-otp-releases/ubuntu/$(lsb_release -rs)/erlang-R14B04-x86_64.tar.bz2', assert: true, echo: true, timing: true]
+    end
   end
 
   describe 'install' do


### PR DESCRIPTION
https://github.com/travis-ci/travis-erlang-builder builds OTP Releases and uploads them to our S3 bucket.

If the user asks for an OTP Release not pre-installed (either too new or too old), this PR will download the appropriate archive and installs it so that it can be used. It will add a few seconds to the build, but generally acceptable perf hit.

I think this is an acceptable workaround for issues such as https://github.com/travis-ci/travis-ci/issues/2757 and https://github.com/travis-ci/travis-ci/issues/4162.