### PR TITLE
[WIP] chruby improvements

### DIFF
--- a/lib/travis/build/script/ruby.rb
+++ b/lib/travis/build/script/ruby.rb
@@ -7,7 +7,6 @@ module Travis
     class Script
       class Ruby < Script
         DEFAULTS = {
-          rvm:     'default',
           gemfile: 'Gemfile'
         }
 

--- a/lib/travis/build/script/shared/chruby.rb
+++ b/lib/travis/build/script/shared/chruby.rb
@@ -4,7 +4,10 @@ module Travis
       module Chruby
         def setup
           super
-          setup_chruby if chruby?
+          if chruby?
+            sh.raw File.read(File.join(File.expand_path('templates', __FILE__.sub('.rb', '')), 'chruby.sh'))
+            setup_chruby
+          end
         end
 
         def announce
@@ -20,8 +23,6 @@ module Travis
 
           def setup_chruby
             sh.echo 'BETA: Using chruby to select Ruby version. This is currently a beta feature and may change at any time.', ansi: :yellow
-            sh.cmd 'curl -sLo ~/chruby.sh https://gist.githubusercontent.com/henrikhodne/a01cd7367b12a59ee051/raw/chruby.sh', echo: false
-            sh.cmd 'source ~/chruby.sh', echo: false
             sh.cmd "chruby #{config[:ruby]}", timing: true
           end
       end

--- a/lib/travis/build/script/shared/chruby.rb
+++ b/lib/travis/build/script/shared/chruby.rb
@@ -5,7 +5,7 @@ module Travis
         def setup
           super
           if chruby?
-            sh.raw File.read(File.join(File.expand_path('templates', __FILE__.sub('.rb', '')), 'chruby.sh'))
+            sh.raw File.read(File.join(File.expand_path('templates', __FILE__.sub('.rb', '')), 'chruby.sh')).untaint
             setup_chruby
           end
         end

--- a/lib/travis/build/script/shared/chruby.rb
+++ b/lib/travis/build/script/shared/chruby.rb
@@ -12,10 +12,6 @@ module Travis
           sh.cmd 'chruby --version' if chruby?
         end
 
-        def cache_slug
-          super.tap { |slug| slug << "--rvm-" << config[:ruby].to_s if chruby? }
-        end
-
         private
 
           def chruby?

--- a/lib/travis/build/script/shared/chruby/templates/chruby.sh
+++ b/lib/travis/build/script/shared/chruby/templates/chruby.sh
@@ -1,0 +1,156 @@
+CHRUBY_VERSION="0.3.8+travisci"
+RUBIES=(~/.rvm/rubies/*)
+
+function chruby_log()
+{
+	if [[ -t 1 ]]; then
+		echo -e "\x1b[1m\x1b[32m>>>\x1b[0m \x1b[1m$1\x1b[0m"
+	else
+		echo ">>> $1"
+	fi
+}
+
+function chruby_warn()
+{
+	if [[ -t 1 ]]; then
+		echo -e "\x1b[1m\x1b[33m***\x1b[0m \x1b[1m$1\x1b[0m" >&2
+	else
+		echo "*** $1" >&2
+	fi
+}
+
+function chruby_error()
+{
+	if [[ -t 1 ]]; then
+		echo -e "\x1b[1m\x1b[31m!!!\x1b[0m \x1b[1m$1\x1b[0m" >&2
+	else
+		echo "!!! $1" >&2
+	fi
+}
+
+
+
+function chruby_reset()
+{
+	[[ -z "$RUBY_ROOT" ]] && return
+
+	PATH=":$PATH:"; PATH="${PATH//:$RUBY_ROOT\/bin:/:}"
+
+	if (( $UID != 0 )); then
+		[[ -n "$GEM_HOME" ]] && PATH="${PATH//:$GEM_HOME\/bin:/:}"
+		[[ -n "$GEM_ROOT" ]] && PATH="${PATH//:$GEM_ROOT\/bin:/:}"
+
+		GEM_PATH=":$GEM_PATH:"
+		[[ -n "$GEM_HOME" ]] && GEM_PATH="${GEM_PATH//:$GEM_HOME:/:}"
+		[[ -n "$GEM_ROOT" ]] && GEM_PATH="${GEM_PATH//:$GEM_ROOT:/:}"
+		GEM_PATH="${GEM_PATH#:}"; GEM_PATH="${GEM_PATH%:}"
+		unset GEM_ROOT GEM_HOME
+		[[ -z "$GEM_PATH" ]] && unset GEM_PATH
+	fi
+
+	PATH="${PATH#:}"; PATH="${PATH%:}"
+	unset RUBY_ROOT RUBY_ENGINE RUBY_VERSION RUBYOPT
+	hash -r
+}
+
+function chruby_use()
+{
+	if [[ ! -x "$1/bin/ruby" ]]; then
+		echo "chruby: $1/bin/ruby not executable" >&2
+		return 1
+	fi
+
+	[[ -n "$RUBY_ROOT" ]] && chruby_reset
+
+	export RUBY_ROOT="$1"
+	export RUBYOPT="$2"
+	export PATH="$RUBY_ROOT/bin:$PATH"
+
+	eval "$("$RUBY_ROOT/bin/ruby" - <<EOF
+puts "export RUBY_ENGINE=#{defined?(RUBY_ENGINE) ? RUBY_ENGINE : 'ruby'};"
+puts "export RUBY_VERSION=#{RUBY_VERSION};"
+begin; require 'rubygems'; puts "export GEM_ROOT=#{Gem.default_dir.inspect};"; rescue LoadError; end
+EOF
+)"
+	# "
+
+	if (( $UID != 0 )); then
+		export GEM_HOME="$HOME/.gem/$RUBY_ENGINE/$RUBY_VERSION"
+		export GEM_PATH="$GEM_HOME${GEM_ROOT:+:$GEM_ROOT}${GEM_PATH:+:$GEM_PATH}"
+		export PATH="$GEM_HOME/bin${GEM_ROOT:+:$GEM_ROOT/bin}:$PATH"
+	fi
+}
+
+function chruby()
+{
+	if [[ "$1" == "--version" ]]; then
+		echo "chruby: $CHRUBY_VERSION"
+		return 0
+	fi
+
+	local dir match opts version
+	version="$1"
+
+	if [[ "$version" =~ -d19$ ]]; then
+		opts="--1.9"
+		version="${version%%-d19}"
+	elif [[ "$version" =~ -19mode$ ]]; then
+		opts="--1.9"
+		version="${version%%-19mode}"
+	elif [[ "$version" =~ -d18 ]]; then
+		opts="--1.8"
+		version="${version%%-d18}"
+	elif [[ "$version" =~ -18mode ]]; then
+		opts="--1.8"
+		version="${version%%-18mode}"
+	fi
+
+	for dir in "${RUBIES[@]}"; do
+		dir="${dir%%/}"
+		case "${dir##*/}" in
+			"$version")	match="$dir" && break ;;
+			*"$version"*)	match="$dir" ;;
+		esac
+	done
+
+	if [[ -z "$match" ]]; then
+                if [[ "$chruby_attempted_install" == "true" ]]; then
+                	chruby_error "unknown Ruby: $version"
+                        return 1
+                fi
+
+		chruby_log "Couldn't find Ruby $version, attempting download"
+
+                ruby="${version%%-*}"
+                ruby="${ruby:-ruby}"
+                version="${version#$ruby}"
+                version="${version#-}"
+
+		case "$ruby" in
+			rbx)
+
+				rbx_url="$(curl -s http://binaries.rubini.us/index.txt | grep ubuntu/12.04/x86_64/rubinius-$version | grep -e '\.tar\.bz2$' | tail -n1)"
+				wget -O- $rbx_url | tar -jx -C ~/.rvm/rubies
+				for d in ~/.rvm/rubies/rubinius/*; do
+					mv "$d" "$(dirname "${d/rubinius/rbx}")-$(basename "$d")"
+				done
+				rmdir ~/.rvm/rubies/rubinius
+				;;
+			jruby)
+				wget -O- http://jruby.org.s3.amazonaws.com/downloads/${version#*-}/jruby-bin-${version}.tar.gz | tar -zx -C ~/.rvm/rubies
+				ln -fs jruby ~/.rvm/rubies/jruby-${version#*-}/bin/ruby
+				;;
+			*)
+				wget -O- https://rubies.travis-ci.org/ubuntu/12.04/x86_64/$ruby-${version}.tar.bz2 | tar -jx -C ~/.rvm/rubies
+				;;
+		esac
+
+                RUBIES=(~/.rvm/rubies/*)
+                chruby_attempted_install=true chruby "$@"
+
+                chruby_log "Installing Rake and Bundler"
+                gem install bundler rake
+        else
+                chruby_use "$match" "$opts"
+        fi
+}

--- a/lib/travis/build/script/shared/chruby/templates/chruby.sh
+++ b/lib/travis/build/script/shared/chruby/templates/chruby.sh
@@ -121,8 +121,10 @@ function chruby()
 
 		chruby_log "Couldn't find Ruby $version, attempting download"
 
-                ruby="${version%%-*}"
-                ruby="${ruby:-ruby}"
+                ruby="${version%%-*}" # remove trailing '-*'
+                if [[ $ruby == $version ]]; then
+                	ruby='ruby'
+                fi
                 version="${version#$ruby}"
                 version="${version#-}"
 
@@ -141,7 +143,7 @@ function chruby()
 				ln -fs jruby ~/.rvm/rubies/jruby-${version#*-}/bin/ruby
 				;;
 			*)
-				wget -O- https://rubies.travis-ci.org/ubuntu/12.04/x86_64/$ruby-${version}.tar.bz2 | tar -jx -C ~/.rvm/rubies
+				wget -O- https://rubies.travis-ci.org/$(lsb_release -is | tr 'A-Z' 'a-z')/$(lsb_release -rs)/$(uname -m)/$ruby-${version}.tar.bz2 | tar -jx -C ~/.rvm/rubies
 				;;
 		esac
 

--- a/lib/travis/build/script/shared/chruby/templates/chruby.sh
+++ b/lib/travis/build/script/shared/chruby/templates/chruby.sh
@@ -109,7 +109,11 @@ function chruby()
 		dir="${dir%%/}"
 		case "${dir##*/}" in
 			"$version")	match="$dir" && break ;;
-			*"$version"*)	match="$dir" ;;
+			*"$version"*)
+				if [[ $match_exact == "false" ]]; then
+					match="$dir"
+				fi
+				;;
 		esac
 	done
 
@@ -148,7 +152,7 @@ function chruby()
 		esac
 
                 RUBIES=(~/.rvm/rubies/*)
-                chruby_attempted_install=true chruby "$@"
+                chruby_attempted_install=true match_exact=false chruby "$@"
 
                 chruby_log "Installing Rake and Bundler"
                 gem install bundler rake

--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -20,7 +20,7 @@ module Travis
         def export
           super
           # for now, we take the rvm key if both are defined
-          # see also:`#version` and `#version_manager`
+          # see also:`#version` and `#cache_name_component`
           if rvm?
             sh.export 'TRAVIS_RUBY_VERSION', config[:rvm], echo: false
           elsif config[:ruby]
@@ -42,7 +42,7 @@ module Travis
         end
 
         def cache_slug
-          super.tap { |slug| slug << "--#{version_manager}-" << ruby_version.to_s }
+          super.tap { |slug| slug << "--#{cache_name_component}-" << ruby_version.to_s }
         end
 
         private
@@ -126,11 +126,11 @@ module Travis
             sh.cmd "rvm autolibs disable", echo: false, timing: false
           end
 
-          def version_manager
+          def cache_name_component
             if rvm?
               'rvm'
             elsif chruby?
-              'chruby'
+              'ruby'
             else
               'rvm'
             end

--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -42,7 +42,7 @@ module Travis
         end
 
         def cache_slug
-          super.tap { |slug| slug << "--#{version_manager}-" << ruby_version.to_s unless chruby? }
+          super.tap { |slug| slug << "--#{version_manager}-" << ruby_version.to_s }
         end
 
         private
@@ -51,7 +51,7 @@ module Travis
             if rvm?
               config[:rvm].to_s
             elsif chruby?
-              config[:chruby].to_s
+              config[:ruby].to_s
             else
               DEFALUT_VERSION
             end

--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -15,7 +15,7 @@ module Travis
           rvm_remote_server_verify_downloads3=1
         )
 
-        DEFALUT_VERSION = 'default'
+        DEFAULT_VERSION = 'default'
 
         def export
           super
@@ -26,7 +26,7 @@ module Travis
           elsif config[:ruby]
             sh.export 'TRAVIS_RUBY_VERSION', config[:ruby], echo: false
           else
-            sh.export 'TRAVIS_RUBY_VERSION', DEFALUT_VERSION, echo: false
+            sh.export 'TRAVIS_RUBY_VERSION', DEFAULT_VERSION, echo: false
           end
         end
 
@@ -53,7 +53,7 @@ module Travis
             elsif chruby?
               config[:ruby].to_s
             else
-              DEFALUT_VERSION
+              DEFAULT_VERSION
             end
           end
 

--- a/spec/build/script/ruby_spec.rb
+++ b/spec/build/script/ruby_spec.rb
@@ -80,25 +80,25 @@ describe Travis::Build::Script::Ruby, :sexp do
 
       describe 'default' do
         subject { script.cache_slug }
-        it { is_expected.to eq('cache--chruby-2.1.1--gemfile-Gemfile') }
+        it { is_expected.to eq('cache--ruby-2.1.1--gemfile-Gemfile') }
       end
 
       describe 'with custom gemfile' do
         before { data[:config][:gemfile] = 'Gemfile.ci' }
         subject { script.cache_slug }
-        it { is_expected.to eq('cache--chruby-2.1.1--gemfile-Gemfile.ci') }
+        it { is_expected.to eq('cache--ruby-2.1.1--gemfile-Gemfile.ci') }
       end
 
       describe 'with custom ruby version' do
         before { data[:config][:ruby] = 'jruby' }
         subject { script.cache_slug }
-        it { is_expected.to eq('cache--chruby-jruby--gemfile-Gemfile') }
+        it { is_expected.to eq('cache--ruby-jruby--gemfile-Gemfile') }
       end
 
       describe 'with custom jdk version' do
         before { data.deep_merge!(config: { ruby: 'jruby', jdk: 'openjdk7' }) }
         subject { script.cache_slug }
-        it { is_expected.to eq('cache--jdk-openjdk7--chruby-jruby--gemfile-Gemfile') }
+        it { is_expected.to eq('cache--jdk-openjdk7--ruby-jruby--gemfile-Gemfile') }
       end
     end
   end

--- a/spec/build/script/ruby_spec.rb
+++ b/spec/build/script/ruby_spec.rb
@@ -50,7 +50,7 @@ describe Travis::Build::Script::Ruby, :sexp do
     end
   end
 
-  describe 'uses chruby if config has a :ruby key set' do
+  context 'config has a :ruby key set' do
     before do
       config[:ruby] = '2.1.1'
     end
@@ -73,6 +73,33 @@ describe Travis::Build::Script::Ruby, :sexp do
 
     it 'does not announce rvm version' do
       should_not include_sexp [:cmd, 'rvm --version', echo: true]
+    end
+
+    describe '#cache_slug' do
+      let(:script) { described_class.new(data) }
+
+      describe 'default' do
+        subject { script.cache_slug }
+        it { is_expected.to eq('cache--chruby-2.1.1--gemfile-Gemfile') }
+      end
+
+      describe 'with custom gemfile' do
+        before { data[:config][:gemfile] = 'Gemfile.ci' }
+        subject { script.cache_slug }
+        it { is_expected.to eq('cache--chruby-2.1.1--gemfile-Gemfile.ci') }
+      end
+
+      describe 'with custom ruby version' do
+        before { data[:config][:ruby] = 'jruby' }
+        subject { script.cache_slug }
+        it { is_expected.to eq('cache--chruby-jruby--gemfile-Gemfile') }
+      end
+
+      describe 'with custom jdk version' do
+        before { data.deep_merge!(config: { ruby: 'jruby', jdk: 'openjdk7' }) }
+        subject { script.cache_slug }
+        it { is_expected.to eq('cache--jdk-openjdk7--chruby-jruby--gemfile-Gemfile') }
+      end
     end
   end
 

--- a/spec/build/script/ruby_spec.rb
+++ b/spec/build/script/ruby_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Travis::Build::Script::Ruby, :sexp do
-  let(:config) { { rvm: 'default', gemfile: 'Gemfile' } }
+  let(:config) { { gemfile: 'Gemfile' } }
   let(:data)   { payload_for(:push, :ruby, :config => config) }
   let(:script) { described_class.new(data) }
   subject      { script.sexp }
@@ -52,7 +52,7 @@ describe Travis::Build::Script::Ruby, :sexp do
 
   describe 'uses chruby if config has a :ruby key set' do
     before do
-      data[:config][:ruby] = '2.1.1'
+      config[:ruby] = '2.1.1'
     end
 
     it 'announces the chruby version' do
@@ -60,8 +60,19 @@ describe Travis::Build::Script::Ruby, :sexp do
     end
 
     it 'uses chruby to set the version' do
-      # should include_sexp [:cmd, 'chruby 2.1.1', assert: true, echo: true]
       should include_sexp [:cmd, 'chruby 2.1.1', assert: true, echo: true, timing: true]
+    end
+
+    it 'sets TRAVIS_RUBY_VERSION' do
+      should include_sexp [:export, ['TRAVIS_RUBY_VERSION', '2.1.1']]
+    end
+
+    it 'does not invoke rvm use' do
+      should_not include_sexp [:cmd, "rvm use default", {:assert=>true, :echo=>true, :timing=>true}]
+    end
+
+    it 'does not announce rvm version' do
+      should_not include_sexp [:cmd, 'rvm --version', echo: true]
     end
   end
 

--- a/spec/build/script/ruby_spec.rb
+++ b/spec/build/script/ruby_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe Travis::Build::Script::Ruby, :sexp do
-  let(:data)   { payload_for(:push, :ruby) }
+  let(:config) { { rvm: 'default', gemfile: 'Gemfile' } }
+  let(:data)   { payload_for(:push, :ruby, :config => config) }
   let(:script) { described_class.new(data) }
   subject      { script.sexp }
   it           { store_example }


### PR DESCRIPTION
This PR adds a few improvements in consistency when `ruby` key is set in `.travis.yml` (i.e., the user wishes to use chruby to mange Ruby runtimes), especially when both `ruby` and `rvm` keys are present.

The `rvm` key is removed from `DEFAULT`, so that the Ruby version is set up correctly when `ruby` is present.

Note also the new cache naming scheme: `chruby` is used instead of `rvm`.