### PR TITLE
remove .ruby-version beta warning

### DIFF
--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -5,8 +5,7 @@ module Travis
         include Chruby
 
         MSGS = {
-          setup_ruby_head:   'Setting up latest %s',
-          ruby_version_file: 'BETA: Using Ruby version from .ruby-version. This is a beta feature and may be removed in the future.'
+          setup_ruby_head:   'Setting up latest %s'
         }
 
         CONFIG = %w(
@@ -84,7 +83,6 @@ module Travis
           end
 
           def use_ruby_version_file
-            sh.echo MSGS[:ruby_version_file], ansi: :yellow
             sh.fold('rvm') do
               sh.cmd 'rvm use $(< .ruby-version) --install --binary --fuzzy'
             end


### PR DESCRIPTION
The [docs](https://docs.travis-ci.com/user/languages/ruby/#Using-.ruby-version) give no indication that version detection via `.ruby-version` is a beta feature. Seems like either the docs should be updated, or the beta warning should be removed from build output. This PR does the latter.