### PR TITLE
C#: replace "nightly" with "weekly" for Mono version

### DIFF
--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -95,7 +95,7 @@ module Travis
           when 'beta'
             repos << 'wheezy'
             repos << 'beta'
-          when 'nightly'
+          when 'weekly', 'nightly'  # nightly is a misnomer, but we need to keep it to avoid breaking existing scripts
             repos << 'wheezy'
             repos << 'nightly'
           else
@@ -106,7 +106,7 @@ module Travis
         end
 
         def mono_version_valid?
-          return true if ['latest', 'alpha', 'beta', 'nightly'].include? config[:mono]
+          return true if ['latest', 'alpha', 'beta', 'weekly', 'nightly'].include? config[:mono]
           return false unless MONO_VERSION_REGEXP === config[:mono]
 
           return false if MONO_VERSION_REGEXP.match(config[:mono])[1] == '2' && !is_mono_2_10_8

--- a/spec/build/script/csharp_spec.rb
+++ b/spec/build/script/csharp_spec.rb
@@ -80,8 +80,13 @@ describe Travis::Build::Script::Csharp, :sexp do
       should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian beta main' >> /etc/apt/sources.list.d/mono-xamarin.list\"", assert: true]
     end
 
-    it 'selects nightly version when specified' do
+    it 'selects nightly (which really is weekly, but kept to avoid breaking existing scripts) version when specified' do
       data[:config][:mono] = 'nightly'
+      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian nightly main' >> /etc/apt/sources.list.d/mono-xamarin.list\"", assert: true]
+    end
+
+    it 'selects weekly version when specified' do
+      data[:config][:mono] = 'weekly'
       should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian nightly main' >> /etc/apt/sources.list.d/mono-xamarin.list\"", assert: true]
     end
   end


### PR DESCRIPTION
We keep nightly working for now, but it is a misnomer. When the name switch eventually happens on the Mono repositories we can just update this in the background without impacting anyone (not that I expect this to be soon).

Corresponding docs PR: https://github.com/travis-ci/docs-travis-ci-com/pull/308

/cc @BanzaiMan @Joshua-Anderson 