### PR TITLE
Announce bash version on Generic builds

### DIFF
--- a/lib/travis/build/script/generic.rb
+++ b/lib/travis/build/script/generic.rb
@@ -3,6 +3,10 @@ module Travis
     class Script
       class Generic < Script
         DEFAULTS = {}
+
+        def announce
+          sh.cmd "bash --version", echo: true, assert: true, timing: false
+        end
       end
     end
   end


### PR DESCRIPTION
This ensures that `travis_result` is called to look at the exit status of a reasonable command.