### PR TITLE
Include `apt-get update` in build output

### DIFF
--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -126,7 +126,7 @@ module Travis
 
             unless whitelisted.empty?
               sh.export 'DEBIAN_FRONTEND', 'noninteractive', echo: true
-              sh.cmd "sudo -E apt-get -yq update &>> ~/apt-get-update.log", echo: true, timing: true
+              sh.cmd "sudo -E apt-get -yq update", echo: true, timing: true
               sh.cmd 'sudo -E apt-get -yq --no-install-suggests --no-install-recommends ' \
                 "--force-yes install #{whitelisted.join(' ')}", echo: true, timing: true
             end


### PR DESCRIPTION
Redirecting output to a log file isn't useful for people trying to debug build failures.
