### PR TITLE
Use `uname` output to set ssh key types

### DIFF
--- a/lib/travis/build/addons/ssh_known_hosts.rb
+++ b/lib/travis/build/addons/ssh_known_hosts.rb
@@ -39,7 +39,7 @@ module Travis
                   next
                 end
 
-                sh.if "$TRAVIS_OS_NAME = 'osx'" do
+                sh.if "$(uname) = 'Darwin'" do
                   sh.cmd "TRAVIS_SSH_KEY_TYPES='rsa,dsa'"
                 end
                 sh.else do


### PR DESCRIPTION
TRAVIS_OS_NAME is set after the addon is run, so this `if`
was ineffective.

Resolves https://github.com/travis-ci/travis-ci/issues/5596