### PR TITLE
Fix R builds on OS X

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -420,7 +420,7 @@ module Travis
             sh.export 'PATH', '/usr/texbin:$PATH'
 
             # set tlpkg writable so no sudo is needed
-            sh.cmd "sudo 757 /usr/local/texlive/2015/tlpkg/"
+            sh.cmd "sudo chmod 757 /usr/local/texlive/2015/tlpkg/"
             sh.cmd 'tlmgr update --self'
 
             # Install common packages


### PR DESCRIPTION
This was a silly oversight in my previous PR, after this change R OS X builds should work as before.