### PR TITLE
Fixes to `fix_resolv_conf` appliance

### DIFF
--- a/lib/travis/build/appliances/fix_resolv_conf.rb
+++ b/lib/travis/build/appliances/fix_resolv_conf.rb
@@ -5,18 +5,11 @@ module Travis
     module Appliances
       class FixResolvConf < Base
         def apply
-          current_resolv_conf = File.read('/etc/resolv.conf')
           resolv_conf_data = <<-EOF
-options rotate
-options timeout:1
-
 nameserver 8.8.8.8
 nameserver 8.8.4.4
           EOF
 
-          if current_resolv_conf =~ /nameserver\s+199\.91\.168/
-            resolv_conf_data << "\nnameserver 199.91.168.70\nnameserver 199.91.168.71\n"
-          end
           sh.raw %(echo "#{resolv_conf_data}" | sudo tee /etc/resolv.conf &> /dev/null)
         end
 

--- a/lib/travis/build/appliances/fix_resolv_conf.rb
+++ b/lib/travis/build/appliances/fix_resolv_conf.rb
@@ -12,8 +12,6 @@ options timeout:1
 
 nameserver 8.8.8.8
 nameserver 8.8.4.4
-nameserver 208.67.222.222
-nameserver 208.67.220.220
           EOF
 
           if current_resolv_conf =~ /nameserver\s+199\.91\.168/


### PR DESCRIPTION
- Remove OpenDNS
- Remove "dead" code testing for BB DNS servers (this was being run on Heroku, so it would never run)

Essentially we are now left with an addon that just overwrites with Google DNS. To my knowledge this appliance is only run on Blue Box VMs.
