### PR TITLE
Adjust Julia release and nightly URL's to download from S3

### DIFF
--- a/lib/travis/build/script/julia.rb
+++ b/lib/travis/build/script/julia.rb
@@ -85,19 +85,20 @@ module Travis
           def julia_url
             case config[:os]
             when 'linux'
-              status = 'linux-x86_64'
               osarch = 'linux/x64'
-              ext = "#{status}.tar.gz"
+              ext = 'linux-x86_64.tar.gz'
+              nightlyext = 'linux64.tar.gz'
             when 'osx'
-              status = 'osx10.7+'
               osarch = 'osx/x64'
-              ext = "#{status}.dmg"
+              ext = 'osx10.7+.dmg'
+              nightlyext = 'osx.dmg'
             end
             case config[:julia].to_s
             when 'release'
-              url = "status.julialang.org/stable/#{status}"
+              # CHANGEME on new minor releases (once or twice a year)
+              url = "s3.amazonaws.com/julialang/bin/#{osarch}/0.4/julia-0.4-latest-#{ext}"
             when 'nightly'
-              url = "status.julialang.org/download/#{status}"
+              url = "s3.amazonaws.com/julianightlies/bin/#{osarch}/julia-latest-#{nightlyext}"
             when /^(\d+\.\d+)\.\d+$/
               url = "s3.amazonaws.com/julialang/bin/#{osarch}/#{$1}/julia-#{config[:julia]}-#{ext}"
             when /^(\d+\.\d+)$/

--- a/spec/build/script/julia_spec.rb
+++ b/spec/build/script/julia_spec.rb
@@ -14,7 +14,7 @@ describe Travis::Build::Script::Julia, :sexp do
   end
 
   it 'downloads and installs Julia' do
-    should include_sexp [:cmd, %r(curl .*/stable/linux-x86_64), assert: true,
+    should include_sexp [:cmd, %r(curl .*latest-linux-x86_64), assert: true,
       echo: true, timing: true]
   end
 


### PR DESCRIPTION
This removes the dependency on status.julialang.org, which is another point of failure for DNS outages etc.
Downside is we'll need a tiny PR to change the `0.4` in `release` every time we have a new minor release, which should only be once or twice a year.