### PR TITLE
Install PostgreSQL on demand

### DIFF
--- a/lib/travis/build/addons/postgresql.rb
+++ b/lib/travis/build/addons/postgresql.rb
@@ -11,6 +11,7 @@ module Travis
         DEFAULT_FALLBACK_PORT = 5433
 
         def after_prepare
+          install(version)
           sh.fold 'postgresql' do
             sh.export 'PATH', "/usr/lib/postgresql/#{version}/bin:$PATH", echo: false
             sh.echo "Starting PostgreSQL v#{version}", ansi: :yellow
@@ -30,6 +31,20 @@ module Travis
 
           def version
             config.to_s.shellescape
+          end
+
+          def install(version)
+            sh.if "! (#{version_installed?(version)})" do
+              sh.fold "install.postgresql_#{version}" do
+                sh.echo "Installing PostgreSQL #{version}", ansi: :yellow
+                sh.cmd "sudo apt-get update -qq"
+                sh.cmd "sudo apt-get install postgresql-contrib-#{version}", echo: true
+              end
+            end
+          end
+
+          def version_installed?(version)
+            "test -d /usr/lib/postgresql/#{version}/bin"
           end
       end
     end

--- a/lib/travis/build/addons/postgresql.rb
+++ b/lib/travis/build/addons/postgresql.rb
@@ -34,7 +34,7 @@ module Travis
           end
 
           def install(version)
-            sh.if "! (#{version_installed?(version)})" do
+            sh.if "!(#{version_installed?(version)})" do
               sh.fold "install.postgresql_#{version}" do
                 sh.echo "Installing PostgreSQL #{version}", ansi: :yellow
                 sh.cmd "sudo apt-get update -qq"

--- a/lib/travis/build/addons/postgresql.rb
+++ b/lib/travis/build/addons/postgresql.rb
@@ -11,11 +11,11 @@ module Travis
         DEFAULT_FALLBACK_PORT = 5433
 
         def after_prepare
-          install(version)
           sh.fold 'postgresql' do
             sh.export 'PATH', "/usr/lib/postgresql/#{version}/bin:$PATH", echo: false
             sh.echo "Starting PostgreSQL v#{version}", ansi: :yellow
             sh.cmd 'service postgresql stop', assert: false, sudo: true, echo: true, timing: true
+            install(version)
             sh.if "-d /var/ramfs && ! -d /var/ramfs/postgresql/#{version}", echo: false do
               sh.cmd "cp -rp /var/lib/postgresql/#{version} /var/ramfs/postgresql/#{version}", sudo: true, assert: false, echo: false, timing: false
             end

--- a/lib/travis/build/addons/postgresql.rb
+++ b/lib/travis/build/addons/postgresql.rb
@@ -37,6 +37,7 @@ module Travis
             sh.if "!(#{version_installed?(version)})" do
               sh.fold "install.postgresql_#{version}" do
                 sh.echo "Installing PostgreSQL #{version}", ansi: :yellow
+                sh.cmd 'service postgresql stop', assert: false, sudo: true, echo: true, timing: true
                 sh.cmd "sudo apt-get update -qq"
                 sh.cmd "sudo apt-get install postgresql-contrib-#{version}", echo: true
               end

--- a/lib/travis/build/addons/postgresql.rb
+++ b/lib/travis/build/addons/postgresql.rb
@@ -39,7 +39,7 @@ module Travis
                 sh.echo "Installing PostgreSQL #{version}", ansi: :yellow
                 sh.cmd 'service postgresql stop', assert: false, sudo: true, echo: true, timing: true
                 sh.cmd "sudo apt-get update -qq"
-                sh.cmd "sudo apt-get install postgresql-contrib-#{version}", echo: true
+                sh.cmd "sudo apt-get install -y postgresql-contrib-#{version}", echo: true
               end
             end
           end

--- a/lib/travis/build/addons/postgresql.rb
+++ b/lib/travis/build/addons/postgresql.rb
@@ -34,7 +34,7 @@ module Travis
           end
 
           def install(version)
-            sh.if "!(#{version_installed?(version)})" do
+            sh.if "! -x #{postgresql_executable(version)}" do
               sh.fold "install.postgresql_#{version}" do
                 sh.echo "Installing PostgreSQL #{version}", ansi: :yellow
                 sh.cmd 'service postgresql stop', assert: false, sudo: true, echo: true, timing: true
@@ -44,8 +44,8 @@ module Travis
             end
           end
 
-          def version_installed?(version)
-            "test -d /usr/lib/postgresql/#{version}/bin"
+          def postgresql_executable(version)
+            "/usr/lib/postgresql/#{version}/bin/postgres"
           end
       end
     end

--- a/spec/build/addons/postgresql_spec.rb
+++ b/spec/build/addons/postgresql_spec.rb
@@ -24,4 +24,10 @@ describe Travis::Build::Addons::Postgresql, :sexp do
   it { should include_sexp [:cmd, "sudo -u postgres createuser -s -p #{described_class::DEFAULT_FALLBACK_PORT} travis &>/dev/null", echo: true, timing: true] }
   it { should include_sexp [:cmd, "sudo -u postgres createdb -O travis -p #{described_class::DEFAULT_PORT} travis &>/dev/null", echo: true, timing: true] }
   it { should include_sexp [:cmd, "sudo -u postgres createdb -O travis -p #{described_class::DEFAULT_FALLBACK_PORT} travis &>/dev/null", echo: true, timing: true] }
+
+  it "installs postgres conditionally" do
+    installed_sexp = sexp_filter(subject, [:if, "!(test -d /usr/lib/postgresql/#{config}/bin)"])[0]
+    fold = sexp_filter(installed_sexp, [:fold, "install.postgresql_#{config}"])
+    expect(fold).to include_sexp [:cmd, "sudo apt-get install -y postgresql-contrib-#{config}", echo: true]
+  end
 end

--- a/spec/build/addons/postgresql_spec.rb
+++ b/spec/build/addons/postgresql_spec.rb
@@ -26,7 +26,7 @@ describe Travis::Build::Addons::Postgresql, :sexp do
   it { should include_sexp [:cmd, "sudo -u postgres createdb -O travis -p #{described_class::DEFAULT_FALLBACK_PORT} travis &>/dev/null", echo: true, timing: true] }
 
   it "installs postgres conditionally" do
-    installed_sexp = sexp_filter(subject, [:if, "!(test -d /usr/lib/postgresql/#{config}/bin)"])[0]
+    installed_sexp = sexp_filter(subject, [:if, "! -x /usr/lib/postgresql/#{config}/bin/postgres"])[0]
     fold = sexp_filter(installed_sexp, [:fold, "install.postgresql_#{config}"])
     expect(fold).to include_sexp [:cmd, "sudo apt-get install -y postgresql-contrib-#{config}", echo: true]
   end


### PR DESCRIPTION
See https://github.com/travis-ci/travis-ci/issues/4264.

With 9.3 (already installed, so nothing happens): https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/469792

With 9.5: https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/469801#L78

Notice that 9.5 is configured on port 5433, which might be a problem.

Note that we do not install PostGIS.