### PR TITLE
Add a means to test dpl from github

### DIFF
--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -108,20 +108,7 @@ module Travis
 
             def install(edge = config[:edge])
               if edge.respond_to? :fetch
-                begin
-                  owner  = 'travis-ci'
-                  repo   = 'dpl'
-                  branch = edge.fetch(:branch, 'master')
-
-                  sh.cmd("git clone https://github.com/#{owner}/#{repo}", echo: false, assert: !allow_failure, timing: true)
-                  sh.cmd("cd dpl",                                        echo: false, assert: !allow_failure, timing: true)
-                  sh.cmd("git checkout #{branch}",                        echo: false, assert: !allow_failure, timing: true)
-                  cmd("gem build dpl.gemspec",                            echo: false, assert: !allow_failure, timing: true)
-                  sh.cmd("mv dpl-*.gem ..",                               echo: false, assert: !allow_failure, timing: true)
-                  sh.cmd("cd ..",                                         echo: false, assert: !allow_failure, timing: true)
-                ensure
-                  sh.cmd("test -e dpl && rm -rf dpl", echo: false, assert: false, timing: true)
-                end
+                deploy_with_branch(edge.fetch(:branch, 'master'))
               end
               command = "gem install dpl"
               command << "-*.gem --local" if edge == 'local' || edge.respond_to?(:fetch)
@@ -167,6 +154,20 @@ module Travis
 
             def negate_condition(conditions)
               Array(conditions).flatten.compact.map { |condition| " ! #{condition}" }.join(" && ")
+            end
+
+            def deploy_with_branch(branch)
+              owner  = 'travis-ci'
+              repo   = 'dpl'
+
+              sh.cmd("git clone https://github.com/#{owner}/#{repo}", echo: false, assert: !allow_failure, timing: true)
+              sh.cmd("cd dpl",                                        echo: false, assert: !allow_failure, timing: true)
+              sh.cmd("git checkout #{branch}",                        echo: false, assert: !allow_failure, timing: true)
+              cmd("gem build dpl.gemspec",                            echo: false, assert: !allow_failure, timing: true)
+              sh.cmd("mv dpl-*.gem ..",                               echo: false, assert: !allow_failure, timing: true)
+              sh.cmd("cd ..",                                         echo: false, assert: !allow_failure, timing: true)
+            ensure
+              sh.cmd("test -e dpl && rm -rf dpl", echo: false, assert: false, timing: true)
             end
         end
       end

--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -157,8 +157,8 @@ module Travis
             end
 
             def build_gem_locally_from(source, branch)
-              sh.echo "Building dpl gem locally", ansi: :yellow
-              sh.cmd("pushd $TMPDIR",                          echo: false, assert: !allow_failure, timing: true)
+              sh.echo "Building dpl gem locally with source #{source} and branch #{branch}", ansi: :yellow
+              sh.cmd("pushd /tmp",                             echo: false, assert: !allow_failure, timing: true)
               sh.cmd("git clone https://github.com/#{source}", echo: false, assert: !allow_failure, timing: true)
               sh.cmd("cd dpl",                                 echo: false, assert: !allow_failure, timing: true)
               sh.cmd("git checkout #{branch}",                 echo: false, assert: !allow_failure, timing: true)
@@ -166,7 +166,7 @@ module Travis
               sh.cmd("mv dpl-*.gem $TRAVIS_BUILD_DIR",         echo: false, assert: !allow_failure, timing: true)
               sh.cmd("popd",                                   echo: false, assert: !allow_failure, timing: true)
             ensure
-              sh.cmd("test -e dpl && rm -rf dpl", echo: false, assert: false, timing: true)
+              sh.cmd("test -e /tmp/dpl && rm -rf dpl", echo: false, assert: false, timing: true)
             end
         end
       end


### PR DESCRIPTION
With the following in .travis.yml:

```yaml
deploy:
  provider: X
  edge:
    source: myown/dpl # defaults to 'travis-ci/dpl'
    branch: foo  # defaults to 'master'
  ⋮
```

we will build and install dpl gem from
the branch 'foo' of https://github.com/myown/dpl.

This allows more flexible testing of dpl PRs without merging
them to the master branch.