### PR TITLE
Tweak Builder's failure method to fail the build.

### DIFF
--- a/lib/travis/shell/builder.rb
+++ b/lib/travis/shell/builder.rb
@@ -84,6 +84,7 @@ module Travis
       def failure(message)
         export 'TRAVIS_CMD', 'no_script', echo: false
         echo message
+        raw 'set -e'
         raw 'false'
       end
 


### PR DESCRIPTION
Currently, calling `sh.failure` in one of the per-language scripts will not
actually fail the build; instead, `false` will be called, and execution will
happily continue (unless `set -e` has been called earlier in the script).

Based on the uses in existing per-language scripts, `sh.failure` only seems to
be called when someone wants to fail the build. I think the fact that this
doesn't actually fail is unexpected.

I'm happy to tweak the method of forcing a build failure -- but most other
options I cooked up (eg switching to `cmd 'false', assert: true, timing:
false, echo: false`) end up with a possibly-confusing failure message.

This will finally fix travis-ci/travis-ci#4133, among others.

PTAL @BanzaiMan @svenfuchs -- Sven, I think you wrote this code originally, so if I'm totally off-base about the original intention, just say so.