### PR TITLE
Rearrange Go build steps

### DIFF
--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -41,7 +41,6 @@ module Travis
         end
 
         def setup
-          super
           sh.cmd %Q'eval "$(gimme #{go_version})"'
 
           # NOTE: $GOPATH is a plural ":"-separated var a la $PATH.  We export
@@ -56,6 +55,12 @@ module Travis
 
           sh.export "TRAVIS_BUILD_DIR", "#{HOME_DIR}/gopath/src/#{data.source_host}/#{data.slug}"
           sh.cd "#{HOME_DIR}/gopath/src/#{data.source_host}/#{data.slug}", assert: true
+
+          # Defer setting up cache until we have changed directories, so that
+          # cache.directories can be properly resolved relative to the directory
+          # in which the user-controlled portion of the build starts
+          # See https://github.com/travis-ci/travis-ci/issues/3055
+          super
         end
 
         def install

--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -53,8 +53,6 @@ module Travis
           sh.mkdir "#{HOME_DIR}/gopath/src/#{go_import_path}", recursive: true, assert: false, timing: false
           sh.cmd "rsync -az ${TRAVIS_BUILD_DIR}/ #{HOME_DIR}/gopath/src/#{go_import_path}/", assert: false, timing: false
 
-          sh.export "TRAVIS_BUILD_DIR", "#{HOME_DIR}/gopath/src/#{data.source_host}/#{data.slug}"
-          sh.cd "#{HOME_DIR}/gopath/src/#{data.source_host}/#{data.slug}", assert: true
           sh.export "TRAVIS_BUILD_DIR", "#{HOME_DIR}/gopath/src/#{go_import_path}"
           sh.cd "#{HOME_DIR}/gopath/src/#{go_import_path}", assert: true
 


### PR DESCRIPTION
Resolves https://github.com/travis-ci/travis-ci/issues/3055

We defer setting up cache until Go's quirky `cd` call has been executed.