### PR TITLE
Fix GCE builds [Smalltalk]

### DIFF
--- a/lib/travis/build/script/smalltalk.rb
+++ b/lib/travis/build/script/smalltalk.rb
@@ -100,7 +100,10 @@ module Travis
             sh.fold 'install_packages' do
               sh.echo 'Installing dependencies', ansi: :yellow
 
-              sh.cmd 'sudo dpkg --add-architecture i386'
+              sh.if '$(lsb_release -cs) != precise' do
+                sh.cmd 'sudo dpkg --add-architecture i386'
+              end
+
               sh.cmd 'sudo apt-get update -qq', retry: true
               sh.cmd 'sudo apt-get install -y --no-install-recommends ' +
                      'libc6:i386 libuuid1:i386 libfreetype6:i386 libssl1.0.0:i386', retry: true
@@ -192,6 +195,7 @@ module Travis
               sh.cmd 'sudo ln -f -s /usr/lib/i386-lin-gnu/libstdc++.so.6 /usr/lib/i386-linux-gnu/libstdc++.so'
             end
             sh.if '$(lsb_release -cs) = trusty' do
+              sh.cmd 'sudo dpkg --add-architecture i386'
               gemstone_install_linux_dependencies
               sh.cmd 'sudo ln -f -s /usr/lib/i386-lin-gnu/libstdc++.so.6 /usr/lib/i386-linux-gnu/libstdc++.so'
             end
@@ -201,7 +205,6 @@ module Travis
             sh.fold 'gemstone_dependencies' do
               sh.echo 'Installing GemStone dependencies', ansi: :yellow
 
-              sh.cmd 'sudo dpkg --add-architecture i386'
               sh.cmd 'sudo apt-get update -qq', retry: true
               sh.cmd 'sudo apt-get install -y --no-install-recommends ' +
                      'libpam0g:i386 libssl1.0.0:i386 gcc-multilib ' +


### PR DESCRIPTION
Currently, Smalltalk builds on GCE fail, because `apt-get` is waiting for user input.
This PR should fix it.

Thanks as always,
Fabio

https://github.com/hpi-swa/smalltalkCI/issues/59