### PR TITLE
Fix for the Sauce Labs addon

### DIFF
--- a/lib/travis/build/addons/sauce_connect.rb
+++ b/lib/travis/build/addons/sauce_connect.rb
@@ -16,15 +16,15 @@ module Travis
           sh.export 'SAUCE_ACCESS_KEY', access_key, echo: false if access_key
 
           if direct_domains
-            sh.export 'SAUCE_DIRECT_DOMAINS', "-D #{direct_domains}", echo: false
+            sh.export 'SAUCE_DIRECT_DOMAINS', "'-D #{direct_domains}'", echo: false
           end
 
           if no_ssl_bump_domains
-            sh.export 'SAUCE_NO_SSL_BUMP_DOMAINS', "-B #{no_ssl_bump_domains}", echo: false
+            sh.export 'SAUCE_NO_SSL_BUMP_DOMAINS', "'-B #{no_ssl_bump_domains}'", echo: false
           end
 
           if tunnel_domains
-            sh.export 'SAUCE_TUNNEL_DOMAINS', "-t #{tunnel_domains}", echo: false
+            sh.export 'SAUCE_TUNNEL_DOMAINS', "'-t #{tunnel_domains}'", echo: false
           end
 
           sh.fold 'sauce_connect.start' do

--- a/spec/build/addons/sauce_connect_spec.rb
+++ b/spec/build/addons/sauce_connect_spec.rb
@@ -41,9 +41,9 @@ describe Travis::Build::Addons::SauceConnect, :sexp do
   describe 'with domain arguments' do
     let(:config) { { :direct_domains => 'travis-ci.org', :no_ssl_bump_domains=> 'travis-ci.org', :tunnel_domains => 'localhost' } }
 
-    it { should include_sexp [:export, ['SAUCE_DIRECT_DOMAINS', '-D travis-ci.org']] }
-    it { should include_sexp [:export, ['SAUCE_NO_SSL_BUMP_DOMAINS', '-B travis-ci.org']] }
-    it { should include_sexp [:export, ['SAUCE_TUNNEL_DOMAINS', '-t localhost']] }
+    it { should include_sexp [:export, ['SAUCE_DIRECT_DOMAINS', "'-D travis-ci.org'"]] }
+    it { should include_sexp [:export, ['SAUCE_NO_SSL_BUMP_DOMAINS', "'-B travis-ci.org'"]] }
+    it { should include_sexp [:export, ['SAUCE_TUNNEL_DOMAINS', "'-t localhost'"]] }
 
     it_behaves_like 'starts sauce connect'
     it { store_example }


### PR DESCRIPTION
When using the additional options in the Sauce Labs addon, I was getting the following error message:
/home/travis/build.sh: line 490: export: `*.travis.salesfloor.net': not a valid identifier

Looking at the source code, I found that it is caused by the following command being run:
export SAUCE_TUNNEL_DOMAINS=-t *.travis.salesfloor.net

The issue is because of the space and the fact that the string is not enclosed, therefore the domain is considered a new identifier and is therefore not valid.