### PR TITLE
Rename mactex-basic to BasicTeX.

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -361,8 +361,8 @@ module Travis
                    "#{latex_packages.join(' ')}",
                    retry: true
           when 'osx'
-            # We use mactex-basic due to disk space constraints.
-            mactex = 'mactex-basic.pkg'
+            # We use basictex due to disk space constraints.
+            mactex = 'BasicTeX.pkg'
             # TODO(craigcitro): Confirm that this will route us to the
             # nearest mirror.
             sh.cmd 'wget http://mirror.ctan.org/systems/mac/mactex/' +


### PR DESCRIPTION
It looks like mactex has renamed the stripped-down package we use, so we just
need to update the path we're pulling from.

PTAL @BanzaiMan -- this should fix travis-ci/travis-ci#4417.