### PR TITLE
workaround for rakudobrew interface changes

### DIFF
--- a/lib/travis/build/script/perl6.rb
+++ b/lib/travis/build/script/perl6.rb
@@ -26,7 +26,7 @@ module Travis
           sh.echo 'and cc @paultcochrane, @hoelzro, @ugexe, and @tony-o', ansi: :red
 
           sh.echo 'Installing Rakudo (MoarVM)', ansi: :yellow
-          sh.cmd 'git clone https://github.com/tadzik/rakudobrew.git $HOME/.rakudobrew'
+          sh.cmd 'git clone -b compat https://github.com/tadzik/rakudobrew.git $HOME/.rakudobrew'
           sh.export 'PATH', '$HOME/.rakudobrew/bin:$PATH', echo: false
         end
 


### PR DESCRIPTION
rakudobrew's interface has changed and no longer works using the current setup. Until someone has time to test a different rakudobrew installation or a switch to a `Configure.pl` based builder (with only a few extra lines), this will keep Perl6 Travis-CI runs from failing by using a branch containing the now defunct version.