### PR TITLE
Add TRAVIS_COMPILER to env

### DIFF
--- a/lib/travis/build/script/c.rb
+++ b/lib/travis/build/script/c.rb
@@ -8,6 +8,7 @@ module Travis
 
         def export
           super
+          sh.export 'TRAVIS_COMPILER', compiler
           sh.export 'CC', compiler
           if data.cache?(:ccache)
             sh.export 'PATH', "/usr/lib/ccache:$PATH"

--- a/lib/travis/build/script/cpp.rb
+++ b/lib/travis/build/script/cpp.rb
@@ -8,6 +8,7 @@ module Travis
 
         def export
           super
+          sh.export 'TRAVIS_COMPILER', compiler
           sh.export 'CXX', cxx
           sh.export 'CC', cc # some projects also need to compile some C, e.g. Rubinius. MK.
         end


### PR DESCRIPTION
This allows user’s choice of compiler to be passed through to build
script for C and C++ without undergoing any processing, as it does now
with C++ (e.g. stripping of version number)

The main reason for this is to avoid duplicating the compiler in the "env" and "compiler" 
directives, as here for example:

https://github.com/sfegan/calin/blob/master/.travis.yml

Which would make specifying the build matrix much easier, e.g. as here:

https://github.com/sfegan/travis_container_test/blob/master/.travis.yml

In that last script I would of course have to put some logic in to use the TRAVIS_COMPILER variable to set CC and CPP, but I didn't do that there.

Of course it is possible to avoid the duplication by simply specifying "g++" generically as the "compiler" and using an "env" to specify the version, but that misses out having a per-"compiler" cache (which is essential to me) and also means the true compiler version doesn't show up in the build status page, as here:

https://travis-ci.org/sfegan/travis_container_test

Thanks,
Steve

PS. I love Travis CI
