### PR TITLE
Ensure that timing marker does not have other text

### DIFF
--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -67,7 +67,7 @@ travis_time_finish() {
   local result=$?
   travis_end_time=$(travis_nanoseconds)
   local duration=$(($travis_end_time-$travis_start_time))
-  echo -en "travis_time:end:$travis_timer_id:start=$travis_start_time,finish=$travis_end_time,duration=$duration\r${ANSI_CLEAR}"
+  echo -en "\ntravis_time:end:$travis_timer_id:start=$travis_start_time,finish=$travis_end_time,duration=$duration\r${ANSI_CLEAR}"
   return $result
 }
 


### PR DESCRIPTION
travis-web-log looks for `/time:(start|end)/` to add the `<span>`
element to display the timing information on the web page.

This is problematic when the line has some text preceding that marker
text, as that line will not be rendered.

This happens if the command that emits the timing information
does not end with "\n".

While it is possible to modify travis-web-log in such a way that
the line is split up to be rendered correctly, this approach requires
complex DOM manipulation.

We sidestep this issue by ensuring that the timing marker line
does not contain any other information which users expect to see.

This has an unfortunate side effect where an empty line is injected
when there *is* a newline in the command with timing information.