### PR TITLE
Ensure rvm function is defined when needed

### DIFF
--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -141,6 +141,7 @@ module Travis
             end
 
             def cmd(cmd, *args)
+              sh.cmd('type rvm &>/dev/null || source ~/.rvm/scripts/rvm', echo: false, assert: false)
               sh.cmd("rvm #{USE_RUBY} --fuzzy do ruby -S #{cmd}", *args)
             end
 

--- a/lib/travis/build/script/shared/directory_cache/s3.rb
+++ b/lib/travis/build/script/shared/directory_cache/s3.rb
@@ -134,6 +134,7 @@ module Travis
 
             def run(command, args, options = {})
               sh.if "-f #{BIN_PATH}" do
+                sh.cmd('type rvm &>/dev/null || source ~/.rvm/scripts/rvm', echo: false, assert: false)
                 sh.cmd "rvm #{USE_RUBY} --fuzzy do #{BIN_PATH} #{command} #{Array(args).join(' ')}", options.merge(echo: false)
               end
             end

--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -50,6 +50,7 @@ module Travis
           end
 
           def setup_rvm
+            sh.cmd('type rvm &>/dev/null || source ~/.rvm/scripts/rvm', echo: false, assert: false)
             sh.file '$rvm_path/user/db', CONFIG.join("\n")
             send rvm_strategy
           end


### PR DESCRIPTION
This change is not strictly necessary when "everything is fine", but issues around rvm availability have happened enough times in recent history that I feel like the benefit is there.