### PR TITLE
Revert RVM alias creations

### DIFF
--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -14,14 +14,6 @@ module Travis
           rvm_remote_server_verify_downloads3=1
         )
 
-        # This list should contain the latest patch version of Ruby
-        ALIASES = {
-          "2.0" => "ruby-2.0.0-p648",
-          "2.1" => "ruby-2.1.8",
-          "2.2" => "ruby-2.2.4",
-          "2.3" => "ruby-2.3.0"
-        }
-
         def export
           super
           sh.export 'TRAVIS_RUBY_VERSION', config[:rvm], echo: false if rvm?
@@ -59,11 +51,6 @@ module Travis
           def setup_rvm
             sh.cmd('type rvm &>/dev/null || source ~/.rvm/scripts/rvm', echo: false, assert: false)
             sh.file '$rvm_path/user/db', CONFIG.join("\n")
-
-            ALIASES.each do |alias_name, ruby_version|
-              sh.cmd "rvm alias create #{alias_name} #{ruby_version}"
-            end
-
             send rvm_strategy
           end
 

--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -61,9 +61,7 @@ module Travis
             sh.file '$rvm_path/user/db', CONFIG.join("\n")
 
             ALIASES.each do |alias_name, ruby_version|
-              sh.cmd "rvm alias create #{alias_name} #{ruby_version}",
-                echo: false,
-                assert: false
+              sh.cmd "rvm alias create #{alias_name} #{ruby_version}"
             end
 
             send rvm_strategy


### PR DESCRIPTION
Reverts #615 and #613.

Some users are reporting breakage with 2.1.8 (which is now the default on `2.1`): e.g., https://github.com/travis-ci/travis-ci/issues/5580.