### PR TITLE
git: fix typo in rm_key

### DIFF
--- a/lib/travis/build/git.rb
+++ b/lib/travis/build/git.rb
@@ -54,7 +54,7 @@ module Travis
         end
 
         def rm_key
-          sh.rm '~/.ssh/source_rsa', force: true, echo: false
+          sh.rm '~/.ssh/id_rsa', force: true, echo: false
         end
 
         def config

--- a/spec/build/git_spec.rb
+++ b/spec/build/git_spec.rb
@@ -5,7 +5,7 @@ describe Travis::Build::Git, :sexp do
   let(:script)  { Travis::Build::Script.new(payload) }
   subject       { script.sexp }
 
-  let(:rm_ssh_key)    { [:rm, '~/.ssh/source_rsa', force: true] }
+  let(:rm_ssh_key)    { [:rm, '~/.ssh/id_rsa', force: true] }
 
   it { should include_sexp rm_ssh_key }
 end


### PR DESCRIPTION
The key that we install is named ~/.ssh/id_rsa, not ~/.ssh/source_rsa.
