### PR TITLE
Clear vendor/cache if empty

### DIFF
--- a/lib/travis/build/script/shared/bundler.rb
+++ b/lib/travis/build/script/shared/bundler.rb
@@ -48,6 +48,9 @@ module Travis
         def install
           sh.if gemfile? do
             sh.if gemfile_lock? do
+              sh.if '$(du -ks vendor/cache | cut -f 1) -eq 0' do
+                sh.cmd 'rm -rf vendor/cache'
+              end
               sh.cmd bundler_install("--deployment"), fold: "install.bundler", retry: true
             end
             sh.else do


### PR DESCRIPTION
`vendor/cache` is empty if it is created by the casher, but the cache is not available. This causes a problem if `bundle install` has `--deployment` (and therefore https://github.com/travis-ci/travis-ci/issues/5664).

The casher creates the directory when `vendor/cache` is given in `cache.directories`. This behavior is a bit confusing, but existing builds may be relying on this behavior at this point, so we deal with the problem within `travis-build`.