### PR TITLE
Make filetreeCI variables globally available

### DIFF
--- a/lib/travis/build/script/smalltalk.rb
+++ b/lib/travis/build/script/smalltalk.rb
@@ -33,7 +33,7 @@ module Travis
             sh.cmd "wget -q -O filetreeCI.zip https://github.com/hpi-swa/filetreeCI/archive/master.zip"
             sh.cmd "unzip -q -o filetreeCI.zip"
             sh.cmd "pushd filetreeCI-*", echo: false
-            sh.cmd "export FILETREE_CI_HOME=\"$(pwd)\""
+            sh.cmd "source env_vars"
             sh.cmd "popd; popd", echo: false
           end
         end

--- a/spec/build/script/smalltalk_spec.rb
+++ b/spec/build/script/smalltalk_spec.rb
@@ -14,7 +14,7 @@ describe Travis::Build::Script::Smalltalk, :sexp do
     should include_sexp [:cmd, "wget -q -O filetreeCI.zip https://github.com/hpi-swa/filetreeCI/archive/master.zip", assert: true, echo: true, timing: true]
     should include_sexp [:cmd, "unzip -q -o filetreeCI.zip", assert: true, echo: true, timing: true]
     should include_sexp [:cmd, "pushd filetreeCI-*", assert: true, timing: true]
-    should include_sexp [:cmd, "export FILETREE_CI_HOME=\"$(pwd)\"", assert: true, echo: true, timing: true]
+    should include_sexp [:cmd, "source env_vars", assert: true, echo: true, timing: true]
     should include_sexp [:cmd, "popd; popd", assert: true, timing: true]
   end
 


### PR DESCRIPTION
This will make more than just `$FILETREE_CI_HOME` globally available.