### PR TITLE
Export $SMALLTALK and $BASELINE before custom env variables

### DIFF
--- a/lib/travis/build/script/smalltalk.rb
+++ b/lib/travis/build/script/smalltalk.rb
@@ -20,9 +20,9 @@ module Travis
         end
 
         def export
-          super
           sh.export 'SMALLTALK', config[:smalltalk], echo: false
           sh.export 'BASELINE', config[:baseline], echo: false
+          super
          end
 
         def setup


### PR DESCRIPTION
@BanzaiMan Unfortunately, the change from yesterday broke all Smalltalk builds, because the value for `baseline` always overrides the custom env variable which everyone used before.

This change should make yesterday's change backwards-compatible by exporting the `$SMALLTALK` and `$BASELINE` before any other env variable.

Sorry about the hassle, but can we also get this in soon? That'd be awesome!

/cc @marceltaeumel