### PR TITLE
Use "gobuild_args" method consistently

### DIFF
--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -75,7 +75,7 @@ module Travis
             sh.cmd 'true', retry: true, fold: 'install' # TODO instead negate the condition
           end
           sh.else do
-            sh.cmd "#{go_get_cmd} #{config[:gobuild_args]} ./...", retry: true, fold: 'install'
+            sh.cmd "#{go_get_cmd} #{gobuild_args} ./...", retry: true, fold: 'install'
           end
         end
 
@@ -84,7 +84,7 @@ module Travis
             sh.cmd 'make'
           end
           sh.else do
-            sh.cmd "go test #{config[:gobuild_args]} ./..."
+            sh.cmd "go test #{gobuild_args} ./..."
           end
         end
 


### PR DESCRIPTION
While working on #508 (and https://github.com/travis-ci/docs-travis-ci-com/pull/346) I noticed there was a method for `gobuild_args` that wasn't being used.  I've updated it here to be used instead of grabbing the `config` directly, but I'd also be happy to update this to just remove the method if you'd rather. :+1: