### PR TITLE
Create RVM aliases to allow short Ruby version

### DIFF
--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -15,6 +15,14 @@ module Travis
           rvm_remote_server_verify_downloads3=1
         )
 
+        # This list should contain the latest patch version of Ruby
+        ALIASES = {
+          "2.0" => "ruby-2.0.0-p648",
+          "2.1" => "ruby-2.1.8",
+          "2.2" => "ruby-2.2.4",
+          "2.3" => "ruby-2.3.0"
+        }
+
         def export
           super
           sh.export 'TRAVIS_RUBY_VERSION', config[:rvm], echo: false if rvm?
@@ -52,6 +60,11 @@ module Travis
           def setup_rvm
             sh.cmd('type rvm &>/dev/null || source ~/.rvm/scripts/rvm', echo: false, assert: false)
             sh.file '$rvm_path/user/db', CONFIG.join("\n")
+
+            ALIASES.each do |alias_name, ruby_version|
+              sh.cmd "rvm alias create #{alias_name} #{ruby_version}"
+            end
+
             send rvm_strategy
           end
 


### PR DESCRIPTION
These aliases will overrides image's RVM aliases, and allow user to
specify MRI version using `MAJOR.MINOR` version number.