### PR TITLE
Fix issues where Elixir 1.1.x triggered warnings about OTP 18.x

### DIFF
--- a/lib/travis/build/script/elixir.rb
+++ b/lib/travis/build/script/elixir.rb
@@ -60,12 +60,17 @@ export MIX_ARCHIVES=#{KIEX_MIX_HOME}elixir-#{elixir_version}' > #{KIEX_ELIXIR_HO
         end
 
         def otp_release_requirement_satisfied?
-          ( elixir_1_2_0_or_higher? &&  otp_release_18_0_or_higher?) ||
-          (!elixir_1_2_0_or_higher? && !otp_release_18_0_or_higher?)
+          !( elixir_1_0_x? &&  otp_release_18_0_or_higher?) &&
+          !( elixir_1_2_0_or_higher? && !otp_release_18_0_or_higher?)
         end
 
         def elixir_1_2_0_or_higher?
           Gem::Version.new(elixir_version) > Gem::Version.new('1.1.999') # use this for pre-release 1.2.0
+        end
+
+        def elixir_1_0_x?
+          Gem::Version.new(elixir_version) < Gem::Version.new('1.1') &&
+          Gem::Version.new(elixir_version) >= Gem::Version.new('1.0.0')
         end
 
         def otp_release_18_0_or_higher?

--- a/spec/build/script/elixir_spec.rb
+++ b/spec/build/script/elixir_spec.rb
@@ -76,9 +76,11 @@ describe Travis::Build::Script::Elixir, :sexp do
   # requirement met
   installs_required_otp_release('1.2.0', '18.0', '18.0')
   installs_required_otp_release('1.1.0', '17.4', '17.4')
+  installs_required_otp_release('1.1.0', '18.0', '18.0')
+  installs_required_otp_release('1.0.5', '17.3', '17.3')
   # requirement not met
   installs_required_otp_release('1.2.0', '17.3', '18.0')
   installs_required_otp_release('1.2.0-dev', '17.4', '18.0')
-  installs_required_otp_release('1.1.0', '18.0', '17.4')
+  installs_required_otp_release('1.0.5', '18.0', '17.4')
 end
 


### PR DESCRIPTION
It is 1.0.x that drops support for OTP 18.x

1.1.x works with both OTP 17.x and 18.x