### PR TITLE
Enforce OTP release requirement for Elixir

### DIFF
--- a/lib/travis/build/script/elixir.rb
+++ b/lib/travis/build/script/elixir.rb
@@ -14,12 +14,19 @@ module Travis
           sh.export 'TRAVIS_ELIXIR_VERSION', elixir_version, echo: false
         end
 
+        def setup
+          unless otp_release_requirement_satisfied?
+            sh.echo "Erlang/OTP Release #{otp_release} is not supported by Elixir #{elixir_version}. Using OTP Release #{required_otp_version}.", ansi: :yellow
+            config[:otp_release] = required_otp_version
+          end
+          super
+        end
+
         def announce
           super
 
           sh.fold "elixir" do
-            sh.cmd "kiex list | grep #{Regexp.escape(elixir_version).shellescape}", echo: false, assert: false
-            sh.if "$? != 0" do
+            sh.if "! -f #{HOME_DIR}/.kiex/elixirs/elixir-#{elixir_version}.env" do
               sh.echo "Installing Elixir #{elixir_version}"
               sh.cmd "wget http://s3.hex.pm/builds/elixir/v#{elixir_version}.zip", assert: true, timing: true
               sh.cmd "unzip -d #{KIEX_ELIXIR_HOME}/elixir-#{elixir_version} v#{elixir_version}.zip 2>&1 > /dev/null", echo: false
@@ -50,6 +57,23 @@ export MIX_ARCHIVES=#{KIEX_MIX_HOME}elixir-#{elixir_version}' > #{KIEX_ELIXIR_HO
 
         def elixir_version
           config[:elixir].to_s
+        end
+
+        def otp_release_requirement_satisfied?
+          ( elixir_1_2_0_or_higher? &&  otp_release_18_0_or_higher?) ||
+          (!elixir_1_2_0_or_higher? && !otp_release_18_0_or_higher?)
+        end
+
+        def elixir_1_2_0_or_higher?
+          Gem::Version.new(elixir_version) > Gem::Version.new('1.1.999') # use this for pre-release 1.2.0
+        end
+
+        def otp_release_18_0_or_higher?
+          Gem::Version.new(otp_release) > Gem::Version.new('17.999')
+        end
+
+        def required_otp_version
+          elixir_1_2_0_or_higher? ? '18.0' : '17.4'
         end
       end
     end

--- a/spec/build/script/elixir_spec.rb
+++ b/spec/build/script/elixir_spec.rb
@@ -42,5 +42,43 @@ describe Travis::Build::Script::Elixir, :sexp do
     subject { described_class.new(data).cache_slug }
     it { is_expected.to eq('cache--otp-17.4--elixir-1.0.2') }
   end
+
+  def self.installs_required_otp_release(elixir_version, otp_release_wanted, otp_release_required)
+    context "when elixir version is #{elixir_version}" do
+      before :each do
+        data[:config][:elixir] = elixir_version
+      end
+
+      context "when OTP release is #{otp_release_wanted}" do
+        before :each do
+          data[:config][:otp_release] = otp_release_wanted
+        end
+
+        if otp_release_wanted == otp_release_required
+          describe "wanted OTP release #{otp_release_wanted}" do
+            it "is installed" do
+              sexp = sexp_find(subject, [:if, "! -f #{Travis::Build::HOME_DIR}/otp/#{otp_release_wanted}/activate"], [:then])
+              expect(sexp).to include_sexp([:cmd, "wget https://s3.amazonaws.com/travis-otp-releases/ubuntu/$(lsb_release -rs)/erlang-#{otp_release_wanted}-x86_64.tar.bz2", assert: true, echo: true, timing: true])
+            end
+          end
+        else
+          describe "required OTP release #{otp_release_required}" do
+            it "is installed" do
+              sexp = sexp_find(subject, [:if, "! -f #{Travis::Build::HOME_DIR}/otp/#{otp_release_required}/activate"], [:then])
+              expect(sexp).to include_sexp([:cmd, "wget https://s3.amazonaws.com/travis-otp-releases/ubuntu/$(lsb_release -rs)/erlang-#{otp_release_required}-x86_64.tar.bz2", assert: true, echo: true, timing: true])
+            end
+          end
+        end
+      end
+    end
+  end
+
+  # requirement met
+  installs_required_otp_release('1.2.0', '18.0', '18.0')
+  installs_required_otp_release('1.1.0', '17.4', '17.4')
+  # requirement not met
+  installs_required_otp_release('1.2.0', '17.3', '18.0')
+  installs_required_otp_release('1.2.0-dev', '17.4', '18.0')
+  installs_required_otp_release('1.1.0', '18.0', '17.4')
 end
 


### PR DESCRIPTION
Elixir 1.2.0 will require OTP 18.0 or later, while
1.1.x will not run on OTP 18.0.

While it is not impossible to test with both Elixir 1.1.x and
1.2.x in the same build with such requirements, it is a bit
cumbersome, as it will require a hack with `matrix.include`.

This commit allows implicit OTP Release requirement specification
for just such a case.

If OTP release requirement is not met for one reason or another,
we will automatically select (and install if unavailable) it.

This does not allow testing Elixir versions with different OTP
releases, but such cases should be uncommon (and are already using
the build matrix one way or another, so the `matrix.include` trick
should be familiar).