### PR TITLE
Rename filetreeCI to smalltalkCI

### DIFF
--- a/lib/travis/build/script/smalltalk.rb
+++ b/lib/travis/build/script/smalltalk.rb
@@ -9,10 +9,10 @@ module Travis
           case config[:os]
           when 'linux'
             sh.fold 'install_packages' do
-              sh.echo 'Installing libc6:i386 and libuuid1:i386', ansi: :yellow
+              sh.echo 'Installing dependencies', ansi: :yellow
               sh.cmd 'sudo apt-get update -qq', retry: true
               sh.cmd 'sudo apt-get install --no-install-recommends ' +
-                     'libc6:i386 libuuid1:i386', retry: true
+                     'libc6:i386 libuuid1:i386 libfreetype6:i386', retry: true
             end
           when 'osx'
             # pass
@@ -33,20 +33,20 @@ module Travis
           sh.echo 'and mention \`@bahnfahren\`, \`@chistopher\`, \`@fniephaus\`, \`@jchromik\` and \`@Nef10\` in the issue', ansi: :green
 
           sh.cmd "export PROJECT_HOME=\"$(pwd)\""
-          sh.cmd "pushd $HOME", echo: false
-          sh.fold 'download_filetreeci' do
-            sh.echo 'Downloading and extracting filetreeCI', ansi: :yellow
-            sh.cmd "wget -q -O filetreeCI.zip https://github.com/hpi-swa/filetreeCI/archive/master.zip"
-            sh.cmd "unzip -q -o filetreeCI.zip"
-            sh.cmd "pushd filetreeCI-*", echo: false
+          sh.cmd "pushd $HOME > /dev/null", echo: false
+          sh.fold 'download_smalltalkci' do
+            sh.echo 'Downloading and extracting smalltalkCI', ansi: :yellow
+            sh.cmd "wget -q -O smalltalkCI.zip https://github.com/hpi-swa/smalltalkCI/archive/master.zip"
+            sh.cmd "unzip -q -o smalltalkCI.zip"
+            sh.cmd "pushd smalltalkCI-* > /dev/null", echo: false
             sh.cmd "source env_vars"
-            sh.cmd "popd; popd", echo: false
+            sh.cmd "popd > /dev/null; popd > /dev/null", echo: false
           end
         end
 
         def script
           super
-          sh.cmd "$FILETREE_CI_HOME/run.sh"
+          sh.cmd "$SMALLTALK_CI_HOME/run.sh"
         end
 
       end

--- a/spec/build/script/smalltalk_spec.rb
+++ b/spec/build/script/smalltalk_spec.rb
@@ -7,15 +7,15 @@ describe Travis::Build::Script::Smalltalk, :sexp do
 
   it_behaves_like 'compiled script' do
     let(:code) { ['TRAVIS_LANGUAGE=smalltalk'] }
-    let(:cmds) { ['$FILETREE_CI_HOME/run.sh'] }
+    let(:cmds) { ['$SMALLTALK_CI_HOME/run.sh'] }
   end
 
   it "downloads and extracts correct script" do
-    should include_sexp [:cmd, "wget -q -O filetreeCI.zip https://github.com/hpi-swa/filetreeCI/archive/master.zip", assert: true, echo: true, timing: true]
-    should include_sexp [:cmd, "unzip -q -o filetreeCI.zip", assert: true, echo: true, timing: true]
-    should include_sexp [:cmd, "pushd filetreeCI-*", assert: true, timing: true]
+    should include_sexp [:cmd, "wget -q -O smalltalkCI.zip https://github.com/hpi-swa/smalltalkCI/archive/master.zip", assert: true, echo: true, timing: true]
+    should include_sexp [:cmd, "unzip -q -o smalltalkCI.zip", assert: true, echo: true, timing: true]
+    should include_sexp [:cmd, "pushd smalltalkCI-* > /dev/null", assert: true, timing: true]
     should include_sexp [:cmd, "source env_vars", assert: true, echo: true, timing: true]
-    should include_sexp [:cmd, "popd; popd", assert: true, timing: true]
+    should include_sexp [:cmd, "popd > /dev/null; popd > /dev/null", assert: true, timing: true]
   end
 
   describe 'on Linux' do
@@ -23,7 +23,7 @@ describe Travis::Build::Script::Smalltalk, :sexp do
       data[:config][:os] = 'linux'
     end
     it 'installs the dependencies' do
-      should include_sexp [:cmd, "sudo apt-get install --no-install-recommends libc6:i386 libuuid1:i386", retry: true]
+      should include_sexp [:cmd, "sudo apt-get install --no-install-recommends libc6:i386 libuuid1:i386 libfreetype6:i386", retry: true]
     end
   end
 
@@ -32,17 +32,17 @@ describe Travis::Build::Script::Smalltalk, :sexp do
       data[:config][:os] = 'osx'
     end
     it 'does not try to call apt-get' do
-      should_not include_sexp [:cmd, "sudo apt-get install --no-install-recommends libc6:i386 libuuid1:i386", retry: true]
+      should_not include_sexp [:cmd, "sudo apt-get install --no-install-recommends libc6:i386 libuuid1:i386 libfreetype6:i386", retry: true]
     end
   end
 
   describe 'set smalltalk version' do
     before do
-      data[:config][:smalltalk] = 'Squeak5.0'
+      data[:config][:smalltalk] = 'Squeak-5.0'
     end
 
     it 'sets SMALLTALK to correct version' do
-      should include_sexp [:export, ['SMALLTALK', 'Squeak5.0']]
+      should include_sexp [:export, ['SMALLTALK', 'Squeak-5.0']]
     end
   end
 


### PR DESCRIPTION
We have decided to rename *filetreeCI* to [*smalltalkCI*](https://github.com/hpi-swa/smalltalkCI/) for consistency reasons.
This changes Smalltalk support on Travis accordingly (currently broken).
Also, it adds `libfreetype6:i386` in order to support more Smalltalk vm plugins.

Sorry for the inconvenience.