### PR TITLE
Optionally separate cache setup process from install

### DIFF
--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -56,6 +56,7 @@ module Travis
       include Appliances, DirectoryCache, Deprecation, Template
 
       attr_reader :sh, :data, :options, :validator, :addons, :stages
+      attr_accessor :setup_cache_has_run_for
 
       def initialize(data)
         @data = Data.new({ config: self.class.defaults }.deep_merge(data.deep_symbolize_keys))
@@ -64,6 +65,7 @@ module Travis
         @sh = Shell::Builder.new
         @addons = Addons.new(self, sh, self.data, config)
         @stages = Stages.new(self, sh, config)
+        @setup_cache_has_run_for = {}
       end
 
       def compile(ignore_taint = false)

--- a/lib/travis/build/script/c.rb
+++ b/lib/travis/build/script/c.rb
@@ -39,6 +39,7 @@ module Travis
 
           if data.cache?(:ccache)
             sh.fold 'cache.ccache' do
+              sh.echo ''
               directory_cache.add('~/.ccache')
             end
           end

--- a/lib/travis/build/script/c.rb
+++ b/lib/travis/build/script/c.rb
@@ -29,9 +29,19 @@ module Travis
 
         def install
           super
+          unless setup_cache_has_run_for[:c]
+            setup_cache
+          end
+        end
+
+        def setup_cache
+          return if setup_cache_has_run_for[:c]
+
           if data.cache?(:ccache)
             directory_cache.add('~/.ccache')
           end
+
+          setup_cache_has_run_for[:c] = true
         end
 
         def use_directory_cache?

--- a/lib/travis/build/script/c.rb
+++ b/lib/travis/build/script/c.rb
@@ -38,7 +38,9 @@ module Travis
           return if setup_cache_has_run_for[:c]
 
           if data.cache?(:ccache)
-            directory_cache.add('~/.ccache')
+            sh.fold 'cache.ccache' do
+              directory_cache.add('~/.ccache')
+            end
           end
 
           setup_cache_has_run_for[:c] = true

--- a/lib/travis/build/script/cpp.rb
+++ b/lib/travis/build/script/cpp.rb
@@ -27,9 +27,19 @@ module Travis
 
         def install
           super
+          unless setup_cache_has_run_for[:cpp]
+            setup_cache
+          end
+        end
+
+        def setup_cache
+          return if setup_cache_has_run_for[:cpp]
+
           if data.cache?(:ccache)
             directory_cache.add('~/.ccache')
           end
+
+          setup_cache_has_run_for[:cpp] = true
         end
 
         def use_directory_cache?

--- a/lib/travis/build/script/cpp.rb
+++ b/lib/travis/build/script/cpp.rb
@@ -37,6 +37,7 @@ module Travis
 
           if data.cache?(:ccache)
             sh.fold 'cache.ccache' do
+              sh.echo ''
               directory_cache.add('~/.ccache')
             end
           end

--- a/lib/travis/build/script/cpp.rb
+++ b/lib/travis/build/script/cpp.rb
@@ -36,7 +36,9 @@ module Travis
           return if setup_cache_has_run_for[:cpp]
 
           if data.cache?(:ccache)
-            directory_cache.add('~/.ccache')
+            sh.fold 'cache.ccache' do
+              directory_cache.add('~/.ccache')
+            end
           end
 
           setup_cache_has_run_for[:cpp] = true

--- a/lib/travis/build/script/objective_c.rb
+++ b/lib/travis/build/script/objective_c.rb
@@ -56,7 +56,11 @@ module Travis
           return if setup_cache_has_run_for[:objective_c]
 
           sh.if podfile? do
-            directory_cache.add("#{pod_dir}/Pods") if data.cache?(:cocoapods)
+            if data.cache?(:cocoapods)
+              sh.fold 'cache.cocoapods' do
+                directory_cache.add("#{pod_dir}/Pods")
+              end
+            end
             sh.if "! ([[ -f #{pod_dir}/Podfile.lock && -f #{pod_dir}/Pods/Manifest.lock ]] && cmp --silent #{pod_dir}/Podfile.lock #{pod_dir}/Pods/Manifest.lock)", raw: true do
               sh.fold('install.cocoapods') do
                 sh.echo "Installing Pods with 'pod install'", ansi: :yellow

--- a/lib/travis/build/script/objective_c.rb
+++ b/lib/travis/build/script/objective_c.rb
@@ -58,6 +58,7 @@ module Travis
           sh.if podfile? do
             if data.cache?(:cocoapods)
               sh.fold 'cache.cocoapods' do
+                sh.echo ''
                 directory_cache.add("#{pod_dir}/Pods")
               end
             end

--- a/lib/travis/build/script/objective_c.rb
+++ b/lib/travis/build/script/objective_c.rb
@@ -46,6 +46,15 @@ module Travis
 
         def install
           super
+          unless setup_cache_has_run_for[:objective_c]
+            setup_cache
+          end
+        end
+
+        def setup_cache
+          super
+          return if setup_cache_has_run_for[:objective_c]
+
           sh.if podfile? do
             directory_cache.add("#{pod_dir}/Pods") if data.cache?(:cocoapods)
             sh.if "! ([[ -f #{pod_dir}/Podfile.lock && -f #{pod_dir}/Pods/Manifest.lock ]] && cmp --silent #{pod_dir}/Podfile.lock #{pod_dir}/Pods/Manifest.lock)", raw: true do
@@ -57,6 +66,8 @@ module Travis
               end
             end
           end
+
+          setup_cache_has_run_for[:objective_c] = true
         end
 
         def script

--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -38,6 +38,14 @@ module Travis
         end
 
         def install
+          unless setup_cache_has_run_for[:python]
+            setup_cache
+          end
+        end
+
+        def setup_cache
+          return if setup_cache_has_run_for[:python]
+
           if data.cache?(:pip)
             directory_cache.add '$HOME/.cache/pip'
           end
@@ -50,6 +58,8 @@ module Travis
           sh.else do
             sh.echo REQUIREMENTS_MISSING # , ansi: :red
           end
+
+          setup_cache_has_run_for[:python] = true
         end
 
         def script

--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -48,6 +48,7 @@ module Travis
 
           if data.cache?(:pip)
             sh.fold 'cache.pip' do
+              sh.echo ''
               directory_cache.add '$HOME/.cache/pip'
             end
           end

--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -47,7 +47,9 @@ module Travis
           return if setup_cache_has_run_for[:python]
 
           if data.cache?(:pip)
-            directory_cache.add '$HOME/.cache/pip'
+            sh.fold 'cache.pip' do
+              directory_cache.add '$HOME/.cache/pip'
+            end
           end
           sh.if '-f Requirements.txt' do
             sh.cmd 'pip install -r Requirements.txt', fold: 'install', retry: true

--- a/lib/travis/build/script/shared/bundler.rb
+++ b/lib/travis/build/script/shared/bundler.rb
@@ -22,6 +22,14 @@ module Travis
         end
 
         def install
+          unless setup_cache_has_run_for[:bundler]
+            setup_cache
+          end
+        end
+
+        def setup_cache
+          return if setup_cache_has_run_for[:bundler]
+
           sh.if gemfile? do
             sh.if gemfile_lock? do
               directory_cache.add(bundler_path(false)) if data.cache?(:bundler)
@@ -33,6 +41,8 @@ module Travis
               sh.cmd bundler_install, fold: "install.bundler", retry: true
             end
           end
+
+          setup_cache_has_run_for[:bundler] = true
         end
 
         def prepare_cache

--- a/lib/travis/build/script/shared/bundler.rb
+++ b/lib/travis/build/script/shared/bundler.rb
@@ -32,12 +32,20 @@ module Travis
 
           sh.if gemfile? do
             sh.if gemfile_lock? do
-              directory_cache.add(bundler_path(false)) if data.cache?(:bundler)
+              if data.cache?(:bundler)
+                sh.fold 'cache.bundler' do
+                  directory_cache.add(bundler_path(false))
+                end
+              end
               sh.cmd bundler_install("--deployment"), fold: "install.bundler", retry: true
             end
             sh.else do
               # Cache bundler if it has been explicitly enabled
-              directory_cache.add(bundler_path(false)) if data.cache?(:bundler, false)
+              if data.cache?(:bundler, false)
+                sh.fold 'cache.bundler' do
+                  directory_cache.add(bundler_path(false))
+                end
+              end
               sh.cmd bundler_install, fold: "install.bundler", retry: true
             end
           end

--- a/lib/travis/build/script/shared/bundler.rb
+++ b/lib/travis/build/script/shared/bundler.rb
@@ -43,6 +43,7 @@ module Travis
               # Cache bundler if it has been explicitly enabled
               if data.cache?(:bundler, false)
                 sh.fold 'cache.bundler' do
+                  sh.echo ''
                   directory_cache.add(bundler_path(false))
                 end
               end

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -19,7 +19,7 @@ module Travis
       ]
 
       STAGES_WITH_SETUP_CACHE = [
-        :builtin,     [:header, :configure, :checkout, :prepare, :disable_sudo, :export, :setup, :announce, :setup_cache],
+        :builtin,     [:header, :configure, :checkout, :prepare, :disable_sudo, :export, :setup, :setup_cache, :announce],
         :custom,      [:before_install, :install, :before_script, :script, :before_cache],
         :builtin,     [:cache],
         :conditional, [:after_success],

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -18,11 +18,23 @@ module Travis
         :builtin,     [:finish]
       ]
 
+      STAGES_WITH_SETUP_CACHE = [
+        :builtin,     [:header, :configure, :checkout, :prepare, :disable_sudo, :export, :setup, :announce, :setup_cache],
+        :custom,      [:before_install, :install, :before_script, :script, :before_cache],
+        :builtin,     [:cache],
+        :conditional, [:after_success],
+        # :addon,       [:deploy_all],
+        :conditional, [:after_failure],
+        :custom,      [:after_script],
+        :builtin,     [:finish]
+      ]
+
       STAGE_DEFAULT_OPTIONS = {
         checkout:       { assert: true,  echo: true,  timing: true  },
         export:         { assert: false, echo: false, timing: false },
         setup:          { assert: true,  echo: true,  timing: true  },
         announce:       { assert: false, echo: true,  timing: false },
+        setup_cache:    { assert: false, echo: true,  timing: false },
         before_install: { assert: true,  echo: true,  timing: true  },
         install:        { assert: true,  echo: true,  timing: true  },
         before_script:  { assert: true,  echo: true,  timing: true  },
@@ -48,7 +60,12 @@ module Travis
       end
 
       def run
-        STAGES.each_slice(2) do |type, names|
+        if config[:cache].is_a?(Hash) && config[:cache][:custom_install]
+          stages = STAGES_WITH_SETUP_CACHE
+        else
+          stages = STAGES
+        end
+        stages.each_slice(2) do |type, names|
           names.each { |name| run_stage(type, name) }
         end
       end


### PR DESCRIPTION
With `cache.custom_install: true`, other caching directives
such as `cache.bundler: true` will be respected, and the
overridden `install` section will not negate `cache.bundler: true`

Caveat: There are no specs yet.