### PR TITLE
Upadte link to travis worker on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Travis Build [![Build Status](https://travis-ci.org/travis-ci/travis-build.png?branch=master)](https://travis-ci.org/travis-ci/travis-build)
 
 Travis Build is a library that [Travis
-Workers](https://github.com/travis-ci/travis-worker) use to generate a shell
+Workers](https://github.com/travis-ci/worker) use to generate a shell
 based build script which is then uploaded to the VMs using SSH and executed,
 with the resulting output streamed back to Travis.
 
 This code base has gone through several iterations of development, and was
 originally extracted from [Travis
-Worker](https://github.com/travis-ci/travis-worker), before taking its current
+Worker](https://github.com/travis-ci/worker), before taking its current
 form.
 
 ## Running test suites


### PR DESCRIPTION
Some links on README.md see travis-ci/travis-worker that is deprecated.