### PR TITLE
Support regular expressions in APT package whitelist

### DIFF
--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -12,19 +12,35 @@ module Travis
 
         class << self
           def package_whitelist
-            @package_whitelist ||= load_package_whitelist
+            @package_whitelist ||= load_package_whitelist.reject { |w| w =~ regex_detecting_regex }
+          end
+
+          def package_whitelist_regexes
+            @package_whitelist_regexes ||= load_package_whitelist
+              .select { |w| w =~ regex_detecting_regex }
+              .map { |w| Regexp.compile(w) rescue nil }
+              .compact
           end
 
           def source_whitelist
             @source_whitelist ||= load_source_whitelist
           end
 
+          def reset_caches
+            @package_whitelist =
+              @package_whitelist_regexes =
+              @source_whitelist =
+              @loaded_package_whitelist = nil
+          end
+
           private
 
           def load_package_whitelist
             require 'faraday'
-            response = fetch_package_whitelist
-            response.split.map(&:strip).sort.uniq
+            @loaded_package_whitelist ||= begin
+              response = fetch_package_whitelist
+              response.split.map(&:strip).sort.uniq
+            end
           rescue => e
             warn e
             []
@@ -54,6 +70,11 @@ module Travis
 
           def source_whitelist_url
             ENV['TRAVIS_BUILD_APT_SOURCE_WHITELIST']
+          end
+
+          def regex_detecting_regex
+            # Detects only the subset of regexes supported in the apt packages whitelist
+            /[*?+()]/
           end
         end
 
@@ -110,7 +131,8 @@ module Travis
             disallowed = []
 
             config_packages.each do |package|
-              if package_whitelist.include?(package)
+              if package_whitelist.include?(package) ||
+                 package_whitelist_regexes.detect { |w| w.match(package) }
                 whitelisted << package
               else
                 disallowed << package
@@ -146,6 +168,10 @@ module Travis
 
           def package_whitelist
             ::Travis::Build::Addons::Apt.package_whitelist
+          end
+
+          def package_whitelist_regexes
+            ::Travis::Build::Addons::Apt.package_whitelist_regexes
           end
 
           def source_whitelist


### PR DESCRIPTION
This PR is an alternative solution to [the issue I opened](https://github.com/travis-ci/apt-package-whitelist/issues/1595) in the apt-package-whitelist repo, regarding my inability to install a specific version of the elasticsearch package.

After some further reflection I've decided that the problem with the elasticsearch case is a fairly repeatable problem that may occur with some semi-commercial or purely-commercial software packages, to wit:
- The package is released as binary-only (no source packages), so the standard apt-package-whitelist workflow can't be used
- The package is deemed sufficiently safe by a Travis CI maintainer that the repo and (non-version-specific) package are added to the respective whitelists
- The package maintainer periodically releases subsequent patch-level or minor-level releases which match the "generic" package name added by the Travis CI maintainer in the previous step

In this situation the Travis CI user is up the proverbial creek because they can't specify which exact package version they are installing - the apt-package-whitelist workflow is unavailable to them (no source packages) and the whitelisted package name ("elasticsearch") doesn't support version information.

My suggestion then is this PR: allow _a Travis CI maintainer_ to specify a package whitelist regex rather than a package whitelist name. This safely limits the subset of package strings that could be requested by Travis CI users, while still allowing them to pick a specific version if that matters to them.

For example, in the [existing ubuntu-precise whitelist](https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise) whitelist could be modified from this:

```
elasticsearch
elasticsearch:i386
```

to

```
^elasticsearch(-1\.[67]\.(\d+)(:i386)?)?$
```

which covers all of the packages currently whitelisted in the elasticsearch-1.6 and elasticsearch-1.7 repos, and also allows users to specify any of the following packages version strings:

```
elasticsearch
elasticsearch-1.6.2
elasticsearch-1.6.2:i386
elasticsearch-1.7.3
```

And, of course, if this gets merged, I'd love it if the regex shown above gets added to the apt-package-whitelist repo as well :-)
