### PR TITLE
Improve dart support

### DIFF
--- a/lib/travis/build/script/dart.rb
+++ b/lib/travis/build/script/dart.rb
@@ -87,26 +87,26 @@ module Travis
 
         def script
           # tests with test package
-          sh.if '[[ -d packages/test ]] || ( [[ -f .packages ]] && grep -q "^test:" .packages )', raw: true do
+          sh.if '[[ -d packages/test ]] || grep -q ^test: .packages 2> /dev/null', raw: true do
             if with_content_shell
-              sh.cmd 'export DISPLAY=:99.0'
+              sh.export 'DISPLAY', ':99.0'
               sh.cmd 'sh -e /etc/init.d/xvfb start'
-              sh.cmd "pub run test -p vm -p content-shell -p firefox"
+              sh.cmd 'pub run test -p vm -p content-shell -p firefox'
             else
-              sh.cmd "pub run test"
+              sh.cmd 'pub run test'
             end
           end
           # tests with test_runner for old tests written with unittest package
-          sh.elif '[[ -d packages/unittest ]] || ( [[ -f .packages ]] && grep -q "^unittest:" .packages )', raw: true do
+          sh.elif '[[ -d packages/unittest ]] || grep -q ^unittest: .packages 2> /dev/null', raw: true do
             sh.fold 'test_runner_install' do
               sh.echo 'Installing Test Runner', ansi: :yellow
-              sh.cmd "pub global activate test_runner"
+              sh.cmd 'pub global activate test_runner'
             end
 
             if with_content_shell
-              sh.cmd "xvfb-run -s '-screen 0 1024x768x24' pub global run test_runner --disable-ansi"
+              sh.cmd 'xvfb-run -s "-screen 0 1024x768x24" pub global run test_runner --disable-ansi'
             else
-              sh.cmd "pub global run test_runner --disable-ansi --skip-browser-tests"
+              sh.cmd 'pub global run test_runner --disable-ansi --skip-browser-tests'
             end
           end
         end

--- a/lib/travis/shell/ast.rb
+++ b/lib/travis/shell/ast.rb
@@ -100,7 +100,9 @@ module Travis
 
       class Elif < Conditional
         def to_sexp
-          [:elif, condition, super]
+          sexp = [:elif, condition, super]
+          sexp << { raw: true } if options[:raw]
+          sexp
         end
       end
 

--- a/lib/travis/shell/generator/bash.rb
+++ b/lib/travis/shell/generator/bash.rb
@@ -130,8 +130,9 @@ module Travis
           handle(cmds)
         end
 
-        def handle_elif(condition, cmds)
-          lines = ["elif [[ #{condition} ]]; then"]
+        def handle_elif(condition, cmds, options = {})
+          condition = "[[ #{condition} ]]" unless options.delete(:raw)
+          lines = ["elif #{condition}; then"]
           lines += handle(cmds)
           lines
         end

--- a/spec/build/script/dart_spec.rb
+++ b/spec/build/script/dart_spec.rb
@@ -45,4 +45,67 @@ describe Travis::Build::Script::Dart, :sexp do
       should include_sexp [:echo, "Installing Content Shell", ansi: :yellow]
     end
   end
+
+  describe 'script' do
+    describe 'if a directory packages/test exists or the file .packages defines a test [something ... target?]' do
+      let(:sexp) { sexp_find(subject, [:if, "[[ -d packages/test ]] || grep -q ^test: .packages 2> /dev/null"]) }
+
+      # TODO this should be tested as part of a general spec for shell/builder, which does not exist atm
+      it 'specifies the condition as raw bash' do
+        expect(sexp.last).to eq(raw: true)
+      end
+
+      describe 'with with_content_shell being true' do
+        let(:sexp) { sexp_filter(super(), [:then]) }
+        before     { data[:config][:with_content_shell] = 'true' }
+
+        it 'exports DISPLAY=:99:0' do
+          expect(sexp).to include_sexp [:export, ['DISPLAY', ':99.0'], echo: true]
+        end
+
+        it 'starts xvfb' do
+          expect(sexp).to include_sexp [:cmd, 'sh -e /etc/init.d/xvfb start', echo: true, timing: true]
+        end
+
+        it 'runs pub run test -p vm -p content-shell -p firefox' do
+          expect(sexp).to include_sexp [:cmd, 'pub run test -p vm -p content-shell -p firefox', echo: true, timing: true]
+        end
+      end
+
+      describe 'with with_content_shell being nil' do
+        let(:sexp) { sexp_filter(super(), [:then]) }
+
+        it 'runs pub run test' do
+          expect(sexp).to include_sexp [:cmd, 'pub run test', echo: true, timing: true]
+        end
+      end
+    end
+
+    describe 'if a directory packages/unittest exists or the file .packages defines a unittest [something ... target?]' do
+      let(:sexp) { sexp_find(subject, [:elif, "[[ -d packages/unittest ]] || grep -q ^unittest: .packages 2> /dev/null"]) }
+
+      # TODO this should be tested as part of a general spec for shell/builder, which does not exist atm
+      it 'specifies the condition as raw bash' do
+        expect(sexp.last).to eq(raw: true)
+      end
+
+      it 'installs the test runner' do
+        expect(sexp).to include_sexp [:cmd, 'pub global activate test_runner', echo: true, timing: true]
+      end
+
+      describe 'with with_content_shell being true' do
+        before { data[:config][:with_content_shell] = 'true' }
+
+        it 'runs pub global run test_runner via xvfb-run' do
+          expect(sexp).to include_sexp [:cmd, 'xvfb-run -s "-screen 0 1024x768x24" pub global run test_runner --disable-ansi', echo: true, timing: true]
+        end
+      end
+
+      describe 'with with_content_shell being nil' do
+        it 'runs pub run test' do
+          expect(sexp).to include_sexp [:cmd, 'pub global run test_runner --disable-ansi --skip-browser-tests', echo: true, timing: true]
+        end
+      end
+    end
+  end
 end

--- a/spec/shell/generator/bash_spec.rb
+++ b/spec/shell/generator/bash_spec.rb
@@ -231,14 +231,28 @@ describe Travis::Shell::Generator::Bash, :include_node_helpers do
   end
 
   describe :if do
-    it 'generates an if statement' do
-      @sexp = [:if, '-f Gemfile', [:cmds, [[:cmd, 'foo']]]]
-      expect(code).to eql("if [[ -f Gemfile ]]; then\n  foo\nfi")
+    describe 'given bash conditions' do
+      it 'generates an if statement' do
+        @sexp = [:if, '-f Gemfile', [:cmds, [[:cmd, 'foo']]]]
+        expect(code).to eql("if [[ -f Gemfile ]]; then\n  foo\nfi")
+      end
+
+      it 'with an elif branch' do
+        @sexp = [:if, '-f Gemfile', [:cmds, [[:cmd, 'foo']]], [:elif, '-f Gemfile.lock', [:cmds, [[:cmd, 'bar']]]]]
+        expect(code).to eql("if [[ -f Gemfile ]]; then\n  foo\nelif [[ -f Gemfile.lock ]]; then\n  bar\nfi")
+      end
     end
 
-    it 'with an elif branch' do
-      @sexp = [:if, '-f Gemfile', [:cmds, [[:cmd, 'foo']]], [:elif, '-f Gemfile.lock', [:cmds, [[:cmd, 'bar']]]]]
-      expect(code).to eql("if [[ -f Gemfile ]]; then\n  foo\nelif [[ -f Gemfile.lock ]]; then\n  bar\nfi")
+    describe 'given raw sh conditions' do
+      it 'generates an if statement' do
+        @sexp = [:if, 'grep FOO .bar 2> /dev/null', [:cmds, [[:cmd, 'foo']]], raw: true]
+        expect(code).to eql("if grep FOO .bar 2> /dev/null; then\n  foo\nfi")
+      end
+
+      it 'with an elif branch' do
+        @sexp = [:if, '-f Gemfile', [:cmds, [[:cmd, 'foo']]], [:elif, 'grep FOO .bar 2> /dev/null', [:cmds, [[:cmd, 'bar']]], raw: true]]
+        expect(code).to eql("if [[ -f Gemfile ]]; then\n  foo\nelif grep FOO .bar 2> /dev/null; then\n  bar\nfi")
+      end
     end
 
     it 'with an else branch' do


### PR DESCRIPTION
* add specs to script/dart
* make sure we pass through a :raw option for :elif nodes
* make sure shell/generator/bash respects :raw for :elif nodes
* simplify the condition 

It seems there's no specs for shell/ast.rb ... we should probably add some at some point, since this would have caught the `:raw` option not being added in for `:elif` nodes. For now I've just added a respective spec to the dart script spec.