### PR TITLE
Effectively revert https://github.com/travis-ci/travis-build/pull/504

### DIFF
--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -18,7 +18,6 @@ module Travis
           npm_disable_spinner
           npm_disable_strict_ssl unless npm_strict_ssl?
           setup_npm_cache if use_npm_cache?
-          install_npm_from_package_json
         end
 
         def announce
@@ -137,16 +136,6 @@ module Travis
 
           def iojs_3_plus?
             (config[:node_js] || '').to_s.split('.')[0].to_i >= 3
-          end
-
-          def install_npm_from_package_json
-            sh.if '-f package.json' do
-              sh.cmd 'jq -e .engines.npm package.json >/dev/null', echo: false, assert: false
-              sh.if '$? -eq 0' do
-                sh.echo "Installing npm specified in package.json: $(jq -r .engines.npm package.json)", ansi: :yellow
-                sh.cmd "npm install -g npm@$(jq -r .engines.npm package.json)", echo: true, assert: false
-              end
-            end
           end
       end
     end

--- a/spec/build/script/node_js_spec.rb
+++ b/spec/build/script/node_js_spec.rb
@@ -67,16 +67,8 @@ describe Travis::Build::Script::NodeJs, :sexp do
     should include_sexp [:cmd, 'npm config set spin false', assert: true]
   end
 
-  context 'when package.json defines .engines.npm' do
-    let(:sexp) { sexp_find(sexp_find(sexp_filter(subject, [:if, '-f package.json'])[0], [:then]), [:if, '$? -eq 0']) }
-
-    it "installs specified npm" do
-      expect(sexp).to include_sexp [:cmd, "npm install -g npm@$(jq -r .engines.npm package.json)", echo: true, timing: true]
-    end
-  end
-
   describe 'if package.json exists' do
-    let(:sexp) { sexp_find(sexp_filter(subject, [:if, '-f package.json'])[1], [:then]) }
+    let(:sexp) { sexp_find(subject, [:if, '-f package.json'], [:then]) }
 
     it 'installs with npm install --npm-args' do
       data[:config][:npm_args] = '--npm-args'
@@ -85,7 +77,7 @@ describe Travis::Build::Script::NodeJs, :sexp do
   end
 
   describe 'script' do
-    let(:sexp) { sexp_filter(subject, [:if, '-f package.json'])[2] }
+    let(:sexp) { sexp_filter(subject, [:if, '-f package.json'])[1] }
 
     it 'runs npm test if package.json exists' do
       branch = sexp_find(sexp, [:then])


### PR DESCRIPTION
According to https://docs.npmjs.com/files/package.json#engines
`package.json` is consulted for the version of `npm` that can
**install* the pacakge, not one that builds it.