### PR TITLE
Enable use of https repositories

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -330,15 +330,17 @@ module Travis
 
         def setup_bioc
           unless @bioc_installed
-            sh.echo 'Installing Bioconductor'
-            bioc_install_script =
-              "source(\"#{config[:bioc]}\");"\
-              'tryCatch('\
-              " useDevel(#{as_r_boolean(config[:bioc_use_devel])}),"\
-              ' error=function(e) {if (!grepl("already in use", e$message)) {e}}'\
-              ');'\
-              'cat(append = TRUE, file = "~/.Rprofile", "options(repos = BiocInstaller::biocinstallRepos());")'
-            sh.cmd "Rscript -e '#{bioc_install_script}'", retry: true
+            sh.fold 'Bioconductor' do
+              sh.echo 'Installing Bioconductor'
+              bioc_install_script =
+                "source(\"#{config[:bioc]}\");"\
+                'tryCatch('\
+                " useDevel(#{as_r_boolean(config[:bioc_use_devel])}),"\
+                ' error=function(e) {if (!grepl("already in use", e$message)) {e}}'\
+                  ');'\
+                  'cat(append = TRUE, file = "~/.Rprofile", "options(repos = BiocInstaller::biocinstallRepos());")'
+                sh.cmd "Rscript -e '#{bioc_install_script}'", retry: true
+            end
           end
           @bioc_installed = true
         end

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -333,7 +333,7 @@ module Travis
         def setup_bioc
           unless @bioc_installed
             sh.fold 'Bioconductor' do
-              sh.echo 'Installing Bioconductor'
+              sh.echo 'Installing Bioconductor', ansi: :yellow
               bioc_install_script =
                 "source(\"#{config[:bioc]}\");"\
                 'tryCatch('\

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -46,6 +46,7 @@ module Travis
           sh.export 'TRAVIS_R_VERSION', version, echo: false
           sh.export 'R_LIBS_USER', '~/R/Library', echo: false
           sh.export '_R_CHECK_CRAN_INCOMING_', 'false', echo: false
+          sh.export 'NOT_CRAN', 'true', echo: false
         end
 
         def configure

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -132,16 +132,20 @@ module Travis
             setup_cache
           end
 
-          # Install any declared packages
-          apt_install config[:apt_packages]
-          brew_install config[:brew_packages]
-          r_binary_install config[:r_binary_packages]
-          r_install config[:r_packages]
-          r_install config[:bioc_packages]
-          r_github_install config[:r_github_packages]
+          sh.fold "R-dependencies" do
+            sh.echo 'Installing package dependencies', ansi: :yellow
 
-          # Install dependencies for the package we're testing.
-          install_deps
+            # Install any declared packages
+            apt_install config[:apt_packages]
+            brew_install config[:brew_packages]
+            r_binary_install config[:r_binary_packages]
+            r_install config[:r_packages]
+            r_install config[:bioc_packages]
+            r_github_install config[:r_github_packages]
+
+            # Install dependencies for the package we're testing.
+            install_deps
+          end
         end
 
         def script
@@ -294,17 +298,14 @@ module Travis
         end
 
         def install_deps
-          sh.fold "R-dependencies" do
-            sh.echo 'Installing package dependencies', ansi: :yellow
-            setup_devtools
-            install_script =
-              'deps <- devtools::install_deps(dependencies = TRUE);'\
-                'if (!all(deps %in% installed.packages())) {'\
-                ' message("missing: ", paste(setdiff(deps, installed.packages()), collapse=", "));'\
-                ' q(status = 1, save = "no")'\
-                '}'
-            sh.cmd "Rscript -e '#{install_script}'"
-          end
+          setup_devtools
+          install_script =
+            'deps <- devtools::install_deps(dependencies = TRUE);'\
+            'if (!all(deps %in% installed.packages())) {'\
+            ' message("missing: ", paste(setdiff(deps, installed.packages()), collapse=", "));'\
+            ' q(status = 1, save = "no")'\
+            '}'
+          sh.cmd "Rscript -e '#{install_script}'"
         end
 
         def export_rcheck_dir

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -9,7 +9,7 @@ module Travis
       class R < Script
         DEFAULTS = {
           # Basic config options
-          cran: 'http://cloud.r-project.org',
+          cran: 'https://cloud.r-project.org',
           repos: {},
           warnings_are_errors: true,
           # Dependencies (installed in this order)
@@ -27,7 +27,7 @@ module Travis
           pandoc: true,
           pandoc_version: '1.15.2',
           # Bioconductor
-          bioc: 'http://bioconductor.org/biocLite.R',
+          bioc: 'https://bioconductor.org/biocLite.R',
           bioc_required: false,
           bioc_use_devel: false,
           R: 'release'
@@ -105,7 +105,9 @@ module Travis
               end
 
               # Set repos in ~/.Rprofile
-              options_repos = "options(repos = c(#{repos.collect {|k,v| "#{k} = \"#{v}\""}.join(", ")}))"
+              repos_str = repos.collect {|k,v| "#{k} = \"#{v}\""}.join(", ")
+              options_repos = "options(repos = c(#{repos_str}), "\
+                              "download.file.method = \"curl\")"
               sh.cmd %Q{echo '#{options_repos}' > ~/.Rprofile}
 
               setup_latex

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -165,22 +165,22 @@ module Travis
             # Test the package
             sh.echo 'Checking with: R CMD check "${PKG_TARBALL}" '\
               "#{config[:r_check_args]}"
-            sh.cmd "R CMD check \"${PKG_TARBALL}\" #{config[:r_check_args]}",
-              assert: false
-            # Build fails if R CMD check fails
-            sh.if '$? -ne 0' do
-              sh.fold "Check logs" do
-                sh.echo 'R CMD check logs', ansi: :yellow
-                dump_logs
-              end
-              sh.failure 'R CMD check failed'
-            end
-
+            sh.cmd "R CMD check \"${PKG_TARBALL}\" #{config[:r_check_args]}; "\
+              "CHECK_RET=$?", assert: false
           end
           export_rcheck_dir
 
           # Output check summary
           sh.cmd 'Rscript -e "cat(devtools::check_failures(path = \"${RCHECK_DIR}\"), \"\\\n\")"', echo: false
+
+          # Build fails if R CMD check fails
+          sh.if 'CHECK_RET=$? -ne 0' do
+            sh.fold "Check logs" do
+              sh.echo 'R CMD check logs', ansi: :yellow
+              dump_logs
+            end
+            sh.failure 'R CMD check failed'
+          end
 
           # Turn warnings into errors, if requested.
           if config[:warnings_are_errors]

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -121,7 +121,7 @@ module Travis
         def announce
           super
           sh.fold 'R-session-info' do
-            sh.echo 'R session information'
+            sh.echo 'R session information', ansi: :yellow
             sh.cmd 'Rscript -e \'sessionInfo()\''
           end
         end

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -27,19 +27,19 @@ describe Travis::Build::Script::R, :sexp do
   end
 
   it 'sets repos in ~/.Rprofile with defaults' do
-    should include_sexp [:cmd, "echo 'options(repos = c(CRAN = \"http://cloud.r-project.org\"))' > ~/.Rprofile",
+    should include_sexp [:cmd, "echo 'options(repos = c(CRAN = \"https://cloud.r-project.org\"), download.file.method = \"curl\")' > ~/.Rprofile",
                          assert: true, echo: true, timing: true]
   end
 
   it 'sets repos in ~/.Rprofile with user specified repos' do
     data[:config][:cran] = 'https://cran.rstudio.org'
-    should include_sexp [:cmd, "echo 'options(repos = c(CRAN = \"https://cran.rstudio.org\"))' > ~/.Rprofile",
+    should include_sexp [:cmd, "echo 'options(repos = c(CRAN = \"https://cran.rstudio.org\"), download.file.method = \"curl\")' > ~/.Rprofile",
                          assert: true, echo: true, timing: true]
   end
 
   it 'sets repos in ~/.Rprofile with additional user specified repos' do
-    data[:config][:repos] = {CRAN: 'https://cran.rstudio.org', ropensci: 'https://packages.ropensci.org'}
-    should include_sexp [:cmd, "echo 'options(repos = c(CRAN = \"https://cran.rstudio.org\", ropensci = \"https://packages.ropensci.org\"))' > ~/.Rprofile",
+    data[:config][:repos] = {CRAN: 'https://cran.rstudio.org', ropensci: 'http://packages.ropensci.org'}
+    should include_sexp [:cmd, "echo 'options(repos = c(CRAN = \"https://cran.rstudio.org\", ropensci = \"http://packages.ropensci.org\"), download.file.method = \"curl\")' > ~/.Rprofile",
                          assert: true, echo: true, timing: true]
   end
 


### PR DESCRIPTION
Because the debian R packages for 12.04 do not have libcurl support we
need to explicitly set `download.file.method = "curl"` in `.Rprofile` to
allow https:// URLs.