### PR TITLE
Split apt-get install command into "download" and "install" stages.

### DIFF
--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -126,9 +126,11 @@ module Travis
 
             unless whitelisted.empty?
               sh.export 'DEBIAN_FRONTEND', 'noninteractive', echo: true
-              sh.cmd "sudo -E apt-get -yq update &>> ~/apt-get-update.log", echo: true, timing: true
-              sh.cmd 'sudo -E apt-get -yq --no-install-suggests --no-install-recommends ' \
-                "--force-yes install #{whitelisted.join(' ')}", echo: true, timing: true
+              sh.cmd "sudo -E apt-get -yq update &>> ~/apt-get-update.log", echo: true, timing: true, retry: true
+              sh.cmd 'sudo -E apt-get -yq --no-install-suggests --no-install-recommends --download-only ' \
+                "--force-yes install #{whitelisted.join(' ')}", echo: true, timing: true, retry: true, assert: true
+              sh.cmd 'sudo -E apt-get -yq --no-install-suggests --no-install-recommends --no-download ' \
+                "--force-yes install #{whitelisted.join(' ')}", echo: true, timing: true, assert: true
             end
           end
 

--- a/spec/build/addons/apt_packages_spec.rb
+++ b/spec/build/addons/apt_packages_spec.rb
@@ -13,31 +13,39 @@ describe Travis::Build::Addons::AptPackages, :sexp do
     addon.before_prepare
   end
 
+  def apt_get_download_command(*packages)
+    "sudo -E apt-get -yq --no-install-suggests --no-install-recommends --download-only --force-yes install #{packages.join(' ')}"
+  end
+
   def apt_get_install_command(*packages)
-    "sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install #{packages.join(' ')}"
+    "sudo -E apt-get -yq --no-install-suggests --no-install-recommends --no-download --force-yes install #{packages.join(' ')}"
   end
 
   context 'with multiple whitelisted packages' do
     let(:config) { ['git', 'curl'] }
 
-    it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true] }
+    it { should include_sexp [:cmd, apt_get_download_command('git', 'curl'), echo: true, timing: true, retry: true, assert: true] }
+    it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true, assert: true] }
   end
 
   context 'with multiple packages, some whitelisted' do
     let(:config) { ['git', 'curl', 'darkcoin'] }
 
-    it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true] }
+    it { should include_sexp [:cmd, apt_get_download_command('git', 'curl'), echo: true, timing: true, retry: true, assert: true] }
+    it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true, assert: true] }
   end
 
   context 'with singular whitelisted package' do
     let(:config) { 'git' }
 
-    it { should include_sexp [:cmd, apt_get_install_command('git'), echo: true, timing: true] }
+    it { should include_sexp [:cmd, apt_get_download_command('git'), echo: true, timing: true, retry: true, assert: true] }
+    it { should include_sexp [:cmd, apt_get_install_command('git'), echo: true, timing: true, assert: true] }
   end
 
   context 'with no whitelisted packages' do
     let(:config) { nil }
 
-    it { should_not include_sexp [:cmd, apt_get_install_command('git'), echo: true, timing: true] }
+    it { should_not include_sexp [:cmd, apt_get_download_command('git'), echo: true, timing: true, retry: true, assert: true] }
+    it { should_not include_sexp [:cmd, apt_get_install_command('git'), echo: true, timing: true, assert: true] }
   end
 end

--- a/spec/build/addons/apt_spec.rb
+++ b/spec/build/addons/apt_spec.rb
@@ -94,38 +94,47 @@ describe Travis::Build::Addons::Apt, :sexp do
       addon.before_prepare
     end
 
+    def apt_get_download_command(*packages)
+      "sudo -E apt-get -yq --no-install-suggests --no-install-recommends --download-only --force-yes install #{packages.join(' ')}"
+    end
+
     def apt_get_install_command(*packages)
-      "sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install #{packages.join(' ')}"
+      "sudo -E apt-get -yq --no-install-suggests --no-install-recommends --no-download --force-yes install #{packages.join(' ')}"
     end
 
     context 'with multiple whitelisted packages' do
       let(:config) { { packages: ['git', 'curl'] } }
 
-      it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true] }
+      it { should include_sexp [:cmd, apt_get_download_command('git', 'curl'), echo: true, timing: true, retry: true, assert: true] }
+      it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true, assert: true] }
     end
 
     context 'with multiple packages, some whitelisted' do
       let(:config) { { packages: ['git', 'curl', 'darkcoin'] } }
 
-      it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true] }
+      it { should include_sexp [:cmd, apt_get_download_command('git', 'curl'), echo: true, timing: true, retry: true, assert: true] }
+      it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true, assert: true] }
     end
 
     context 'with singular whitelisted package' do
       let(:config) { { packages: 'git' } }
 
-      it { should include_sexp [:cmd, apt_get_install_command('git'), echo: true, timing: true] }
+      it { should include_sexp [:cmd, apt_get_download_command('git'), echo: true, timing: true, retry: true, assert: true] }
+      it { should include_sexp [:cmd, apt_get_install_command('git'), echo: true, timing: true, assert: true] }
     end
 
     context 'with no whitelisted packages' do
       let(:config) { { packages: nil } }
 
-      it { should_not include_sexp [:cmd, apt_get_install_command('git'), echo: true, timing: true] }
+      it { should_not include_sexp [:cmd, apt_get_download_command('git'), echo: true, timing: true, retry: true, assert: true] }
+      it { should_not include_sexp [:cmd, apt_get_install_command('git'), echo: true, timing: true, assert: true] }
     end
 
     context 'with nested arrays of packages' do
       let(:config) { { packages: [%w(git curl)] } }
 
-      it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true] }
+      it { should include_sexp [:cmd, apt_get_download_command('git', 'curl'), echo: true, timing: true, retry: true, assert: true] }
+      it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true, assert: true] }
     end
   end
 


### PR DESCRIPTION
Turn on assertion to stop proceeding when any of the stages fail.
Retry the "download" stage to overcome network issues.

See #600
