### PR TITLE
Add GemStone support and refactor smalltalk.rb

### DIFF
--- a/lib/travis/build/script/smalltalk.rb
+++ b/lib/travis/build/script/smalltalk.rb
@@ -1,39 +1,68 @@
+# Copyright (c) 2015-2016 Software Architecture Group (Hasso Plattner Institute)
+# Copyright (c) 2015-2016 Fabio Niephaus, Google Inc.
+
 module Travis
   module Build
     class Script
       class Smalltalk < Script
-        DEFAULTS = {}
+        DEFAULTS = {
+          gemstone_hostname: 'travis.dev'
+        }
+        HOSTS_FILE = '/etc/hosts'
+        TEMP_HOSTS_FILE = '/tmp/hosts'
+        SYSCTL_FILE = '/etc/sysctl.conf'
+        TEMP_SYSCTL_FILE = '/tmp/sysctl.conf'
 
         def configure
           super
-          case config[:os]
-          when 'linux'
-            sh.fold 'install_packages' do
-              sh.echo 'Installing dependencies', ansi: :yellow
-              sh.cmd 'sudo apt-get update -qq', retry: true
-              sh.cmd 'sudo apt-get install --no-install-recommends ' +
-                     'libc6:i386 libuuid1:i386 libfreetype6:i386 libssl1.0.0:i386', retry: true
+
+          if is_squeak? or is_pharo?
+            case config[:os]
+            when 'linux'
+              install_dependencies
+            when 'osx'
+              # pass
             end
-          when 'osx'
-            # pass
+
+          elsif is_gemstone?
+
+            sh.fold 'gemstone_prepare_dependencies' do
+            sh.echo 'Preparing build for GemStone', ansi: :yellow
+              add_host('#{gemstone_hostname}')
+
+              case config[:os]
+              when 'linux'
+                sh.cmd 'sudo hostname #{gemstone_hostname}'
+
+                gemstone_prepare_linux_shared_memory
+                gemstone_prepare_linux_dependencies
+              when 'osx'
+                sh.cmd 'sudo scutil --set HostName #{gemstone_hostname}'
+
+                gemstone_prepare_osx_shared_memory
+              end
+
+              gemstone_prepare_netldi
+              gemstone_prepare_directories
+            end
+
           end
         end
 
         def export
           super
-          sh.export 'SMALLTALK', config[:smalltalk], echo: false
-          sh.export 'BASELINE', config[:baseline], echo: false
-         end
+
+          sh.export 'TRAVIS_SMALLTALK_VERSION', smalltalk_version, echo: false
+        end
 
         def setup
           super
 
-          sh.echo 'Smalltalk for Travis-CI is not officially supported, but is community maintained.', ansi: :green
+          sh.echo 'Smalltalk for Travis-CI is not officially supported, ' \
+            'but is community maintained.', ansi: :green
           sh.echo 'Please file any issues using the following link', ansi: :green
-          sh.echo '  https://github.com/travis-ci/travis-ci/issues/new?labels=community:smalltalk', ansi: :green
-          sh.echo 'and mention \`@bahnfahren\`, \`@chistopher\`, \`@fniephaus\`, \`@jchromik\` and \`@Nef10\` in the issue', ansi: :green
+          sh.echo '  https://github.com/hpi-swa/smalltalkCI/issues', ansi: :green
 
-          sh.cmd "export PROJECT_HOME=\"$(pwd)\""
           sh.cmd "pushd $HOME > /dev/null", echo: false
           sh.fold 'download_smalltalkci' do
             sh.echo 'Downloading and extracting smalltalkCI', ansi: :yellow
@@ -47,8 +76,160 @@ module Travis
 
         def script
           super
+
           sh.cmd "$SMALLTALK_CI_HOME/run.sh"
         end
+
+        private
+
+          def smalltalk_version
+            config[:smalltalk].to_s
+          end
+
+          def is_squeak?
+            is_platform?('squeak')
+          end
+
+          def is_pharo?
+            is_platform?('pharo')
+          end
+
+          def is_gemstone?
+            is_platform?('gemstone')
+          end
+
+          def is_platform?(name)
+            config[:smalltalk].to_s.downcase.start_with?(name)
+          end
+
+          def add_host(name)
+            sh.cmd "sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 #{host}/' #{HOSTS_FILE} | sed -e 's/^\\(::1.*\\)$/\\1 #{host}/' > #{TEMP_HOSTS_FILE}"
+            sh.cmd "cat #{TEMP_HOSTS_FILE} | sudo tee #{HOSTS_FILE} > /dev/null"
+          end
+
+          def install_dependencies
+            sh.fold 'install_packages' do
+              sh.echo 'Installing dependencies', ansi: :yellow
+
+              case rel_version
+              when '14.04'
+                sh.cmd 'sudo dpkg --add-architecture i386'
+              end
+
+              sh.cmd 'sudo apt-get update -qq', retry: true
+              sh.cmd 'sudo apt-get install --no-install-recommends ' +
+                     'libc6:i386 libuuid1:i386 libfreetype6:i386 libssl1.0.0:i386', retry: true
+            end
+          end
+
+          def gemstone_prepare_linux_shared_memory
+            sh.fold 'gemstone_shared_memory' do
+              sh.echo 'Setting up shared memory', ansi: :yellow
+
+              sh.cmd 'SMALLTALK_CI_TOTALMEM=$(($(awk "/MemTotal:/{print($2);}"" /proc/meminfo) * 1024))'
+              sh.cmd 'SMALLTALK_CI_SHMMAX=`cat /proc/sys/kernel/shmmax`'
+              sh.cmd 'SMALLTALK_CI_SHMALL=`cat /proc/sys/kernel/shmall`'
+
+              sh.cmd 'SMALLTALK_CI_SHMMAX_NEW=$(($SMALLTALK_CI_TOTALMEM * 3/4))'
+              sh.cmd '[[ $SMALLTALK_CI_SHMMAX_NEW -gt 2147483648 ]] && SMALLTALK_CI_SHMMAX_NEW=2147483648'
+
+              sh.if '$SMALLTALK_CI_SHMMAX_NEW -gt $SMALLTALK_CI_SHMMAX' do
+                sh.cmd 'sudo bash -c "echo $SMALLTALK_CI_SHMMAX_NEW > /proc/sys/kernel/shmmax"'
+                sh.cmd "sudo /bin/su -c \"echo 'kernel.shmmax=$SMALLTALK_CI_SHMMAX_NEW' >> #{SYSCTL_FILE}\""
+              end
+
+              sh.cmd 'SMALLTALK_CI_SHMALL_NEW=$(($SMALLTALK_CI_SHMALL / 4096))'
+              sh.cmd '[[ $SMALLTALK_CI_SHMALL_NEW -lt $SMALLTALK_CI_SHMALL ]] && SMALLTALK_CI_SHMALL_NEW=$SMALLTALK_CI_SHMALL'
+
+              sh.if '$SMALLTALK_CI_SHMALL_NEW -gt $SMALLTALK_CI_SHMALL' do
+                sh.cmd 'sudo bash -c "echo $SMALLTALK_CI_SHMALL_NEW > /proc/sys/kernel/shmall"'
+              end
+
+              sh.if "! -f #{SYSCTL_FILE} || `grep -sc \"kern.*m\" #{SYSCTL_FILE}` -eq 0" do
+                sh.cmd "echo \"kernelmmax=`cat /proc/sys/kernel/shmmax`\" >> #{TEMP_SYSCTL_FILE}"
+                sh.cmd "echo \"kernelmall=`cat /proc/sys/kernel/shmall`\" >> #{TEMP_SYSCTL_FILE}"
+                sh.cmd "sudo bash -c \"cat #{TEMP_SYSCTL_FILE} >> #{SYSCTL_FILE}\""
+                sh.cmd "/bin/rm -f #{TEMP_SYSCTL_FILE}"
+              end
+            end
+          end
+
+          def gemstone_prepare_osx_shared_memory
+            sh.fold 'gemstone_shared_memory' do
+              sh.echo 'Setting up shared memory', ansi: :yellow
+
+              sh.cmd 'SMALLTALK_CI_TOTALMEM=$(($(sysctl hw.memsize | cut -f2 -d' ') * 1024))'
+              sh.cmd 'SMALLTALK_CI_SHMMAX=`sysctl kern.sysv.shmmax | cut -f2 -d' '`'
+              sh.cmd 'SMALLTALK_CI_SHMALL=`sysctl kern.sysv.shmall | cut -f2 -d' '`'
+
+              sh.cmd 'SMALLTALK_CI_SHMMAX_NEW=$(($SMALLTALK_CI_TOTALMEM * 3/4))'
+              sh.cmd '[[ $SMALLTALK_CI_SHMMAX_NEW -gt 2147483648 ]] && SMALLTALK_CI_SHMMAX_NEW=2147483648'
+
+              sh.if '$SMALLTALK_CI_SHMMAX_NEW -gt $SMALLTALK_CI_SHMMAX' do
+                sh.cmd 'sudo sysctl -w kern.sysv.shmmax=$SMALLTALK_CI_SHMMAX_NEW'
+              end
+
+              sh.cmd 'SMALLTALK_CI_SHMALL_NEW=$(($SMALLTALK_CI_SHMALL / 4096))'
+              sh.cmd '[[ $SMALLTALK_CI_SHMALL_NEW -lt $SMALLTALK_CI_SHMALL ]] && SMALLTALK_CI_SHMALL_NEW=$SMALLTALK_CI_SHMALL'
+
+              sh.if '$SMALLTALK_CI_SHMALL_NEW -gt $SMALLTALK_CI_SHMALL' do
+                sh.cmd 'sudo sysctl -w kern.sysv.shmall=$SMALLTALK_CI_SHMALL_NEW'
+              end
+
+              sh.if "! -f #{SYSCTL_FILE} || `grep -sc \"kern.*m\" #{SYSCTL_FILE}` -eq 0" do
+                sh.cmd 'sysctl kern.sysv.shmmax kern.sysv.shmall kern.sysv.shmmin kern.sysv.shmmni'
+                sh.cmd "kern.sysv.mseg  | tr \":\" \"=\" | tr -d \" \" >> #{TEMP_SYSCTL_FILE}"
+                sh.cmd "sudo bash -c \"cat #{TEMP_SYSCTL_FILE} >> #{SYSCTL_FILE}\""
+                sh.cmd "/bin/rm -f #{TEMP_SYSCTL_FILE}"
+              end
+
+            end
+          end
+
+          def gemstone_prepare_linux_dependencies
+            case rel_version
+            when '12.04'
+              gemstone_install_linux_dependencies
+              sh.cmd 'sudo ln -f -s /lib/i386-linux-gnu/libpam.so.0 /lib/libpam.so.0'
+              sh.cmd 'sudo ln -f -s /usr/lib/i386-lin-gnu/libstdc++.so.6 /usr/lib/i386-linux-gnu/libstdc++.so'
+            when '14.04'
+              sh.cmd 'sudo dpkg --add-architecture i386'
+              gemstone_install_linux_dependencies
+              sh.cmd 'sudo ln -f -s /usr/lib/i386-lin-gnu/libstdc++.so.6 /usr/lib/i386-linux-gnu/libstdc++.so'
+            end
+          end
+
+          def gemstone_install_linux_dependencies
+            sh.fold 'gemstone_dependencies' do
+              sh.echo 'Installing GemStone dependencies', ansi: :yellow
+              sh.cmd 'sudo apt-get update -qq', retry: true
+              sh.cmd 'sudo apt-get install --no-install-recommends ' +
+                     'curl git zip unzip libpam0g:i386 libssl1.0.0:i386 ' +
+                     'gcc-multilib libstdc++6:i386 gdb libfreetype6:i386 ' +
+                     'pstack libgl1-mesa-glx:i386 libxcb-dri2-0:i386', retry: true
+              sh.cmd "sudo /bin/su -c \"echo 'kernel.yama.ptrace_scope = 0' >>/etc/sysctl.d/10-ptrace.conf\""
+            end
+          end
+
+          def gemstone_prepare_netldi
+            sh.if '`grep -sc "^gs64ldi" /etc/services` -eq 0' do
+              sh.fold 'gemstone_netldi' do
+                sh.echo 'Setting up GemStone netldi service port', ansi: :yellow
+                sh.cmd "sudo bash -c 'echo \"gs64ldi         50377/tcp        # Gemstone netldi\"  >> /etc/services'"
+              end
+            end
+          end
+
+          def gemstone_prepare_directories
+            sh.if '! -e /opt/gemstone' do
+              sh.fold 'gemstone_directories' do
+                sh.echo 'Creating /opt/gemstone directory', ansi: :yellow
+                sh.cmd 'sudo mkdir -p /opt/gemstone /opt/gemstone/log /opt/gemstone/locks'
+                sh.cmd 'sudo chown $USER:${GROUPS[0]} /opt/gemstone /opt/gemstone/log /opt/gemstone/locks'
+                sh.cmd 'sudo chmod 770 /opt/gemstone /opt/gemstone/log /opt/gemstone/locks'
+              end
+            end
+          end
 
       end
     end

--- a/spec/build/script/smalltalk_spec.rb
+++ b/spec/build/script/smalltalk_spec.rb
@@ -4,6 +4,7 @@ describe Travis::Build::Script::Smalltalk, :sexp do
   let(:data)   { payload_for(:push, :smalltalk) }
   let(:script) { described_class.new(data) }
   subject      { script.sexp }
+  it           { store_example }
 
   it_behaves_like 'compiled script' do
     let(:code) { ['TRAVIS_LANGUAGE=smalltalk'] }
@@ -20,6 +21,7 @@ describe Travis::Build::Script::Smalltalk, :sexp do
 
   describe 'on Linux' do
     before do
+      data[:config][:smalltalk] = 'Squeak-5.0'
       data[:config][:os] = 'linux'
     end
     it 'installs the dependencies' do
@@ -41,8 +43,8 @@ describe Travis::Build::Script::Smalltalk, :sexp do
       data[:config][:smalltalk] = 'Squeak-5.0'
     end
 
-    it 'sets SMALLTALK to correct version' do
-      should include_sexp [:export, ['SMALLTALK', 'Squeak-5.0']]
+    it 'sets TRAVIS_SMALLTALK_VERSION to correct version' do
+      should include_sexp [:export, ['TRAVIS_SMALLTALK_VERSION', 'Squeak-5.0']]
     end
   end
 

--- a/spec/build/script/smalltalk_spec.rb
+++ b/spec/build/script/smalltalk_spec.rb
@@ -1,10 +1,11 @@
 require 'spec_helper'
 
 describe Travis::Build::Script::Smalltalk, :sexp do
-  let(:data)   { payload_for(:push, :smalltalk) }
-  let(:script) { described_class.new(data) }
-  subject      { script.sexp }
-  it           { store_example }
+  let(:data)      { payload_for(:push, :smalltalk) }
+  let(:script)    { described_class.new(data) }
+  let(:defaults)  { described_class::DEFAULTS }
+  subject         { script.sexp }
+  it              { store_example }
 
   it_behaves_like 'compiled script' do
     let(:code) { ['TRAVIS_LANGUAGE=smalltalk'] }
@@ -19,7 +20,7 @@ describe Travis::Build::Script::Smalltalk, :sexp do
     should include_sexp [:cmd, "popd > /dev/null; popd > /dev/null", assert: true, timing: true]
   end
 
-  describe 'on Linux' do
+  describe 'Squeak on Linux' do
     before do
       data[:config][:smalltalk] = 'Squeak-5.0'
       data[:config][:os] = 'linux'
@@ -29,12 +30,52 @@ describe Travis::Build::Script::Smalltalk, :sexp do
     end
   end
 
-  describe 'on OS X' do
+  describe 'Squeak on OS X' do
     before do
+      data[:config][:smalltalk] = 'Squeak-5.0'
       data[:config][:os] = 'osx'
     end
     it 'does not try to call apt-get' do
       should_not include_sexp [:cmd, "sudo apt-get install --no-install-recommends libc6:i386 libuuid1:i386 libfreetype6:i386 libssl1.0.0:i386", retry: true]
+    end
+  end
+
+  describe 'GemStone on Linux' do
+    before do
+      data[:config][:smalltalk] = 'GemStone-3.2.12'
+      data[:config][:os] = 'linux'
+      defaults[:release_version] = '12.04'
+    end
+
+    it 'set hostname' do
+      should include_sexp [:cmd, "sudo hostname " + defaults[:gemstone_hostname]]
+      should include_sexp [:cmd, "cat /tmp/hosts | sudo tee /etc/hosts > /dev/null"]
+    end
+
+    it 'installs the dependencies' do
+      should include_sexp [:cmd, "sudo apt-get install --no-install-recommends " +
+                     "curl git zip unzip libpam0g:i386 libssl1.0.0:i386 " +
+                     "gcc-multilib libstdc++6:i386 gdb libfreetype6:i386 " +
+                     "pstack libgl1-mesa-glx:i386 libxcb-dri2-0:i386", retry: true]
+    end
+  end
+
+  describe 'GemStone on OS X' do
+    before do
+      data[:config][:smalltalk] = 'GemStone-3.2.12'
+      data[:config][:os] = 'osx'
+    end
+
+    it 'set hostname' do
+      should include_sexp [:cmd, "sudo scutil --set HostName " + defaults[:gemstone_hostname]]
+      should include_sexp [:cmd, "cat /tmp/hosts | sudo tee /etc/hosts > /dev/null"]
+    end
+
+    it 'does not try to call apt-get' do
+      should_not include_sexp [:cmd, "sudo apt-get install --no-install-recommends " +
+                     "curl git zip unzip libpam0g:i386 libssl1.0.0:i386 " +
+                     "gcc-multilib libstdc++6:i386 gdb libfreetype6:i386 " +
+                     "pstack libgl1-mesa-glx:i386 libxcb-dri2-0:i386", retry: true]
     end
   end
 


### PR DESCRIPTION
We are trying to get [GemStone running on Travis' container-based infrastructure](https://github.com/hpi-swa/smalltalkCI/issues/28).
Unfortunately, GemStone requires some complex OS prereqs.
This PR is based on the official [prereqs script](https://github.com/GsDevKit/GsDevKit_home/blob/dev/bin/utils/installOsPrereqs).

We have used the chance to remove `baseline:` again, since we are working on a more Travis-independent solution to configure Smalltalk builds. Also, we updated the announcement and the tests.

We do understand if reviewing this PR takes more time, but thanks for the awesome work!

Please let us know if there's any way we can test this (e.g. locally or in staging) before it's getting merged.

Many thanks,
Fabio

/cc @dalehenrich, @bahnfahren, @chistopher, @jchromik, and @Nef10