### PR TITLE
Install artifacts from travis-ci-gmbh bucket

### DIFF
--- a/lib/travis/build/addons/artifacts/templates/artifacts.sh
+++ b/lib/travis/build/addons/artifacts/templates/artifacts.sh
@@ -1,8 +1,10 @@
+#!/usr/bin/env bash
+
 function travis_artifacts_install() {
   local os=$(uname | tr '[:upper:]' '[:lower:]')
   local arch=$(uname -m)
   [[ $arch == x86_64 ]] && arch=amd64
-  local source="https://s3.amazonaws.com/meatballhat/artifacts/stable/build/$os/$arch/artifacts"
+  local source="https://s3.amazonaws.com/travis-ci-gmbh/artifacts/stable/build/$os/$arch/artifacts"
   local target=$HOME/bin/artifacts
 
   mkdir -p $(dirname $target)


### PR DESCRIPTION
already copied bucket contents:

```
$ aws s3 ls meatballhat/ --recursive | grep artifacts/stable/build/
2014-12-09 17:06:29    8328704 artifacts/stable/build/darwin/amd64/artifacts
2014-12-09 17:06:29    8252720 artifacts/stable/build/linux/amd64/artifacts
2014-12-09 17:06:29    8336384 artifacts/stable/build/windows/amd64/artifacts.exe
$ aws s3 ls travis-ci-gmbh/ --recursive | grep artifacts/stable/build/
2015-11-14 08:43:40    8328704 artifacts/stable/build/darwin/amd64/artifacts
2015-11-14 08:43:40    8252720 artifacts/stable/build/linux/amd64/artifacts
2015-11-14 08:43:40    8336384 artifacts/stable/build/windows/amd64/artifacts.exe
```