### PR TITLE
haxe: set default version to latest release (3.2.1)

### DIFF
--- a/lib/travis/build/script/haxe.rb
+++ b/lib/travis/build/script/haxe.rb
@@ -17,7 +17,7 @@ module Travis
     class Script
       class Haxe < Script
         DEFAULTS = {
-          haxe: '3.2.0',
+          haxe: '3.2.1',
           neko: '2.0.0'
         }
 


### PR DESCRIPTION
haxe 3.2.1 has just been released.
http://haxe.org/download/version/3.2.1/