### PR TITLE
Configure /etc/hosts on OS X just like on Linux [Smalltalk]

### DIFF
--- a/lib/travis/build/script/smalltalk.rb
+++ b/lib/travis/build/script/smalltalk.rb
@@ -113,12 +113,7 @@ module Travis
           def gemstone_configure_hosts()
             sh.echo 'Configuring /etc/hosts file', ansi: :yellow
 
-            case config[:os]
-            when 'linux'
-              sh.cmd "sed -e \"s/^\\(127\\.0\\.0\\.1.*\\)$/\\1 $(hostname)/\" #{HOSTS_FILE} | sed -e \"s/^\\(::1.*\\)$/\\1 $(hostname)/\" > #{TEMP_HOSTS_FILE}"
-            when 'osx'
-              sh.cmd "sed -e \"s/^\\(127\\.0\\.0\\.1.*\\)$/\\1 $(scutil --get HostName)/\" #{HOSTS_FILE} | sed -e \"s/^\\(::1.*\\)$/\\1 $(scutil --get HostName)/\" > #{TEMP_HOSTS_FILE}"
-            end
+            sh.cmd "sed -e \"s/^\\(127\\.0\\.0\\.1.*\\)$/\\1 $(hostname)/\" #{HOSTS_FILE} | sed -e \"s/^\\(::1.*\\)$/\\1 $(hostname)/\" > #{TEMP_HOSTS_FILE}"
             sh.cmd "cat #{TEMP_HOSTS_FILE} | sudo tee #{HOSTS_FILE} > /dev/null"
           end
 

--- a/spec/build/script/smalltalk_spec.rb
+++ b/spec/build/script/smalltalk_spec.rb
@@ -75,7 +75,7 @@ describe Travis::Build::Script::Smalltalk, :sexp do
     end
 
     it 'set hostname' do
-      should include_sexp [:cmd, "sed -e \"s/^\\(127\\.0\\.0\\.1.*\\)$/\\1 $(scutil --get HostName)/\" /etc/hosts | sed -e \"s/^\\(::1.*\\)$/\\1 $(scutil --get HostName)/\" > /tmp/hosts"]
+      should include_sexp [:cmd, "sed -e \"s/^\\(127\\.0\\.0\\.1.*\\)$/\\1 $(hostname)/\" /etc/hosts | sed -e \"s/^\\(::1.*\\)$/\\1 $(hostname)/\" > /tmp/hosts"]
       should include_sexp [:cmd, "cat /tmp/hosts | sudo tee /etc/hosts > /dev/null"]
     end
 


### PR DESCRIPTION
Hi @BanzaiMan,

We finally have [GemStone running on containers](https://travis-ci.org/hpi-swa/smalltalkCI/jobs/111612181)!
There still is a `hostname`-related issue that keeps GemStone from also running on OS X.
This PR should fix it (https://github.com/hpi-swa/smalltalkCI/issues/68).

Best,
Fabio