### PR TITLE
Install R and dependencies in the configure block rather than setup

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -227,7 +227,7 @@ module Travis
         def r_binary_install(packages)
           return if packages.empty?
           if config[:os] == 'linux'
-            if config[:sudo] == 'false'
+            if config[:sudo] == false
               sh.echo "R binary packages not supported with 'sudo: false', " +
                 ' falling back to source install'
               return r_install packages

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -47,8 +47,6 @@ module Travis
         def configure
           super
 
-          # TODO(craigcitro): Confirm that these do, in fact, print as
-          # green. (They're yellow under vagrant.)
           sh.echo 'R for Travis-CI is not officially supported, ' +
                   'but is community maintained.', ansi: :green
           sh.echo 'Please file any issues using the following link',
@@ -60,7 +58,6 @@ module Travis
 
           sh.fold("R-install") do
             sh.with_options({ assert: true,  echo: true,  timing: true  }) do
-              # TODO(craigcitro): python-software-properties?
               sh.echo 'Installing R', ansi: :yellow
               case config[:os]
               when 'linux'
@@ -169,7 +166,7 @@ module Travis
               sh.failure "Found warnings, treating as errors (as requested)."
             end
           end
-          
+
           # Check revdeps, if requested.
           if config[:r_check_revdep]
             sh.echo "Checking reverse dependencies"
@@ -226,7 +223,7 @@ module Travis
           ].join(' ')
           sh.cmd "Rscript -e '#{install_script}'"
         end
-        
+
         def r_binary_install(packages)
           return if packages.empty?
           case config[:os]
@@ -297,7 +294,7 @@ module Travis
           )
           sh.export 'RCHECK_DIR', "$(Rscript -e '#{pkg_script}')"
         end
-        
+
         def dump_logs
           export_rcheck_dir
           ['out', 'log', 'fail'].each do |ext|
@@ -312,7 +309,7 @@ module Travis
             sh.cmd cmd
           end
         end
-        
+
         def setup_bioc
           unless @bioc_installed
             sh.echo 'Installing BioConductor'
@@ -391,7 +388,7 @@ module Travis
           pandoc_srcdir = "pandoc-#{config[:pandoc_version]}/#{os_path}"
           pandoc_destdir = '${HOME}/opt/pandoc'
           pandoc_tmpfile = "/tmp/pandoc-#{config[:pandoc_version]}.zip"
-          
+
           sh.mkdir pandoc_destdir, recursive: true
           sh.cmd "curl -o #{pandoc_tmpfile} #{pandoc_url}"
           ['pandoc', 'pandoc-citeproc'].each do |filename|
@@ -400,10 +397,9 @@ module Travis
                    "-d #{pandoc_destdir}"
             sh.chmod '+x', "#{File.join(pandoc_destdir, filename)}"
           end
-          
+
           sh.export 'PATH', "$PATH:#{pandoc_destdir}"
         end
-        
       end
     end
   end

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -194,7 +194,7 @@ module Travis
 
           if data.cache?(:R)
             sh.fold 'cache.R' do
-              sh.echo ''
+              sh.sh 'mkdir -p $R_LIBS_USER'
               directory_cache.add '$R_LIBS_USER'
             end
           end

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -1,3 +1,8 @@
+# Maintained by:
+# Jim Hester     @jimhester       james.hester@rstudio.com
+# Craig Citro    @craigcitro      craigcitro@google.com
+# Hadley Wickham @hadley          hadley@rstudio.com
+#
 module Travis
   module Build
     class Script

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -44,6 +44,7 @@ module Travis
           super
           sh.export 'TRAVIS_R_VERSION', version, echo: false
           sh.export 'R_LIBS_USER', '~/R/Library', echo: false
+          sh.export 'TEXMFHOME', '~/texmf'
         end
 
         def configure
@@ -123,7 +124,7 @@ module Travis
 
         def install
           super
-          unless setup_cache_has_run_for[:R]
+          unless setup_cache_has_run_for[:packages]
             setup_cache
           end
 
@@ -190,15 +191,15 @@ module Travis
         end
 
         def setup_cache
-          return if setup_cache_has_run_for[:R]
+          return if setup_cache_has_run_for[:packages]
 
-          if data.cache?(:R)
+          if data.cache?(:packages)
             sh.fold 'cache.R' do
               sh.sh 'mkdir -p $R_LIBS_USER'
               directory_cache.add '$R_LIBS_USER'
             end
           end
-          setup_cache_has_run_for[:R] = true
+          setup_cache_has_run_for[:packages] = true
         end
 
         def cache_slug
@@ -206,7 +207,7 @@ module Travis
         end
 
         def use_directory_cache?
-          super || data.cache?(:R)
+          super || data.cache?(:packages)
         end
 
         private

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -253,7 +253,7 @@ module Travis
         def r_binary_install(packages)
           return if packages.empty?
           if config[:os] == 'linux'
-            if config[:sudo] == false
+            unless config[:sudo]
               sh.echo "R binary packages not supported with 'sudo: false', " +
                 ' falling back to source install'
               return r_install packages

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -54,58 +54,59 @@ module Travis
                   ansi: :green
 
           sh.fold("R-install") do
+            sh.with_options({ assert: true,  echo: true,  timing: true  }) do
+              # TODO(craigcitro): python-software-properties?
+              sh.echo 'Installing R', ansi: :yellow
+              case config[:os]
+              when 'linux'
+                # Set up our CRAN mirror.
+                sh.cmd 'sudo add-apt-repository ' +
+                  "\"deb #{config[:cran]}/bin/linux/ubuntu " +
+                  "$(lsb_release -cs)/\""
+                sh.cmd 'sudo apt-key adv --keyserver keyserver.ubuntu.com ' +
+                  '--recv-keys E084DAB9'
 
-            # TODO(craigcitro): python-software-properties?
-            sh.echo 'Installing R'
-            case config[:os]
-            when 'linux'
-              # Set up our CRAN mirror.
-              sh.cmd 'sudo add-apt-repository ' +
-                "\"deb #{config[:cran]}/bin/linux/ubuntu " +
-                "$(lsb_release -cs)/\""
-              sh.cmd 'sudo apt-key adv --keyserver keyserver.ubuntu.com ' +
-                '--recv-keys E084DAB9'
+                # Add marutter's c2d4u repository.
+                sh.cmd 'sudo add-apt-repository -y "ppa:marutter/rrutter"'
+                sh.cmd 'sudo add-apt-repository -y "ppa:marutter/c2d4u"'
 
-              # Add marutter's c2d4u repository.
-              sh.cmd 'sudo add-apt-repository -y "ppa:marutter/rrutter"'
-              sh.cmd 'sudo add-apt-repository -y "ppa:marutter/c2d4u"'
+                # Update after adding all repositories. Retry several
+                # times to work around flaky connection to Launchpad PPAs.
+                sh.cmd 'sudo apt-get update -qq', retry: true
 
-              # Update after adding all repositories. Retry several
-              # times to work around flaky connection to Launchpad PPAs.
-              sh.cmd 'sudo apt-get update -qq', retry: true
+                # Install an R development environment. qpdf is also needed for
+                # --as-cran checks:
+                #   https://stat.ethz.ch/pipermail/r-help//2012-September/335676.html
+                sh.cmd 'sudo apt-get install -y --no-install-recommends r-base-dev ' +
+                  'r-recommended qpdf', retry: true
 
-              # Install an R development environment. qpdf is also needed for
-              # --as-cran checks:
-              #   https://stat.ethz.ch/pipermail/r-help//2012-September/335676.html
-              sh.cmd 'sudo apt-get install -y --no-install-recommends r-base-dev ' +
-                'r-recommended qpdf', retry: true
+                # Change permissions for /usr/local/lib/R/site-library
+                # This should really be via 'sudo adduser travis staff'
+                # but that may affect only the next shell
+                sh.cmd 'sudo chmod 2777 /usr/local/lib/R /usr/local/lib/R/site-library'
 
-              # Change permissions for /usr/local/lib/R/site-library
-              # This should really be via 'sudo adduser travis staff'
-              # but that may affect only the next shell
-              sh.cmd 'sudo chmod 2777 /usr/local/lib/R /usr/local/lib/R/site-library'
+              when 'osx'
+                # We want to update, but we don't need the 800+ lines of
+                # output.
+                sh.cmd 'brew update >/dev/null', retry: true
 
-            when 'osx'
-              # We want to update, but we don't need the 800+ lines of
-              # output.
-              sh.cmd 'brew update >/dev/null', retry: true
+                # Install from latest CRAN binary build for OS X
+                sh.cmd "wget #{config[:cran]}/bin/macosx/R-latest.pkg " +
+                  '-O /tmp/R-latest.pkg'
 
-              # Install from latest CRAN binary build for OS X
-              sh.cmd "wget #{config[:cran]}/bin/macosx/R-latest.pkg " +
-                '-O /tmp/R-latest.pkg'
+                sh.echo 'Installing OS X binary package for R'
+                sh.cmd 'sudo installer -pkg "/tmp/R-latest.pkg" -target /'
+                sh.rm '/tmp/R-latest.pkg'
 
-              sh.echo 'Installing OS X binary package for R'
-              sh.cmd 'sudo installer -pkg "/tmp/R-latest.pkg" -target /'
-              sh.rm '/tmp/R-latest.pkg'
+              else
+                sh.failure "Operating system not supported: #{config[:os]}"
+              end
 
-            else
-              sh.failure "Operating system not supported: #{config[:os]}"
+              setup_latex
+
+              setup_bioc if needs_bioc?
+              setup_pandoc if config[:pandoc]
             end
-
-            setup_latex
-
-            setup_bioc if needs_bioc?
-            setup_pandoc if config[:pandoc]
           end
         end
 

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -226,8 +226,12 @@ module Travis
 
         def r_binary_install(packages)
           return if packages.empty?
-          case config[:os]
-          when 'linux'
+          if config[:os] == 'linux'
+            if config[:sudo] == 'false'
+              sh.echo "R binary packages not supported with 'sudo: false', " +
+                ' falling back to source install'
+              return r_install packages
+            end
             sh.echo "Installing *binary* R packages: #{packages.join(', ')}"
             apt_install packages.collect{|p| "r-cran-#{p.downcase}"}
           else

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -26,8 +26,17 @@ describe Travis::Build::Script::R, :sexp do
                          assert: true, echo: true, timing: true]
   end
 
-  it 'installs binary devtools if sudo: true' do
+  it 'installs binary devtools if sudo: required' do
+    data[:config][:sudo] = 'required'
     should include_sexp [:cmd, /sudo apt-get install.*r-cran-devtools/,
+                         assert: true, echo: true, timing: true, retry: true]
+  end
+
+  it 'installs source devtools if sudo: is missing' do
+    should include_sexp [:cmd, /Rscript -e 'install\.packages\(c\(\"devtools\"\)/,
+                         assert: true, echo: true, timing: true]
+
+    should_not include_sexp [:cmd, /sudo apt-get install.*r-cran-devtools/,
                          assert: true, echo: true, timing: true, retry: true]
   end
 

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -16,8 +16,12 @@ describe Travis::Build::Script::R, :sexp do
                          assert: true, echo: true, retry: true, timing: true]
   end
 
-  it 'installs pandoc into ${HOME}' do
-    should include_sexp [:cmd, /unzip -j \/tmp\/pandoc-.* \$\{HOME\}\/opt\/pandoc/,
+  it 'downloads pandoc and installs into /usr/bin/pandoc' do
+    data[:config][:pandoc_version] = '1.15.2'
+    should include_sexp [:cmd, %r{curl -Lo /tmp/pandoc-1\.15\.2-1-amd64.deb https://github\.com/jgm/pandoc/releases/download/1.15.2/pandoc-1\.15\.2-1-amd64.deb},
+                         assert: true, echo: true, timing: true]
+
+    should include_sexp [:cmd, %r{sudo dpkg -i /tmp/pandoc-},
                          assert: true, echo: true, timing: true]
   end
 

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -21,6 +21,20 @@ describe Travis::Build::Script::R, :sexp do
                          assert: true, echo: true, timing: true]
   end
 
+  it 'installs binary devtools if sudo: true' do
+    should include_sexp [:cmd, /sudo apt-get install.*r-cran-devtools/,
+                         assert: true, echo: true, timing: true, retry: true]
+  end
+
+  it 'installs source devtools if sudo: false' do
+    data[:config][:sudo] =  'false'
+    should include_sexp [:cmd, /Rscript -e 'install\.packages\(c\(\"devtools\"\)/,
+                         assert: true, echo: true, timing: true]
+
+    should_not include_sexp [:cmd, /sudo apt-get install.*r-cran-devtools/,
+                         assert: true, echo: true, timing: true, retry: true]
+  end
+
   it 'fails on package build and test failures' do
     should include_sexp [:cmd, /.*R CMD build.*/,
                          assert: true, echo: true, timing: true]

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -8,7 +8,8 @@ describe Travis::Build::Script::R, :sexp do
   it_behaves_like 'a build script sexp'
 
   it 'exports TRAVIS_R_VERSION' do
-    should include_sexp [:export, ['TRAVIS_R_VERSION', 'release']]
+    data[:config][:R] = '3.2.3'
+    should include_sexp [:export, ['TRAVIS_R_VERSION', '3.2.3']]
   end
 
   it 'downloads and installs R' do
@@ -65,4 +66,20 @@ describe Travis::Build::Script::R, :sexp do
     end
   end
 
+  describe '#cache_slug' do
+    subject { described_class.new(data).cache_slug }
+    it {
+      data[:config][:R] = '3.2.3'
+      should eq('cache--R-3.2.3')
+    }
+
+    it {
+      data[:config][:R] = 'release'
+      should eq('cache--R-3.2.3')
+    }
+    it {
+      data[:config][:R] = 'devel'
+      should eq('cache--R-devel')
+    }
+  end
 end

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -27,7 +27,7 @@ describe Travis::Build::Script::R, :sexp do
   end
 
   it 'installs source devtools if sudo: false' do
-    data[:config][:sudo] =  'false'
+    data[:config][:sudo] = false
     should include_sexp [:cmd, /Rscript -e 'install\.packages\(c\(\"devtools\"\)/,
                          assert: true, echo: true, timing: true]
 


### PR DESCRIPTION
This should allow using `language: r` on the container based infrastructure.

From looking at the [csharp builder](https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/script/csharp.rb#L16-L58) it looks like `sudo` commands can be used in the `configure()` block for language implementations. This PR simply moves the R `setup()` commands to `configure()` and puts them in a travis fold so the output log is easier to browse.

@BanzaiMan if I am mistaken about this or if there is a more preferred method please let me know.

cc @craigcitro @hadley