### PR TITLE
Always convert julia: setting to string

### DIFF
--- a/lib/travis/build/script/julia.rb
+++ b/lib/travis/build/script/julia.rb
@@ -93,7 +93,7 @@ module Travis
               osarch = 'osx/x64'
               ext = "#{status}.dmg"
             end
-            case config[:julia]
+            case config[:julia].to_s
             when 'release'
               url = "status.julialang.org/stable/#{status}"
             when 'nightly'


### PR DESCRIPTION
Otherwise un-quoted `0.3` gives an "Unknown Julia version," whoops.

ref https://github.com/travis-ci/docs-travis-ci-com/pull/314#issuecomment-125992331