### PR TITLE
Update sbt to latest version

### DIFF
--- a/lib/travis/build/script/scala.rb
+++ b/lib/travis/build/script/scala.rb
@@ -10,6 +10,18 @@ module Travis
           jdk:   'default'
         }
 
+        SBT_PATH = '/usr/local/bin/sbt'
+        SBT_SHA  = 'b9c8cb273d38e0d8da9211902a18018fe82aa14e'
+        SBT_URL  = "https://raw.githubusercontent.com/paulp/sbt-extras/#{SBT_SHA}/sbt"
+
+        def configure
+          super
+          if use_sbt?
+            sh.echo "Updating sbt", ansi: :green
+            sh.cmd "sudo curl -sS -o #{SBT_PATH} #{SBT_URL}"
+          end
+        end
+
         def export
           super
           sh.export 'TRAVIS_SCALA_VERSION', version, echo: false
@@ -17,7 +29,7 @@ module Travis
 
         def setup
           super
-          sh.if '-d project || -f build.sbt' do
+          sh.if use_sbt? do
             sh.export 'JVM_OPTS', '@/etc/sbt/jvmopts', echo: true
             sh.export 'SBT_OPTS', '@/etc/sbt/sbtopts', echo: true
           end
@@ -29,13 +41,13 @@ module Travis
         end
 
         def install
-          sh.if '! -d project && ! -f build.sbt' do
+          sh.if not_use_sbt? do
             super
           end
         end
 
         def script
-          sh.if '-d project || -f build.sbt' do
+          sh.if use_sbt? do
             sh.cmd "sbt#{sbt_args} ++#{version} test"
           end
           sh.else do
@@ -55,6 +67,14 @@ module Travis
 
           def sbt_args
             config[:sbt_args] && " #{config[:sbt_args]}"
+          end
+
+          def use_sbt?
+            '-d project || -f build.sbt'
+          end
+
+          def not_use_sbt?
+            '! -d project && ! -f build.sbt'
           end
       end
     end

--- a/spec/build/script/scala_spec.rb
+++ b/spec/build/script/scala_spec.rb
@@ -3,6 +3,9 @@ require 'spec_helper'
 describe Travis::Build::Script::Scala, :sexp do
   let(:data)   { payload_for(:push, :scala) }
   let(:script) { described_class.new(data) }
+  let(:sbt_path) { '/usr/local/bin/sbt'}
+  let(:sbt_sha) { 'b9c8cb273d38e0d8da9211902a18018fe82aa14e'}
+  let(:sbt_url) { "https://raw.githubusercontent.com/paulp/sbt-extras/#{sbt_sha}/sbt"}
   subject      { script.sexp }
   it           { store_example }
 
@@ -28,6 +31,10 @@ describe Travis::Build::Script::Scala, :sexp do
 
   describe 'if ./project directory or build.sbt file exists' do
     let(:sexp) { sexp_find(subject, [:if, '-d project || -f build.sbt']) }
+
+    it "updates SBT" do
+      should include_sexp [:cmd, "sudo curl -sS -o #{sbt_path} #{sbt_url}"]
+    end
 
     it 'sets JVM_OPTS' do
       should include_sexp export_jvm_opts


### PR DESCRIPTION
Fixes https://github.com/travis-ci/travis-ci/issues/4527

This, in effect, negates what we do in the cookbooks
https://github.com/eed3si9n/travis-cookbooks/blob/8ef970bff256656219f1673472445c70d44789af/ci_environment/sbt-extras/recipes/default.rb#L16-L22
and makes the build (ever so slightly) more susceptible to
network (but the risk should be minimal, since we are relying on
GitHub anyway).

When the new image containing this version of sbt is provisioned
and deployed, this commit should be either updated or reverted.

Test build on staging: https://staging.travis-ci.org/BanzaiMan/vamp-common/builds/434194