### PR TITLE
Ensure "travis" user and db are present for all PostgreSQL versions

### DIFF
--- a/lib/travis/build/addons/postgresql.rb
+++ b/lib/travis/build/addons/postgresql.rb
@@ -17,8 +17,8 @@ module Travis
             end
             sh.cmd "service postgresql start #{version}", assert: false, sudo: true, echo: true, timing: true
             %w(5432 5433).each do |pgport|
-              sh.raw "sudo -u postgres createuser -p #{pgport} travis", assert: false, echo: true, timing: true
-              sh.raw "sudo -u postgres createdb -p #{pgport} travis", assert: false, echo: true, timing: true
+              sh.raw "sudo -u postgres createuser -p #{pgport} travis &>/dev/null", assert: false, echo: true, timing: true
+              sh.raw "sudo -u postgres createdb -p #{pgport} travis &>/dev/null", assert: false, echo: true, timing: true
             end
           end
         end

--- a/lib/travis/build/addons/postgresql.rb
+++ b/lib/travis/build/addons/postgresql.rb
@@ -9,13 +9,17 @@ module Travis
 
         def after_prepare
           sh.fold 'postgresql' do
-            sh.export "PATH", "/usr/lib/postgresql/#{version}/bin:$PATH", echo: false
+            sh.export 'PATH', "/usr/lib/postgresql/#{version}/bin:$PATH", echo: false
             sh.echo "Starting PostgreSQL v#{version}", ansi: :yellow
-            sh.cmd "service postgresql stop", assert: false, sudo: true, echo: true, timing: true
+            sh.cmd 'service postgresql stop', assert: false, sudo: true, echo: true, timing: true
             sh.if "-d /var/ramfs && ! -d /var/ramfs/postgresql/#{version}", echo: false do
               sh.cmd "cp -rp /var/lib/postgresql/#{version} /var/ramfs/postgresql/#{version}", sudo: true, assert: false, echo: false, timing: false
             end
             sh.cmd "service postgresql start #{version}", assert: false, sudo: true, echo: true, timing: true
+            %w(5432 5433).each do |pgport|
+              sh.raw "sudo -u postgres createuser -p #{pgport} travis", assert: false, echo: true, timing: true
+              sh.raw "sudo -u postgres createdb -p #{pgport} travis", assert: false, echo: true, timing: true
+            end
           end
         end
 

--- a/lib/travis/build/addons/postgresql.rb
+++ b/lib/travis/build/addons/postgresql.rb
@@ -7,6 +7,9 @@ module Travis
       class Postgresql < Base
         SUPER_USER_SAFE = true
 
+        DEFAULT_PORT = 5432
+        DEFAULT_FALLBACK_PORT = 5433
+
         def after_prepare
           sh.fold 'postgresql' do
             sh.export 'PATH', "/usr/lib/postgresql/#{version}/bin:$PATH", echo: false
@@ -16,7 +19,7 @@ module Travis
               sh.cmd "cp -rp /var/lib/postgresql/#{version} /var/ramfs/postgresql/#{version}", sudo: true, assert: false, echo: false, timing: false
             end
             sh.cmd "service postgresql start #{version}", assert: false, sudo: true, echo: true, timing: true
-            %w(5432 5433).each do |pgport|
+            [DEFAULT_PORT, DEFAULT_FALLBACK_PORT].each do |pgport|
               sh.cmd "sudo -u postgres createuser -p #{pgport} travis &>/dev/null", assert: false, echo: true, timing: true
               sh.cmd "sudo -u postgres createdb -p #{pgport} travis &>/dev/null", assert: false, echo: true, timing: true
             end

--- a/lib/travis/build/addons/postgresql.rb
+++ b/lib/travis/build/addons/postgresql.rb
@@ -17,8 +17,8 @@ module Travis
             end
             sh.cmd "service postgresql start #{version}", assert: false, sudo: true, echo: true, timing: true
             %w(5432 5433).each do |pgport|
-              sh.raw "sudo -u postgres createuser -p #{pgport} travis &>/dev/null", assert: false, echo: true, timing: true
-              sh.raw "sudo -u postgres createdb -p #{pgport} travis &>/dev/null", assert: false, echo: true, timing: true
+              sh.cmd "sudo -u postgres createuser -p #{pgport} travis &>/dev/null", assert: false, echo: true, timing: true
+              sh.cmd "sudo -u postgres createdb -p #{pgport} travis &>/dev/null", assert: false, echo: true, timing: true
             end
           end
         end

--- a/spec/build/addons/postgresql_spec.rb
+++ b/spec/build/addons/postgresql_spec.rb
@@ -20,8 +20,8 @@ describe Travis::Build::Addons::Postgresql, :sexp do
   it { should include_sexp [:cmd, 'service postgresql stop', sudo: true, echo: true, timing: true] }
   it { should include_sexp [:cmd, 'cp -rp /var/lib/postgresql/9.3 /var/ramfs/postgresql/9.3', sudo: true] }
   it { should include_sexp [:cmd, 'service postgresql start 9.3', sudo: true, echo: true, timing: true] }
-  it { should include_sexp [:cmd, 'sudo -u postgres createuser -p 5432 travis &>/dev/null', echo: true, timing: true] }
-  it { should include_sexp [:cmd, 'sudo -u postgres createuser -p 5433 travis &>/dev/null', echo: true, timing: true] }
-  it { should include_sexp [:cmd, 'sudo -u postgres createdb -p 5432 travis &>/dev/null', echo: true, timing: true] }
-  it { should include_sexp [:cmd, 'sudo -u postgres createdb -p 5433 travis &>/dev/null', echo: true, timing: true] }
+  it { should include_sexp [:cmd, "sudo -u postgres createuser -p #{described_class::DEFAULT_PORT} travis &>/dev/null", echo: true, timing: true] }
+  it { should include_sexp [:cmd, "sudo -u postgres createuser -p #{described_class::DEFAULT_FALLBACK_PORT} travis &>/dev/null", echo: true, timing: true] }
+  it { should include_sexp [:cmd, "sudo -u postgres createdb -p #{described_class::DEFAULT_PORT} travis &>/dev/null", echo: true, timing: true] }
+  it { should include_sexp [:cmd, "sudo -u postgres createdb -p #{described_class::DEFAULT_FALLBACK_PORT} travis &>/dev/null", echo: true, timing: true] }
 end

--- a/spec/build/addons/postgresql_spec.rb
+++ b/spec/build/addons/postgresql_spec.rb
@@ -20,4 +20,8 @@ describe Travis::Build::Addons::Postgresql, :sexp do
   it { should include_sexp [:cmd, 'service postgresql stop', sudo: true, echo: true, timing: true] }
   it { should include_sexp [:cmd, 'cp -rp /var/lib/postgresql/9.3 /var/ramfs/postgresql/9.3', sudo: true] }
   it { should include_sexp [:cmd, 'service postgresql start 9.3', sudo: true, echo: true, timing: true] }
+  it { should include_sexp [:cmd, 'sudo -u postgres createuser -p 5432 travis &>/dev/null', echo: true, timing: true] }
+  it { should include_sexp [:cmd, 'sudo -u postgres createuser -p 5433 travis &>/dev/null', echo: true, timing: true] }
+  it { should include_sexp [:cmd, 'sudo -u postgres createdb -p 5432 travis &>/dev/null', echo: true, timing: true] }
+  it { should include_sexp [:cmd, 'sudo -u postgres createdb -p 5433 travis &>/dev/null', echo: true, timing: true] }
 end


### PR DESCRIPTION
The good news is that the existing addon Just Works™ even when installing PostgreSQL from the pgdg repo.  Cycling through both ports 5432 and 5433 is a bit of a hack, as installing previously absent versions of PostgreSQL while there's a server still running will cause the installer to select the next unused port, which is 5433.

Working build in staging: https://staging.travis-ci.org/meatballhat/yolo-octo-adventure/builds/433553
Associated config: https://github.com/meatballhat/yolo-octo-adventure/blob/5b2db2f53e2a8dbd599f067b8dc85addaa26aae0/.travis.yml