### PR TITLE
Explicitly download `-nonroot` tarball for erlang/elixir

### DIFF
--- a/lib/travis/build/addons/firefox.rb
+++ b/lib/travis/build/addons/firefox.rb
@@ -24,7 +24,7 @@ module Travis
             sh.chown 'travis', install_dir, recursive: true
             sh.cd install_dir, echo: false, stack: true
             sh.cmd "wget -O /tmp/#{filename} $FIREFOX_SOURCE_URL", echo: true, timing: true, retry: true
-            sh.cmd "tar xf /tmp/#{filename}"
+            sh.cmd "tar -xf /tmp/#{filename}"
             sh.cmd "sudo ln -sf #{install_dir}/firefox/firefox /usr/local/bin/firefox", echo: false
             sh.cd :back, echo: false, stack: true
           end

--- a/lib/travis/build/git/tarball.rb
+++ b/lib/travis/build/git/tarball.rb
@@ -24,7 +24,7 @@ module Travis
           end
 
           def extract
-            sh.cmd "tar xfz #{filename}"
+            sh.cmd "tar -xfz #{filename}"
           end
 
           def move

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -134,7 +134,7 @@ module Travis
         end
 
         def host_os
-          case RbConfig::CONFIG["host_os"]
+          case rbconfig_host_os
           when /^(?i:linux)/
             '$(lsb_release -is | tr "A-Z" "a-z")'
           when /^(?i:darwin)/
@@ -143,12 +143,16 @@ module Travis
         end
 
         def rel_version
-          case RbConfig::CONFIG["host_os"]
+          case rbconfig_host_os
           when /^(?i:linux)/
             '$(lsb_release -rs)'
           when /^(?i:darwin)/
             '${$(sw_vers -productVersion)%*.*}'
           end
+        end
+
+        def rbconfig_host_os
+          RbConfig::CONFIG["host_os"]
         end
     end
   end

--- a/lib/travis/build/script/erlang.rb
+++ b/lib/travis/build/script/erlang.rb
@@ -58,19 +58,15 @@ module Travis
             "#{HOME_DIR}/otp/#{otp_release}/activate"
           end
 
-          def erlang_archive_url(release)
-            "https://s3.amazonaws.com/travis-otp-releases/ubuntu/$(lsb_release -rs)/erlang-#{release}-x86_64.tar.bz2"
-          end
-
           def archive_name(release)
-            "erlang-#{release}.tar.bz2"
+            "erlang-#{release}-nonroot.tar.bz2"
           end
 
           def install_erlang(release)
             sh.echo "#{release} is not installed. Downloading and installing pre-build binary.", ansi: :yellow
             sh.cmd "kerl update releases"
-            sh.cmd "wget #{archive_url_for('travis-otp-releases',release, 'erlang')}"
-            sh.cmd "tar xf #{archive_name(release)} -C ~/otp/"
+            sh.cmd "wget #{archive_url_for('travis-otp-releases', release, 'erlang').gsub(/\.tar\.bz2/, '-nonroot.tar.bz2')}"
+            sh.cmd "tar -xf #{archive_name(release)} -C ~/otp/"
             sh.cmd "echo '#{release},#{release}' >> ~/.kerl/otp_builds", echo: false
             sh.cmd "echo '#{release} #{HOME_DIR}/otp/#{release}' >> ~/.kerl/otp_builds", echo: false
           end

--- a/lib/travis/build/script/perl.rb
+++ b/lib/travis/build/script/perl.rb
@@ -63,7 +63,7 @@ module Travis
 
         def install_perl_archive(version)
           sh.cmd "curl -s -o perl-#{version}.tar.bz2 #{archive_url_for('travis-perl-archives', version)}", echo: false
-          sh.cmd "sudo tar xjf perl-#{version}.tar.bz2 --directory /", echo: false
+          sh.cmd "sudo tar -xjf perl-#{version}.tar.bz2 --directory /", echo: false
           sh.cmd "rm perl-#{version}.tar.bz2", echo: false
         end
 

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -120,7 +120,7 @@ hhvm.libxml.ext_entity_whitelist=file,http,https
             setup_alias(version, '7.0')
             version = '7.0'
           end
-          sh.cmd "curl -s -o archive.tar.bz2 #{archive_url_for('travis-php-archives', version)} && tar xjf archive.tar.bz2 --directory /", echo: false, assert: false
+          sh.cmd "curl -s -o archive.tar.bz2 #{archive_url_for('travis-php-archives', version)} && tar -xjf archive.tar.bz2 --directory /", echo: false, assert: false
           sh.cmd "rm -f archive.tar.bz2", echo: false
         end
 

--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -105,7 +105,7 @@ module Travis
           def install_python_archive(version = 'nightly')
             puts archive_url_for('travis-python-archives', version)
             sh.cmd "curl -s -o python-#{version}.tar.bz2 #{archive_url_for('travis-python-archives', version)}", echo: false
-            sh.cmd "sudo tar xjf python-#{version}.tar.bz2 --directory /", echo: false
+            sh.cmd "sudo tar -xjf python-#{version}.tar.bz2 --directory /", echo: false
             sh.cmd "rm python-#{version}.tar.bz2", echo: false
           end
 

--- a/spec/build/addons/firefox_spec.rb
+++ b/spec/build/addons/firefox_spec.rb
@@ -28,7 +28,7 @@ describe Travis::Build::Addons::Firefox, :sexp do
     it { should include_sexp [:export, ['FIREFOX_SOURCE_URL', "'https://#{host}/#{path}'"], echo: true] }
 
     it { should include_sexp [:cmd, 'wget -O /tmp/firefox-20.0.tar.bz2 $FIREFOX_SOURCE_URL', echo: true, timing: true, retry: true] }
-    it { should include_sexp [:cmd, 'tar xf /tmp/firefox-20.0.tar.bz2'] }
+    it { should include_sexp [:cmd, 'tar -xf /tmp/firefox-20.0.tar.bz2'] }
     it { should include_sexp [:cmd, 'sudo ln -sf $HOME/firefox-20.0/firefox/firefox /usr/local/bin/firefox'] }
     it { should include_sexp [:cd, :back, stack: true] }
   end

--- a/spec/build/git/tarball_spec.rb
+++ b/spec/build/git/tarball_spec.rb
@@ -21,7 +21,7 @@ describe Travis::Build::Git::Clone, :sexp do
   let(:curl)     { "curl -o #{file} -H \"Authorization: token #{token}\" -L #{url}" }
   let(:echo)     { "curl -o #{file} -H \"Authorization: token [SECURE]\" -L #{url}" }
   let(:download) { [:cmd, curl, assert: true, echo: echo, retry: true, timing: true] }
-  let(:extract)  { [:cmd, "tar xfz #{file}", assert: true, echo: true, timing: true] }
+  let(:extract)  { [:cmd, "tar -xfz #{file}", assert: true, echo: true, timing: true] }
   let(:move)     { [:mv, ['travis-ci-travis-ci-313f61b/*', 'travis-ci/travis-ci'], assert: true] }
   let(:cd)       { [:cd, 'travis-ci/travis-ci', echo: true] }
 

--- a/spec/build/script/elixir_spec.rb
+++ b/spec/build/script/elixir_spec.rb
@@ -1,9 +1,14 @@
 require 'spec_helper'
 
 describe Travis::Build::Script::Elixir, :sexp do
-  let(:data)   { payload_for(:push, :elixir) }
+  let(:data) { payload_for(:push, :elixir) }
   let(:script) { described_class.new(data) }
-  subject      { script.sexp }
+
+  subject { script.sexp }
+
+  before do
+    script.stubs(:rbconfig_host_os).returns('linux')
+  end
 
   it_behaves_like 'compiled script' do
     let(:code) { ['TRAVIS_LANGUAGE=elixir'] }
@@ -56,16 +61,28 @@ describe Travis::Build::Script::Elixir, :sexp do
 
         if otp_release_wanted == otp_release_required
           describe "wanted OTP release #{otp_release_wanted}" do
-            xit "is installed" do
+            it "is installed" do
               sexp = sexp_find(subject, [:if, "! -f #{Travis::Build::HOME_DIR}/otp/#{otp_release_wanted}/activate"], [:then])
-              expect(sexp).to include_sexp([:cmd, "wget https://s3.amazonaws.com/travis-otp-releases/ubuntu/$(lsb_release -rs)/erlang-#{otp_release_wanted}-x86_64.tar.bz2", assert: true, echo: true, timing: true])
+              expect(sexp).to include_sexp(
+                [
+                  :cmd,
+                  %{wget https://s3.amazonaws.com/travis-otp-releases/binaries/$(lsb_release -is | tr "A-Z" "a-z")/$(lsb_release -rs)/$(uname -m)/erlang-#{otp_release_wanted}-nonroot.tar.bz2},
+                  assert: true, echo: true, timing: true
+                ]
+              )
             end
           end
         else
           describe "required OTP release #{otp_release_required}" do
-            xit "is installed" do
+            it "is installed" do
               sexp = sexp_find(subject, [:if, "! -f #{Travis::Build::HOME_DIR}/otp/#{otp_release_required}/activate"], [:then])
-              expect(sexp).to include_sexp([:cmd, "wget https://s3.amazonaws.com/travis-otp-releases/ubuntu/$(lsb_release -rs)/erlang-#{otp_release_required}-x86_64.tar.bz2", assert: true, echo: true, timing: true])
+              expect(sexp).to include_sexp(
+                [
+                  :cmd,
+                  %{wget https://s3.amazonaws.com/travis-otp-releases/binaries/$(lsb_release -is | tr "A-Z" "a-z")/$(lsb_release -rs)/$(uname -m)/erlang-#{otp_release_required}-nonroot.tar.bz2},
+                  assert: true, echo: true, timing: true
+                ]
+              )
             end
           end
         end

--- a/spec/build/script/python_spec.rb
+++ b/spec/build/script/python_spec.rb
@@ -39,7 +39,7 @@ describe Travis::Build::Script::Python, :sexp do
 
   it 'sets up the python version nightly' do
     data[:config][:python] = 'nightly'
-    should include_sexp [:cmd,  'sudo tar xjf python-nightly.tar.bz2 --directory /']
+    should include_sexp [:cmd,  'sudo tar -xjf python-nightly.tar.bz2 --directory /']
     should include_sexp [:cmd,  'source ~/virtualenv/pythonnightly/bin/activate', assert: true, echo: true, timing: true]
   end
 


### PR DESCRIPTION
plus attempting to re-enable other specs that verify download URLs.  This is
failing pretty spectacularly on my local OSX machine, so pushing to see how it
fares in CI.