### PR TITLE
Hide RVM aliases creation from log

### DIFF
--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -61,7 +61,9 @@ module Travis
             sh.file '$rvm_path/user/db', CONFIG.join("\n")
 
             ALIASES.each do |alias_name, ruby_version|
-              sh.cmd "rvm alias create #{alias_name} #{ruby_version}"
+              sh.cmd "rvm alias create #{alias_name} #{ruby_version}",
+                echo: false,
+                assert: false
             end
 
             send rvm_strategy


### PR DESCRIPTION
This information is not useful for the user.