### PR TITLE
Source `~/.bash_profile` if present

### DIFF
--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 source /etc/profile
 
+if [[ -s ~/.bash_profile ]] ; then
+  source ~/.bash_profile
+fi
+
 ANSI_RED="\033[31;1m"
 ANSI_GREEN="\033[32;1m"
 ANSI_RESET="\033[0m"


### PR DESCRIPTION
to ensure that user-level interactive shell goodies are present, as hooking into `~/.bash_profile` is arguably more standard than `/etc/profile` for such things.