### PR TITLE
Update HHVM on Precise

### DIFF
--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -74,12 +74,24 @@ module Travis
         end
 
         def configure_hhvm
-          install_hhvm_nightly if nightly?
+          if nightly?
+            install_hhvm_nightly
+          elsif hhvm?
+            update_hhvm
+          end
           fix_hhvm_php_ini
         end
 
+        def update_hhvm
+          sh.if '"$(lsb_release -sc &> /dev/null)" = "precise"' do
+            sh.echo 'Updating HHVM', ansi: :yellow
+            sh.cmd 'sudo apt-get update -qq'
+            sh.cmd 'sudo apt-get install hhvm 2>&1 >/dev/null'
+          end
+        end
+
         def install_hhvm_nightly
-          sh.if '$(lsb_release -sc) = "precise"' do
+          sh.if '"$(lsb_release -sc &> /dev/null)" = "precise"' do
             sh.echo "HHVM nightly is no longer supported on Ubuntu Precise. See https://github.com/travis-ci/travis-ci/issues/3788 and https://github.com/facebook/hhvm/issues/5220", ansi: :yellow
             sh.raw "travis_terminate 1"
           end

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -83,7 +83,7 @@ module Travis
         end
 
         def update_hhvm
-          sh.if '"$(lsb_release -sc &> /dev/null)" = "precise"' do
+          sh.if '"$(lsb_release -sc 2>/dev/null)" = "precise"' do
             sh.echo 'Updating HHVM', ansi: :yellow
             sh.cmd 'sudo apt-get update -qq'
             sh.cmd 'sudo apt-get install hhvm 2>&1 >/dev/null'
@@ -91,7 +91,7 @@ module Travis
         end
 
         def install_hhvm_nightly
-          sh.if '"$(lsb_release -sc &> /dev/null)" = "precise"' do
+          sh.if '"$(lsb_release -sc 2>/dev/null)" = "precise"' do
             sh.echo "HHVM nightly is no longer supported on Ubuntu Precise. See https://github.com/travis-ci/travis-ci/issues/3788 and https://github.com/facebook/hhvm/issues/5220", ansi: :yellow
             sh.raw "travis_terminate 1"
           end


### PR DESCRIPTION
Since our support on Precise is ending, we do not have a chance to update HHVM to anything newer than 3.5 that we currently have.

HHVM has terminated [Precise support at 3.6.x](https://github.com/facebook/hhvm/wiki/Prebuilt-Packages-on-Ubuntu-12.04), so we handle this special case.

On future releases and OS X, we do not update HHVM, as we assume that it is reasonably up-to-date.