### PR TITLE
Allow C++ compiler versions to be specified in yaml-file

### DIFF
--- a/lib/travis/build/script/c.rb
+++ b/lib/travis/build/script/c.rb
@@ -3,7 +3,7 @@ module Travis
     class Script
       class C < Script
         DEFAULTS = {
-          compiler: 'gcc'
+          compiler: ''
         }
 
         def export
@@ -43,7 +43,13 @@ module Travis
         private
 
           def compiler
-            config[:compiler].to_s
+            case config[:compiler].to_s
+            when /^gcc/i, /^clang/i
+              config[:compiler].to_s
+            else
+              { 'linux' => 'gcc', 
+                'osx' => 'clang' }[config[:os]]
+            end
           end
       end
     end

--- a/lib/travis/build/script/cpp.rb
+++ b/lib/travis/build/script/cpp.rb
@@ -3,7 +3,7 @@ module Travis
     class Script
       class Cpp < Script
         DEFAULTS = {
-          compiler: 'g++'
+          compiler: ''
         }
 
         def export
@@ -41,28 +41,30 @@ module Travis
         private
 
           def compiler
-            config[:compiler].to_s
+            cxx
           end
 
           def cxx
-            case compiler
-            when /^gcc/i, /^g\+\+/i then
-              'g++'
-            when /^clang/i, /^clang\+\+/i then
-              'clang++'
+            case config[:compiler].to_s
+            when /^gcc(.*)$/i, /^g\+\+(.*)$/i
+              'g++' + $1
+            when /^clang([^+]*)$/i, /^clang\+\+(.*)$/i
+              'clang++' + $1
             else
-              'g++'
+              { 'linux' => 'g++', 
+                'osx' => 'clang++' }[config[:os]]
             end
           end
 
           def cc
-            case compiler
-            when /^gcc/i, /^g\+\+/i then
-              'gcc'
-            when /^clang/i, /^clang\+\+/i then
-              'clang'
+            case config[:compiler].to_s
+            when /^gcc(.*)$/i, /^g\+\+(.*)$/i
+              'gcc' + $1
+            when /^clang([^+]*)$/i, /^clang\+\+(.*)$/i
+              'clang' + $1
             else
-              'gcc'
+              { 'linux' => 'gcc', 
+                'osx' => 'clang' }[config[:os]]
             end
           end
       end


### PR DESCRIPTION
Using a specific compiler version required up to now to manually export $CC and $CXX (a hack that is very common in the wild, see linked issues). This changeset should solve this so you can simply do `compiler: gcc-4.9`. Closes [#3871](https://github.com/travis-ci/travis-ci/issues/3871), partly implements [#979](https://github.com/travis-ci/travis-ci/issues/979), replaces [PR#542](https://github.com/travis-ci/travis-build/pull/542) (which accurately describes the problem, but just makes the hack easier).

Additionally, this solves the minor problem that `announce` displays the given `compiler: anystring` without sanitising the string, such that it prints a different version (the specified `anystring`) than the one that is actually used (the system default if not either `g++` or `clang++` is specified). Finally, this changeset also sets the default OS X compiler to `clang` instead of `gcc`.