### PR TITLE
Install Firefox "latest" variants according to the new URL scheme

### DIFF
--- a/lib/travis/build/addons/firefox.rb
+++ b/lib/travis/build/addons/firefox.rb
@@ -31,8 +31,8 @@ module Travis
               sh.cmd "wget -O /tmp/#{filename} $FIREFOX_SOURCE_URL", echo: true, timing: true, retry: true
               sh.cmd "tar xf /tmp/#{filename}"
               sh.cmd "sudo ln -sf #{install_dir}/firefox/firefox /usr/local/bin/firefox", echo: false
-              sh.cd :back, echo: false, stack: true
             end
+            sh.cd :back, echo: false, stack: true
           end
         end
 

--- a/lib/travis/build/addons/firefox.rb
+++ b/lib/travis/build/addons/firefox.rb
@@ -23,15 +23,9 @@ module Travis
             sh.mkdir install_dir, echo: false, recursive: true
             sh.chown 'travis', install_dir, recursive: true
             sh.cd install_dir, echo: false, stack: true
-            sh.if 'z$FIREFOX_SOURCE_URL == "z"' do
-              sh.echo "Unable to find Firefox #{version}"
-            end
-            sh.else do
-              sh.echo "Found Firefox $FIREFOX_SOURCE_URL"
-              sh.cmd "wget -O /tmp/#{filename} $FIREFOX_SOURCE_URL", echo: true, timing: true, retry: true
-              sh.cmd "tar xf /tmp/#{filename}"
-              sh.cmd "sudo ln -sf #{install_dir}/firefox/firefox /usr/local/bin/firefox", echo: false
-            end
+            sh.cmd "wget -O /tmp/#{filename} $FIREFOX_SOURCE_URL", echo: true, timing: true, retry: true
+            sh.cmd "tar xf /tmp/#{filename}"
+            sh.cmd "sudo ln -sf #{install_dir}/firefox/firefox /usr/local/bin/firefox", echo: false
             sh.cd :back, echo: false, stack: true
           end
         end

--- a/lib/travis/build/addons/firefox.rb
+++ b/lib/travis/build/addons/firefox.rb
@@ -70,7 +70,7 @@ module Travis
 
             host = 'download.mozilla.org'
 
-            sh.if "$TRAVIS_OS_NAME = 'linux'" do
+            sh.if "$(uname) = 'Linux'" do
               sh.export 'FIREFOX_SOURCE_URL', "http://#{host}/?product=#{product}&lang=en-US&os=linux64"
             end
             sh.else do

--- a/lib/travis/build/addons/firefox.rb
+++ b/lib/travis/build/addons/firefox.rb
@@ -7,8 +7,12 @@ module Travis
       class Firefox < Base
         SUPER_USER_SAFE = true
 
+        attr_reader :version, :latest
+
         def after_prepare
           sh.fold 'install_firefox' do
+            sanitize(raw_version)
+
             unless version
               sh.echo "Invalid version '#{raw_version}' given.", ansi: :red
               return
@@ -33,17 +37,15 @@ module Travis
         end
 
         private
-
-          def version
-            sanitize raw_version
-          end
-
           def raw_version
             config.to_s.strip.shellescape
           end
 
           def sanitize(input)
-            (m = /\A(?<version>[\d\.]+(?:esr)?|latest(?:-(?:beta|esr))?)\z/.match(input.chomp)) && m[:version]
+            if m = /\A(?<version>[\d\.]+(?:esr)?|(?<latest>latest(?:-(?:beta|esr))?)?)\z/.match(input.chomp)
+              @version = m[:version]
+              @latest  = m[:latest]
+            end
           end
 
           def install_dir
@@ -55,12 +57,24 @@ module Travis
           end
 
           def export_source_url
-            host = 'releases.mozilla.org'
-            path = "pub/firefox/releases/#{version}/linux-x86_64/en-US/"
-            if version.include? 'latest'
-              sh.export 'FIREFOX_SOURCE_URL', "http://#{host}/#{path}$(curl -o- -s http://#{host}/#{path} | grep -o -E 'firefox-[0-9]+(\.[0-9]+)+(b[0-9]|esr)?\.tar\.bz2' | head -1)"
+            product = case latest
+            when 'latest'
+              'firefox-latest'
+            when 'latest-beta'
+              'firefox-beta-latest'
+            when 'latest-esr'
+              'firefox-esr-latest'
             else
-              sh.export 'FIREFOX_SOURCE_URL', "http://#{host}/#{path}#{filename}"
+              "firefox-#{version}"
+            end
+
+            host = 'download.mozilla.org'
+
+            sh.if "$TRAVIS_OS_NAME = 'linux'" do
+              sh.export 'FIREFOX_SOURCE_URL', "http://#{host}/?product=#{product}&lang=en-US&os=linux64"
+            end
+            sh.else do
+              sh.export 'FIREFOX_SOURCE_URL', "http://#{host}/?product=#{product}&lang=en-US&os=osx"
             end
           end
 

--- a/lib/travis/build/addons/firefox.rb
+++ b/lib/travis/build/addons/firefox.rb
@@ -65,10 +65,10 @@ module Travis
             host = 'download.mozilla.org'
 
             sh.if "$(uname) = 'Linux'" do
-              sh.export 'FIREFOX_SOURCE_URL', "http://#{host}/?product=#{product}&lang=en-US&os=linux64"
+              sh.export 'FIREFOX_SOURCE_URL', "'http://#{host}/?product=#{product}&lang=en-US&os=linux64'"
             end
             sh.else do
-              sh.export 'FIREFOX_SOURCE_URL', "http://#{host}/?product=#{product}&lang=en-US&os=osx"
+              sh.export 'FIREFOX_SOURCE_URL', "'http://#{host}/?product=#{product}&lang=en-US&os=osx'"
             end
           end
 

--- a/spec/build/addons/firefox_spec.rb
+++ b/spec/build/addons/firefox_spec.rb
@@ -27,12 +27,10 @@ describe Travis::Build::Addons::Firefox, :sexp do
     it { should include_sexp [:cd, '$HOME/firefox-20.0', stack: true] }
     it { should include_sexp [:export, ['FIREFOX_SOURCE_URL', "http://#{host}/#{path}"], echo: true] }
 
-    let(:sexp) { sexp_find(sexp_filter(subject, [:if, 'z$FIREFOX_SOURCE_URL == "z"']), [:else]) }
-
-    it { expect(sexp).to include_sexp [:cmd, 'wget -O /tmp/firefox-20.0.tar.bz2 $FIREFOX_SOURCE_URL', echo: true, timing: true, retry: true] }
-    it { expect(sexp).to include_sexp [:cmd, 'tar xf /tmp/firefox-20.0.tar.bz2'] }
-    it { expect(sexp).to include_sexp [:cmd, 'sudo ln -sf $HOME/firefox-20.0/firefox/firefox /usr/local/bin/firefox'] }
-    it { expect(sexp).to include_sexp [:cd, :back, stack: true] }
+    it { should include_sexp [:cmd, 'wget -O /tmp/firefox-20.0.tar.bz2 $FIREFOX_SOURCE_URL', echo: true, timing: true, retry: true] }
+    it { should include_sexp [:cmd, 'tar xf /tmp/firefox-20.0.tar.bz2'] }
+    it { should include_sexp [:cmd, 'sudo ln -sf $HOME/firefox-20.0/firefox/firefox /usr/local/bin/firefox'] }
+    it { should include_sexp [:cd, :back, stack: true] }
   end
 
   context 'given a valid version "latest"' do

--- a/spec/build/addons/firefox_spec.rb
+++ b/spec/build/addons/firefox_spec.rb
@@ -25,7 +25,7 @@ describe Travis::Build::Addons::Firefox, :sexp do
     it { should include_sexp [:mkdir, '$HOME/firefox-20.0', recursive: true] }
     it { should include_sexp [:chown, ['travis', '$HOME/firefox-20.0'], recursive: true] }
     it { should include_sexp [:cd, '$HOME/firefox-20.0', stack: true] }
-    it { should include_sexp [:export, ['FIREFOX_SOURCE_URL', "http://#{host}/#{path}"], echo: true] }
+    it { should include_sexp [:export, ['FIREFOX_SOURCE_URL', "'http://#{host}/#{path}'"], echo: true] }
 
     it { should include_sexp [:cmd, 'wget -O /tmp/firefox-20.0.tar.bz2 $FIREFOX_SOURCE_URL', echo: true, timing: true, retry: true] }
     it { should include_sexp [:cmd, 'tar xf /tmp/firefox-20.0.tar.bz2'] }

--- a/spec/build/addons/firefox_spec.rb
+++ b/spec/build/addons/firefox_spec.rb
@@ -6,8 +6,9 @@ describe Travis::Build::Addons::Firefox, :sexp do
   let(:sh)     { Travis::Shell::Builder.new }
   let(:addon)  { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
   let(:home)   { Travis::Build::HOME_DIR }
-  let(:host)   { 'releases.mozilla.org'}
-  let(:path)   { "pub/firefox/releases/#{config}/linux-x86_64/en-US/"}
+  let(:host)   { 'download.mozilla.org'}
+  let(:os)     { 'linux64' }
+  let(:path)   { "?product=firefox-#{config}&lang=en-US&os=#{os}"}
   subject      { sh.to_sexp }
   before       { addon.after_prepare }
 
@@ -24,7 +25,7 @@ describe Travis::Build::Addons::Firefox, :sexp do
     it { should include_sexp [:mkdir, '$HOME/firefox-20.0', recursive: true] }
     it { should include_sexp [:chown, ['travis', '$HOME/firefox-20.0'], recursive: true] }
     it { should include_sexp [:cd, '$HOME/firefox-20.0', stack: true] }
-    it { should include_sexp [:export, ['FIREFOX_SOURCE_URL', "http://#{host}/#{path}firefox-20.0.tar.bz2"], echo: true] }
+    it { should include_sexp [:export, ['FIREFOX_SOURCE_URL', "http://#{host}/#{path}"], echo: true] }
 
     let(:sexp) { sexp_find(sexp_filter(subject, [:if, 'z$FIREFOX_SOURCE_URL == "z"']), [:else]) }
 


### PR DESCRIPTION
Mozilla recently changed (https://bugzilla.mozilla.org/show_bug.cgi?id=1223019) the URL scheme for Firefox downloads.

This PR adapts to the new scheme.

Tests:
* `latest-esr`: https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/461441#L116(edited)
* `latest-beta`: https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/461443#L116
* `latest`: https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/461445#L116
* specific version: https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/461447#L116

This fixes https://github.com/travis-ci/travis-ci/issues/5082.