### PR TITLE
Look for BUNDLE_GEMFILE if it's defined

### DIFF
--- a/lib/travis/build/script/shared/bundler.rb
+++ b/lib/travis/build/script/shared/bundler.rb
@@ -46,11 +46,11 @@ module Travis
         private
 
           def gemfile?
-            "-f #{config[:gemfile]}"
+            "-f ${BUNDLE_GEMFILE:-#{config[:gemfile]}}"
           end
 
           def gemfile_lock?
-            "-f #{config[:gemfile]}.lock"
+            "-f ${BUNDLE_GEMFILE:-#{config[:gemfile]}}.lock"
           end
 
           def gemfile_path(*path)

--- a/spec/build/script/objective_c_spec.rb
+++ b/spec/build/script/objective_c_spec.rb
@@ -67,7 +67,7 @@ describe Travis::Build::Script::ObjectiveC, :sexp do
 
   describe 'install' do
     it 'runs bundle install if the project is a RubyMotion project' do
-      sexp = sexp_find(sexp_filter(subject, [:if, '-f Gemfile'])[1], [:then])
+      sexp = sexp_find(sexp_filter(subject, [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}"])[1], [:then])
       expect(sexp).to include_sexp [:cmd, 'bundle install --jobs=3 --retry=3', echo: true, timing: true, assert: true, retry: true]
     end
 

--- a/spec/build/script/ruby_spec.rb
+++ b/spec/build/script/ruby_spec.rb
@@ -65,7 +65,7 @@ describe Travis::Build::Script::Ruby, :sexp do
   end
 
   it 'sets BUNDLE_GEMFILE if a gemfile exists' do
-    sexp = sexp_find(subject, [:if, '-f Gemfile'], [:then])
+    sexp = sexp_find(subject, [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}"], [:then])
     expect(sexp).to include_sexp [:export, ['BUNDLE_GEMFILE', '$PWD/Gemfile'], echo: true]
   end
 
@@ -88,24 +88,24 @@ describe Travis::Build::Script::Ruby, :sexp do
 
   describe 'install' do
     it 'runs bundle install --deployment if there is a Gemfile and a Gemfile.lock' do
-      sexp = sexp_find(sexp_filter(subject, [:if, '-f Gemfile'])[1], [:if, '-f Gemfile.lock'], [:then])
+      sexp = sexp_find(sexp_filter(subject, [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}"])[1], [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}.lock"], [:then])
       expect(sexp).to include_sexp [:cmd, 'bundle install --jobs=3 --retry=3 --deployment', assert: true, echo: true, timing: true, retry: true]
     end
 
     it "runs bundle install if a Gemfile exists" do
-      sexp = sexp_find(sexp_filter(subject, [:if, '-f Gemfile'])[1], [:if, '-f Gemfile.lock'], [:else])
+      sexp = sexp_find(sexp_filter(subject, [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}"])[1], [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}.lock"], [:else])
       should include_sexp [:cmd, 'bundle install --jobs=3 --retry=3', assert: true, echo: true, timing: true, retry: true]
     end
   end
 
   describe 'script' do
     it 'runs bundle exec rake if a gemfile exists' do
-      sexp = sexp_find(subject, [:if, '-f Gemfile'], [:then])
+      sexp = sexp_find(subject, [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}"], [:then])
       should include_sexp [:cmd, 'bundle exec rake', echo: true, timing: true]
     end
 
     it 'runs rake if a gemfile does not exist' do
-      sexp = sexp_find(subject, [:if, '-f Gemfile'], [:else])
+      sexp = sexp_find(subject, [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}"], [:else])
       should include_sexp [:cmd, 'rake', echo: true, timing: true]
     end
   end


### PR DESCRIPTION
When looking for Gemfile, consult `$BUNDLE_GEMFILE` first,
which is an absolute path if it is set.

This sidesteps the issue if the build changes working directory
when we do not expect (e.g., in before_install).

A simple test case (assume files exist):

```yaml
language: ruby
gemfile: path/to/Gemfile
before_install: cd $(dirname $BUNDLE_GEMFILE)
script: ./test.sh
```

This has been tested on staging:

Before: https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/435418
After: https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/435420#L97 (Note that Gemfile is found, and `bundle install` is run.)