### PR TITLE
Set PIP_DISABLE_PIP_VERSION_CHECK=1 after showing pip version

### DIFF
--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -35,6 +35,7 @@ module Travis
         def announce
           sh.cmd 'python --version'
           sh.cmd 'pip --version'
+          sh.export 'PIP_DISABLE_PIP_VERSION_CHECK', '1', echo: false
         end
 
         def install


### PR DESCRIPTION
Resolves https://github.com/travis-ci/travis-ci/issues/5499

By setting this value, we avoid making extra network calls
for each invocation of `pip`.
We do this *after* announcing the pip version, so that the user
may become aware.