### PR TITLE
[haxe] fixed mac builds

### DIFF
--- a/lib/travis/build/script/haxe.rb
+++ b/lib/travis/build/script/haxe.rb
@@ -58,7 +58,14 @@ module Travis
             sh.cmd %Q{curl -s -L --retry 3 '#{neko_url}' } \
                    '| tar -C ~/neko -x -z --strip-components=1 -f -'
             sh.cmd 'export NEKOPATH="${HOME}/neko"' # required by `nekotools boot ...`
-            sh.cmd 'export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${NEKOPATH}"' # for loading libneko.so
+            case config[:os]
+            when 'linux'
+              # for loading libneko.so
+              sh.cmd 'export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${NEKOPATH}"'
+            when 'osx'
+              # for loading libneko.dylib
+              sh.cmd 'export DYLD_FALLBACK_LIBRARY_PATH="${DYLD_FALLBACK_LIBRARY_PATH}:${NEKOPATH}"'
+            end
             sh.cmd 'export PATH="${PATH}:${NEKOPATH}"'
           end
 
@@ -108,7 +115,7 @@ module Travis
             when 'linux'
               os = 'linux64'
             when 'osx'
-              os = 'osx'
+              os = 'osx64'
             end
             version = config[:neko]
             "http://nekovm.org/_media/neko-#{version}-#{os}.tar.gz"


### PR DESCRIPTION
 * the haxe binaries are 64bit, so install 64bit neko
 * add $NEKOPATH to $DYLD_FALLBACK_LIBRARY_PATH, such that libneko.dylib can be loaded