### PR TITLE
Move artifacts from `before_finish` to `after_script`

### DIFF
--- a/lib/travis/build/addons/artifacts.rb
+++ b/lib/travis/build/addons/artifacts.rb
@@ -22,7 +22,7 @@ module Travis
           sh.raw template('artifacts.sh')
         end
 
-        def before_finish
+        def after_script
           sh.newline
           validator.valid? ? run : warn
           sh.newline

--- a/spec/build/addons/artifacts_spec.rb
+++ b/spec/build/addons/artifacts_spec.rb
@@ -12,7 +12,7 @@ describe Travis::Build::Addons::Artifacts, :sexp do
   before :each do
     addon.validator.stubs(valid?: true)
     addon.after_header
-    addon.before_finish
+    addon.after_script
   end
 
   it_behaves_like 'compiled script' do
@@ -60,13 +60,13 @@ describe Travis::Build::Addons::Artifacts, :sexp do
     end
 
     it 'echoes the messages' do
-      addon.before_finish
+      addon.after_script
       should include_sexp [:echo, 'kaputt 1', ansi: :red], [:echo, 'kaputt 2', ansi: :red]
     end
 
     it 'does not run the addon' do
       subject.expects(:run).never
-      addon.before_finish
+      addon.after_script
     end
   end
 end


### PR DESCRIPTION
so that the uploaded artifacts are available for deployment step(s)