### PR TITLE
Run 'phpenv rehash' after setting up

### DIFF
--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -24,6 +24,7 @@ module Travis
             install_php_on_demand(version)
             sh.cmd "phpenv global #{version}", assert: true
           end
+          sh.cmd "phpenv rehash", assert: false, echo: false, timing: false
         end
 
         def announce

--- a/spec/build/script/php_spec.rb
+++ b/spec/build/script/php_spec.rb
@@ -19,6 +19,7 @@ describe Travis::Build::Script::Php, :sexp do
 
   it 'sets up the php version' do
     should include_sexp [:cmd, 'phpenv global 5.5 2>/dev/null', echo: true, timing: true]
+    should include_sexp [:cmd, 'phpenv rehash']
   end
 
   it 'announces php --version' do


### PR DESCRIPTION
Fixes https://github.com/travis-ci/travis-ci/issues/4593 by running `phpenv rehash` after expanding the archive.

Tested on staging: https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/434582

The 5.5 and 5.6 jobs failed to find `phpdbg`. `phpdbg` is supposed to be a part of 5.6 core, but I am not really sure if this is something to be concerned.

