### PR TITLE
#Stop overriding travis-rubies URL

### DIFF
--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -9,12 +9,6 @@ module Travis
           ruby_version_file: 'BETA: Using Ruby version from .ruby-version. This is a beta feature and may be removed in the future.'
         }
 
-        CONFIG = %w(
-          rvm_remote_server_url3=https://s3.amazonaws.com/travis-rubies/binaries
-          rvm_remote_server_type3=rubies
-          rvm_remote_server_verify_downloads3=1
-        )
-
         def export
           super
           sh.export 'TRAVIS_RUBY_VERSION', config[:rvm], echo: false if rvm?
@@ -51,7 +45,6 @@ module Travis
 
           def setup_rvm
             sh.cmd('type rvm &>/dev/null || source ~/.rvm/scripts/rvm', echo: false, assert: false)
-            sh.file '$rvm_path/user/db', CONFIG.join("\n")
             send rvm_strategy
           end
 


### PR DESCRIPTION
This patch makes RVM on Travis CI to successfully install binary rubies from travis-rubies server given only the partial version string. (For example, "2.3" now correctly use "2.3.0", "2.2" uses "2.2.4", etc.)

This override were causing RVM to unable to see which binary rubies are available from travis-rubies, as the old travis-ruby URL does not contain the necessary index file[[1]]. RVM already properly configured the
new travis-ruby URL[[2]] which host the necessary index file[[3]] on it, so this override is no longer needed.

[1]: https://s3.amazonaws.com/travis-rubies/binaries/index.txt
[2]: https://github.com/rvm/rvm/blob/1.26.11/config/db#L87
[3]: https://rubies.travis-ci.org/index.txt