### PR TITLE
Remove a no-op actool

### DIFF
--- a/lib/travis/build/script/objective_c.rb
+++ b/lib/travis/build/script/objective_c.rb
@@ -38,12 +38,6 @@ module Travis
           end
         end
 
-        def setup
-          super
-          sh.cmd "echo '#!/bin/bash\n# no-op' > /usr/local/bin/actool", echo: false
-          sh.cmd 'chmod +x /usr/local/bin/actool', echo: false
-        end
-
         def install
           super
           sh.if podfile? do


### PR DESCRIPTION
This effectively reverts https://github.com/travis-ci/travis-build/pull/157,
which was added as a hack to get around the problem where
`actool` was expected but not found.

This manifested in an error when the job was routed to Linux but
the build script was on Objective-C.