### PR TITLE
Add directories to cache in one pass

### DIFF
--- a/lib/travis/build/script/shared/directory_cache/s3.rb
+++ b/lib/travis/build/script/shared/directory_cache/s3.rb
@@ -30,6 +30,10 @@ module Travis
                   time_total:  %{time_total} s
           EOF
 
+          # maximum number of directories to be 'added' to cache via casher
+          # in one invocation
+          ADD_DIR_MAX = 100
+
           KeyPair = Struct.new(:id, :secret)
 
           Location = Struct.new(:scheme, :region, :bucket, :path) do
@@ -78,7 +82,9 @@ module Travis
           end
 
           def add(*paths)
-            run('add', paths) if paths
+            if paths
+              paths.flatten.each_slice(ADD_DIR_MAX) { |dirs| run('add', dirs) }
+            end
           end
 
           def fetch

--- a/lib/travis/build/script/shared/directory_cache/s3.rb
+++ b/lib/travis/build/script/shared/directory_cache/s3.rb
@@ -61,7 +61,7 @@ module Travis
             fold 'Setting up build cache' do
               install
               fetch
-              directories.each { |dir| add(dir) } if data.cache?(:directories)
+              add(directories) if data.cache?(:directories)
             end
           end
 
@@ -77,8 +77,8 @@ module Travis
             end
           end
 
-          def add(path)
-            run('add', path) if path
+          def add(*paths)
+            run('add', paths) if paths
           end
 
           def fetch

--- a/spec/build/script/directory_cache/s3_spec.rb
+++ b/spec/build/script/directory_cache/s3_spec.rb
@@ -88,6 +88,13 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
   describe 'add' do
     before { cache.add('/foo/bar') }
     it { should include_sexp [:cmd, 'rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher add /foo/bar'] }
+
+    context 'when multiple directories are given' do
+      before { cache.setup }
+      let(:config) { { cache: { directories: ['/foo/bar', '/bar/baz'] } } }
+
+      it { should include_sexp [:cmd, 'rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher add /foo/bar /bar/baz'] }
+    end
   end
 
   describe 'push' do

--- a/spec/build/script/directory_cache/s3_spec.rb
+++ b/spec/build/script/directory_cache/s3_spec.rb
@@ -95,6 +95,14 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
 
       it { should include_sexp [:cmd, 'rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher add /foo/bar /bar/baz'] }
     end
+
+    context 'when more than ADD_DIR_MAX directories are given' do
+      before { cache.setup }
+      let(:dirs) { ('dir000'...'dir999').to_a }
+      let(:config) { { cache: { directories: dirs } } }
+
+      it { should include_sexp [:cmd, "rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher add #{dirs.take(Travis::Build::Script::DirectoryCache::S3::ADD_DIR_MAX).join(' ')}"] }
+    end
   end
 
   describe 'push' do


### PR DESCRIPTION
To avoid scanning the same archive multiple times to extract
directories, we pass directories to 'casher add' in one go.