### PR TITLE
baseline key for smalltalk

### DIFF
--- a/lib/travis/build/script/smalltalk.rb
+++ b/lib/travis/build/script/smalltalk.rb
@@ -22,6 +22,7 @@ module Travis
         def export
           super
           sh.export 'SMALLTALK', config[:smalltalk], echo: false
+          sh.export 'BASELINE', config[:baseline], echo: false
          end
 
         def setup

--- a/lib/travis/build/script/smalltalk.rb
+++ b/lib/travis/build/script/smalltalk.rb
@@ -12,7 +12,7 @@ module Travis
               sh.echo 'Installing dependencies', ansi: :yellow
               sh.cmd 'sudo apt-get update -qq', retry: true
               sh.cmd 'sudo apt-get install --no-install-recommends ' +
-                     'libc6:i386 libuuid1:i386 libfreetype6:i386 libssl1.0.0:386', retry: true
+                     'libc6:i386 libuuid1:i386 libfreetype6:i386 libssl1.0.0:i386', retry: true
             end
           when 'osx'
             # pass

--- a/lib/travis/build/script/smalltalk.rb
+++ b/lib/travis/build/script/smalltalk.rb
@@ -12,7 +12,7 @@ module Travis
               sh.echo 'Installing dependencies', ansi: :yellow
               sh.cmd 'sudo apt-get update -qq', retry: true
               sh.cmd 'sudo apt-get install --no-install-recommends ' +
-                     'libc6:i386 libuuid1:i386 libfreetype6:i386', retry: true
+                     'libc6:i386 libuuid1:i386 libfreetype6:i386 libssl1.0.0:386', retry: true
             end
           when 'osx'
             # pass

--- a/spec/build/script/smalltalk_spec.rb
+++ b/spec/build/script/smalltalk_spec.rb
@@ -23,7 +23,7 @@ describe Travis::Build::Script::Smalltalk, :sexp do
       data[:config][:os] = 'linux'
     end
     it 'installs the dependencies' do
-      should include_sexp [:cmd, "sudo apt-get install --no-install-recommends libc6:i386 libuuid1:i386 libfreetype6:i386", retry: true]
+      should include_sexp [:cmd, "sudo apt-get install --no-install-recommends libc6:i386 libuuid1:i386 libfreetype6:i386 libssl1.0.0:i386", retry: true]
     end
   end
 
@@ -32,7 +32,7 @@ describe Travis::Build::Script::Smalltalk, :sexp do
       data[:config][:os] = 'osx'
     end
     it 'does not try to call apt-get' do
-      should_not include_sexp [:cmd, "sudo apt-get install --no-install-recommends libc6:i386 libuuid1:i386 libfreetype6:i386", retry: true]
+      should_not include_sexp [:cmd, "sudo apt-get install --no-install-recommends libc6:i386 libuuid1:i386 libfreetype6:i386 libssl1.0.0:i386", retry: true]
     end
   end
 


### PR DESCRIPTION
We just added the baseline key support in smalltalk.rb as requested in pull request [#419](https://github.com/travis-ci/docs-travis-ci-com/pull/419) of [travis-ci/docs-travis-ci-com](https://github.com/travis-ci/docs-travis-ci-com/).