### PR TITLE
Add a configurable "import path" for Go builds

### DIFF
--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -51,11 +51,11 @@ module Travis
           sh.export 'GOPATH', "#{HOME_DIR}/gopath", echo: true
           sh.export 'PATH', "#{HOME_DIR}/gopath/bin:$PATH", echo: true
 
-          sh.mkdir "#{HOME_DIR}/gopath/src/#{data.source_host}/#{data.slug}", recursive: true, assert: false, timing: false
-          sh.cmd "rsync -az ${TRAVIS_BUILD_DIR}/ #{HOME_DIR}/gopath/src/#{data.source_host}/#{data.slug}/", assert: false, timing: false
+          sh.mkdir "#{HOME_DIR}/gopath/src/#{go_import_path}", recursive: true, assert: false, timing: false
+          sh.cmd "rsync -az ${TRAVIS_BUILD_DIR}/ #{HOME_DIR}/gopath/src/#{go_import_path}/", assert: false, timing: false
 
-          sh.export "TRAVIS_BUILD_DIR", "#{HOME_DIR}/gopath/src/#{data.source_host}/#{data.slug}"
-          sh.cd "#{HOME_DIR}/gopath/src/#{data.source_host}/#{data.slug}", assert: true
+          sh.export "TRAVIS_BUILD_DIR", "#{HOME_DIR}/gopath/src/#{go_import_path}"
+          sh.cd "#{HOME_DIR}/gopath/src/#{go_import_path}", assert: true
         end
 
         def install
@@ -100,6 +100,10 @@ module Travis
 
           def gobuild_args
             config[:gobuild_args]
+          end
+
+          def go_import_path
+            config[:go_import_path] || "#{data.source_host}/#{data.slug}"
           end
 
           def go_version


### PR DESCRIPTION
Wasn't sure what to name this new configuration option...  The `gobuild_args` has me confused because it seems like it should really be either `gobuildargs` or `go_build_args`.

I'm definitely more than happy to rebase/amend as desired though!

As for what this enables, it's most useful for "vanity import paths" (like [`pault.ag/go/debian`](http://pault.ag/go/debian) and `golang.org/x/net`, for example).  For repos that specify it, this will also smooth out forks running tests on the forked repo, since they'll be put into the proper import path so imports between packages in the same repo will work properly without modification.

This could also be expanded to use `go list` to check for https://golang.org/s/go14customimport and use that if no configuration is supplied (ie, something like `go list -e -f '{{.ImportComment}}'`).