### PR TITLE
Retry the apt-get commands to overcome network issues.

### DIFF
--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -126,9 +126,9 @@ module Travis
 
             unless whitelisted.empty?
               sh.export 'DEBIAN_FRONTEND', 'noninteractive', echo: true
-              sh.cmd "sudo -E apt-get -yq update &>> ~/apt-get-update.log", echo: true, timing: true
+              sh.cmd "sudo -E apt-get -yq update &>> ~/apt-get-update.log", echo: true, timing: true, retry: true
               sh.cmd 'sudo -E apt-get -yq --no-install-suggests --no-install-recommends ' \
-                "--force-yes install #{whitelisted.join(' ')}", echo: true, timing: true
+                "--force-yes install #{whitelisted.join(' ')}", echo: true, timing: true, retry: true
             end
           end
 

--- a/spec/build/addons/apt_packages_spec.rb
+++ b/spec/build/addons/apt_packages_spec.rb
@@ -20,24 +20,24 @@ describe Travis::Build::Addons::AptPackages, :sexp do
   context 'with multiple whitelisted packages' do
     let(:config) { ['git', 'curl'] }
 
-    it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true] }
+    it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true, retry: true] }
   end
 
   context 'with multiple packages, some whitelisted' do
     let(:config) { ['git', 'curl', 'darkcoin'] }
 
-    it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true] }
+    it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true, retry: true] }
   end
 
   context 'with singular whitelisted package' do
     let(:config) { 'git' }
 
-    it { should include_sexp [:cmd, apt_get_install_command('git'), echo: true, timing: true] }
+    it { should include_sexp [:cmd, apt_get_install_command('git'), echo: true, timing: true, retry: true] }
   end
 
   context 'with no whitelisted packages' do
     let(:config) { nil }
 
-    it { should_not include_sexp [:cmd, apt_get_install_command('git'), echo: true, timing: true] }
+    it { should_not include_sexp [:cmd, apt_get_install_command('git'), echo: true, timing: true, retry: true] }
   end
 end

--- a/spec/build/addons/apt_spec.rb
+++ b/spec/build/addons/apt_spec.rb
@@ -101,31 +101,31 @@ describe Travis::Build::Addons::Apt, :sexp do
     context 'with multiple whitelisted packages' do
       let(:config) { { packages: ['git', 'curl'] } }
 
-      it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true] }
+      it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true, retry: true] }
     end
 
     context 'with multiple packages, some whitelisted' do
       let(:config) { { packages: ['git', 'curl', 'darkcoin'] } }
 
-      it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true] }
+      it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true, retry: true] }
     end
 
     context 'with singular whitelisted package' do
       let(:config) { { packages: 'git' } }
 
-      it { should include_sexp [:cmd, apt_get_install_command('git'), echo: true, timing: true] }
+      it { should include_sexp [:cmd, apt_get_install_command('git'), echo: true, timing: true, retry: true] }
     end
 
     context 'with no whitelisted packages' do
       let(:config) { { packages: nil } }
 
-      it { should_not include_sexp [:cmd, apt_get_install_command('git'), echo: true, timing: true] }
+      it { should_not include_sexp [:cmd, apt_get_install_command('git'), echo: true, timing: true, retry: true] }
     end
 
     context 'with nested arrays of packages' do
       let(:config) { { packages: [%w(git curl)] } }
 
-      it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true] }
+      it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true, retry: true] }
     end
   end
 


### PR DESCRIPTION
The apt repos are unstable from time to time, leading to builds failing (e.g. https://travis-ci.org/HaxeFoundation/haxe/builds/103538766).

This PR add retry to the apt-get commands, hopefully will reduce the impact of network issues.