### PR TITLE
Skip kerl update releases

### DIFF
--- a/lib/travis/build/script/erlang.rb
+++ b/lib/travis/build/script/erlang.rb
@@ -64,7 +64,6 @@ module Travis
 
           def install_erlang(release)
             sh.echo "#{release} is not installed. Downloading and installing pre-build binary.", ansi: :yellow
-            sh.cmd "kerl update releases"
             sh.cmd "wget #{archive_url_for('travis-otp-releases',release, 'erlang').sub(/\.tar\.bz2/, '-nonroot.tar.bz2')}"
             sh.cmd "tar -xf #{archive_name(release)} -C ~/otp/"
             sh.cmd "echo '#{release},#{release}' >> ~/.kerl/otp_builds", echo: false


### PR DESCRIPTION
`kerl update releases` ends up calling
`curl -L -s http://www.erlang.org/download` to gather
list of OTP Releases avialble.
This adds another network resource Erlang builds rely on.

The information thus gathered, however, is not put to good use,
as we will use our archive repository to pull down the pre-built
binary files any way.

So, we will skip this step altogether with few ill effects.