### PR TITLE
Introduce a new build stage "setup_cache"

### DIFF
--- a/lib/travis/build/script/c.rb
+++ b/lib/travis/build/script/c.rb
@@ -27,8 +27,7 @@ module Travis
           super << '--compiler-' << compiler
         end
 
-        def install
-          super
+        def setup_cache
           if data.cache?(:ccache)
             directory_cache.add('~/.ccache')
           end

--- a/lib/travis/build/script/c.rb
+++ b/lib/travis/build/script/c.rb
@@ -27,6 +27,11 @@ module Travis
           super << '--compiler-' << compiler
         end
 
+        def setup
+          super
+          setup_cache
+        end
+
         def setup_cache
           if data.cache?(:ccache)
             directory_cache.add('~/.ccache')

--- a/lib/travis/build/script/cpp.rb
+++ b/lib/travis/build/script/cpp.rb
@@ -25,8 +25,7 @@ module Travis
           super << '--compiler-' << compiler.tr('+', 'p')
         end
 
-        def install
-          super
+        def setup_cache
           if data.cache?(:ccache)
             directory_cache.add('~/.ccache')
           end

--- a/lib/travis/build/script/cpp.rb
+++ b/lib/travis/build/script/cpp.rb
@@ -25,6 +25,11 @@ module Travis
           super << '--compiler-' << compiler.tr('+', 'p')
         end
 
+        def setup
+          super
+          setup_cache
+        end
+
         def setup_cache
           if data.cache?(:ccache)
             directory_cache.add('~/.ccache')

--- a/lib/travis/build/script/objective_c.rb
+++ b/lib/travis/build/script/objective_c.rb
@@ -44,10 +44,16 @@ module Travis
           sh.cmd 'chmod +x /usr/local/bin/actool', echo: false
         end
 
-        def install
+        def setup_cache
           super
           sh.if podfile? do
             directory_cache.add("#{pod_dir}/Pods") if data.cache?(:cocoapods)
+          end
+        end
+
+        def install
+          super
+          sh.if podfile? do
             sh.if "! ([[ -f #{pod_dir}/Podfile.lock && -f #{pod_dir}/Pods/Manifest.lock ]] && cmp --silent #{pod_dir}/Podfile.lock #{pod_dir}/Pods/Manifest.lock)", raw: true do
               sh.fold('install.cocoapods') do
                 sh.echo "Installing Pods with 'pod install'", ansi: :yellow

--- a/lib/travis/build/script/objective_c.rb
+++ b/lib/travis/build/script/objective_c.rb
@@ -40,6 +40,7 @@ module Travis
 
         def setup
           super
+          setup_cache
           sh.cmd "echo '#!/bin/bash\n# no-op' > /usr/local/bin/actool", echo: false
           sh.cmd 'chmod +x /usr/local/bin/actool', echo: false
         end

--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -29,6 +29,7 @@ module Travis
 
         def setup
           super
+          setup_cache
           sh.cmd "source #{virtualenv_activate}"
         end
 

--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -37,10 +37,13 @@ module Travis
           sh.cmd 'pip --version'
         end
 
-        def install
+        def setup_cache
           if data.cache?(:pip)
             directory_cache.add '$HOME/.cache/pip'
           end
+        end
+
+        def install
           sh.if '-f Requirements.txt' do
             sh.cmd 'pip install -r Requirements.txt', fold: 'install', retry: true
           end

--- a/lib/travis/build/script/shared/bundler.rb
+++ b/lib/travis/build/script/shared/bundler.rb
@@ -21,7 +21,7 @@ module Travis
           sh.cmd 'bundle --version'
         end
 
-        def install
+        def setup_cache
           sh.if gemfile? do
             sh.if gemfile_lock? do
               directory_cache.add(bundler_path(false)) if data.cache?(:bundler)

--- a/lib/travis/build/script/shared/bundler.rb
+++ b/lib/travis/build/script/shared/bundler.rb
@@ -10,6 +10,7 @@ module Travis
 
         def setup
           super
+          setup_cache
 
           sh.if gemfile? do
             sh.export 'BUNDLE_GEMFILE', "$PWD/#{config[:gemfile]}"

--- a/lib/travis/build/script/shared/bundler.rb
+++ b/lib/travis/build/script/shared/bundler.rb
@@ -11,10 +11,6 @@ module Travis
         def setup
           super
           setup_cache
-
-          sh.if gemfile? do
-            sh.export 'BUNDLE_GEMFILE', "$PWD/#{config[:gemfile]}"
-          end
         end
 
         def announce
@@ -24,6 +20,7 @@ module Travis
 
         def setup_cache
           sh.if gemfile? do
+            sh.export 'BUNDLE_GEMFILE', "$PWD/#{config[:gemfile]}"
             sh.if gemfile_lock? do
               directory_cache.add(bundler_path(false)) if data.cache?(:bundler)
               sh.cmd bundler_install("--deployment"), fold: "install.bundler", retry: true

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -8,7 +8,7 @@ module Travis
   module Build
     class Stages
       STAGES = [
-        :builtin,     [:header, :configure, :checkout, :prepare, :disable_sudo, :export, :setup, :announce],
+        :builtin,     [:header, :configure, :checkout, :prepare, :disable_sudo, :export, :setup, :announce, :setup_cache],
         :custom,      [:before_install, :install, :before_script, :script, :before_cache],
         :builtin,     [:cache],
         :conditional, [:after_success],
@@ -23,6 +23,7 @@ module Travis
         export:         { assert: false, echo: false, timing: false },
         setup:          { assert: true,  echo: true,  timing: true  },
         announce:       { assert: false, echo: true,  timing: false },
+        setup_cache:    { assert: true,  echo: true,  timing: true  },
         before_install: { assert: true,  echo: true,  timing: true  },
         install:        { assert: true,  echo: true,  timing: true  },
         before_script:  { assert: true,  echo: true,  timing: true  },

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -8,7 +8,7 @@ module Travis
   module Build
     class Stages
       STAGES = [
-        :builtin,     [:header, :configure, :checkout, :prepare, :disable_sudo, :export, :setup, :announce, :setup_cache],
+        :builtin,     [:header, :configure, :checkout, :prepare, :disable_sudo, :export, :setup, :announce],
         :custom,      [:before_install, :install, :before_script, :script, :before_cache],
         :builtin,     [:cache],
         :conditional, [:after_success],
@@ -23,7 +23,6 @@ module Travis
         export:         { assert: false, echo: false, timing: false },
         setup:          { assert: true,  echo: true,  timing: true  },
         announce:       { assert: false, echo: true,  timing: false },
-        setup_cache:    { assert: true,  echo: true,  timing: true  },
         before_install: { assert: true,  echo: true,  timing: true  },
         install:        { assert: true,  echo: true,  timing: true  },
         before_script:  { assert: true,  echo: true,  timing: true  },

--- a/spec/build/script/objective_c_spec.rb
+++ b/spec/build/script/objective_c_spec.rb
@@ -72,7 +72,7 @@ describe Travis::Build::Script::ObjectiveC, :sexp do
     end
 
     it 'runs pod install if a Podfile exists' do
-      sexp = sexp_filter(subject, [:if, '-f Podfile'])[1]
+      sexp = sexp_filter(subject, [:if, '-f Podfile'])[2]
       expect(sexp).to include_sexp [:cmd, 'pod install', assert: true, echo: true, retry: true, timing: true]
     end
 

--- a/spec/build/script/objective_c_spec.rb
+++ b/spec/build/script/objective_c_spec.rb
@@ -31,7 +31,7 @@ describe Travis::Build::Script::ObjectiveC, :sexp do
     end
 
     it 'announces CocoaPods version if a Podfile exists' do
-      sexp = sexp_find(subject, [:if, '-f Podfile'])
+      sexp = sexp_filter(subject, [:if, '-f Podfile'])[2]
       expect(sexp).to include_sexp [:cmd, 'pod --version', echo: true]
     end
   end
@@ -72,7 +72,7 @@ describe Travis::Build::Script::ObjectiveC, :sexp do
     end
 
     it 'runs pod install if a Podfile exists' do
-      sexp = sexp_filter(subject, [:if, '-f Podfile'])[2]
+      sexp = sexp_filter(subject, [:if, '-f Podfile'])[3]
       expect(sexp).to include_sexp [:cmd, 'pod install', assert: true, echo: true, retry: true, timing: true]
     end
 
@@ -139,7 +139,7 @@ describe Travis::Build::Script::ObjectiveC, :sexp do
     before { data[:config][:cache] = 'cocoapods' }
 
     it 'should add Poject/Podfile to directory cache' do
-      script.directory_cache.expects(:add).with('./Pods')
+      script.directory_cache.expects(:add).with('./Pods').at_least_once
       script.sexp
     end
   end

--- a/spec/build/script/ruby_spec.rb
+++ b/spec/build/script/ruby_spec.rb
@@ -65,7 +65,7 @@ describe Travis::Build::Script::Ruby, :sexp do
   end
 
   it 'sets BUNDLE_GEMFILE if a gemfile exists' do
-    sexp = sexp_find(subject, [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}"], [:then])
+    sexp = sexp_find(subject, [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}"])
     expect(sexp).to include_sexp [:export, ['BUNDLE_GEMFILE', '$PWD/Gemfile'], echo: true]
   end
 
@@ -88,12 +88,12 @@ describe Travis::Build::Script::Ruby, :sexp do
 
   describe 'install' do
     it 'runs bundle install --deployment if there is a Gemfile and a Gemfile.lock' do
-      sexp = sexp_find(sexp_filter(subject, [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}"])[1], [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}.lock"], [:then])
+      sexp = sexp_find(sexp_filter(subject, [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}"])[0], [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}.lock"], [:then])
       expect(sexp).to include_sexp [:cmd, 'bundle install --jobs=3 --retry=3 --deployment', assert: true, echo: true, timing: true, retry: true]
     end
 
     it "runs bundle install if a Gemfile exists" do
-      sexp = sexp_find(sexp_filter(subject, [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}"])[1], [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}.lock"], [:else])
+      sexp = sexp_find(sexp_filter(subject, [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}"])[0], [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}.lock"], [:else])
       should include_sexp [:cmd, 'bundle install --jobs=3 --retry=3', assert: true, echo: true, timing: true, retry: true]
     end
   end


### PR DESCRIPTION
This dissociates setting up cache from the "install" step.
"install" is often overridden, which can confuse
users when "cache: bundler" (for example) does not work.

This resolves https://github.com/travis-ci/travis-ci/issues/3239

It is tested briefly: https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/439189