### PR TITLE
Remove tryCatch blocks

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -213,12 +213,7 @@ module Travis
           pkg_arg = packages_as_arg(packages)
           install_script = [
             "options(repos = c(CRAN = \"#{config[:cran]}\"));",
-            'tryCatch({',
-            "  devtools::install_github(#{pkg_arg}, build_vignettes = FALSE)",
-            '}, error = function(e) {',
-            '  message(e);',
-            '  q(status = 1, save = "no")',
-            '})',
+            "devtools::install_github(#{pkg_arg}, build_vignettes = FALSE)",
           ].join(' ')
           sh.cmd "Rscript -e '#{install_script}'"
         end
@@ -278,12 +273,7 @@ module Travis
           end
           install_script = [
             "options(repos = #{repos});",
-            'tryCatch({',
-            '  deps <- devtools::install_deps(dependencies = TRUE)',
-            '}, error = function(e) {',
-            '  message(e);',
-            '  q(status=1)',
-            '});',
+            'deps <- devtools::install_deps(dependencies = TRUE);',
             'if (!all(deps %in% installed.packages())) {',
             ' message("missing: ", paste(setdiff(deps, installed.packages()), collapse=", "));',
             ' q(status = 1, save = "no")',


### PR DESCRIPTION
These were inadvertently suppressing the error output due to the
following behavior of `message()` when the first argument is a
condition.

  If a condition object is supplied to ‘message’ it should be the only
  argument, and further arguments will be ignored, with a warning.

In this situation no linefeed was printed after the error message and it
was being swallowed in the Travis logs, resulting in user confusion, see

- https://github.com/travis-ci/travis-ci/issues/4591
- https://github.com/travis-ci/travis-ci/issues/4116

PTAL @craigcitro @hadleywickham

This largely reverts the changes in https://github.com/travis-ci/travis-build/pull/395 so I want to make sure we are still getting the desired behavior.

FWIW RScript does set the error status to `1` and halts execution if there is an error, so I am not entirely sure what the original changes were trying to address.

```bash
 Rscript -e 'stop("blah");message("hi")' || echo $?
Error: blah
Execution halted
1
```

If we end up _do_ wanting the `tryCatch` blocks a simple fix for this is to make the calls `message(e, "")` instead of just `message(e)`. Passing more than one argument avoids the code in https://github.com/wch/r-source/blob/b156e3a711967f58131e23c1b1dc1ea90e2f0c43/src/library/base/R/message.R#L34-L37, which was causing the missing linefeed.