### PR TITLE
HHVM on Trusty

### DIFF
--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -90,7 +90,7 @@ module Travis
               sh.cmd 'echo "deb http://dl.hhvm.com/ubuntu $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list'
             end
             sh.cmd 'sudo apt-get update -qq'
-            sh.cmd 'sudo apt-get install hhvm 2>&1 >/dev/null'
+            sh.cmd 'sudo apt-get install -y hhvm 2>&1 >/dev/null'
           end
         end
 
@@ -101,7 +101,7 @@ module Travis
           end
           sh.echo 'Installing HHVM nightly', ansi: :yellow
           sh.cmd 'sudo apt-get update -qq'
-          sh.cmd 'sudo apt-get install hhvm-nightly 2>&1 >/dev/null'
+          sh.cmd 'sudo apt-get install hhvm-nightly -y 2>&1 >/dev/null'
         end
 
         def fix_hhvm_php_ini

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -83,7 +83,7 @@ module Travis
         end
 
         def update_hhvm
-          sh.if '"$(lsb_release -sc 2>/dev/null)" = "precise"' do
+          sh.if '"$(lsb_release -sc 2>/dev/null)"' do
             sh.echo 'Updating HHVM', ansi: :yellow
             sh.cmd 'sudo apt-get update -qq'
             sh.cmd 'sudo apt-get install hhvm 2>&1 >/dev/null'

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -85,6 +85,10 @@ module Travis
         def update_hhvm
           sh.if '"$(lsb_release -sc 2>/dev/null)"' do
             sh.echo 'Updating HHVM', ansi: :yellow
+            sh.if "! $(grep -r hhvm\\.com /etc/apt/sources* 2>/dev/null)" do
+              sh.cmd 'sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0x5a16e7281be7a449'
+              sh.cmd 'echo "deb http://dl.hhvm.com/ubuntu $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list'
+            end
             sh.cmd 'sudo apt-get update -qq'
             sh.cmd 'sudo apt-get install hhvm 2>&1 >/dev/null'
           end

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -19,10 +19,12 @@ module Travis
 
         def setup
           super
-          sh.cmd "phpenv global #{version} 2>/dev/null", assert: false
-          sh.if "$? -ne 0" do
-            install_php_on_demand(version)
-            sh.cmd "phpenv global #{version}", assert: true
+          unless hhvm?
+            sh.cmd "phpenv global #{version} 2>/dev/null", assert: false
+            sh.if "$? -ne 0" do
+              install_php_on_demand(version)
+              sh.cmd "phpenv global #{version}", assert: true
+            end
           end
           sh.cmd "phpenv rehash", assert: false, echo: false, timing: false
         end

--- a/spec/build/script/php_spec.rb
+++ b/spec/build/script/php_spec.rb
@@ -56,7 +56,7 @@ describe Travis::Build::Script::Php, :sexp do
   describe 'installs hhvm-nightly' do
     before { data[:config][:php] = 'hhvm-nightly' }
     it { should include_sexp [:cmd, 'sudo apt-get update -qq'] }
-    it { should include_sexp [:cmd, 'sudo apt-get install hhvm-nightly 2>&1 >/dev/null'] }
+    it { should include_sexp [:cmd, 'sudo apt-get install hhvm-nightly -y 2>&1 >/dev/null'] }
   end
 
   describe 'when desired PHP version is not found' do


### PR DESCRIPTION
This PR adds support for HHVM on Trusty, which is at 3.11 as of this writing.

A single build test is here: https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/465695

And a matrix build, along with other PHP versions, is here: https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/465699