### PR TITLE
Install mariadb-server and mariadb-server-specific-version

### DIFF
--- a/lib/travis/build/addons/mariadb.rb
+++ b/lib/travis/build/addons/mariadb.rb
@@ -17,7 +17,7 @@ module Travis
             sh.cmd "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 #{MARIADB_GPG_KEY}", sudo: true
             sh.cmd 'add-apt-repository "deb http://%p/mariadb/repo/%p/ubuntu $(lsb_release -cs) main"' % [MARIADB_MIRROR, mariadb_version], sudo: true
             sh.cmd "apt-get update -qq", assert: false, sudo: true
-            sh.cmd "apt-get install -o Dpkg::Options::='--force-confnew' mariadb-server libmariadbclient-dev", sudo: true, echo: true, timing: true
+            sh.cmd "apt-get install -o Dpkg::Options::='--force-confnew' mariadb-server mariadb-server-#{mariadb_version} libmariadbclient-dev", sudo: true, echo: true, timing: true
             sh.echo "Starting MariaDB v#{mariadb_version}", ansi: :yellow
             sh.cmd "service mysql start", sudo: true, assert: false, echo: true, timing: true
             sh.export 'TRAVIS_MARIADB_VERSION', mariadb_version, echo: false

--- a/spec/build/addons/mariadb_spec.rb
+++ b/spec/build/addons/mariadb_spec.rb
@@ -23,7 +23,7 @@ describe Travis::Build::Addons::Mariadb, :sexp do
   it { should include_sexp [:cmd, "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 #{Travis::Build::Addons::Mariadb::MARIADB_GPG_KEY}", sudo: true] }
   it { should include_sexp [:cmd, 'add-apt-repository "deb http://%p/mariadb/repo/%p/ubuntu $(lsb_release -cs) main"' % [Travis::Build::Addons::Mariadb::MARIADB_MIRROR, config], sudo: true] }
   it { should include_sexp [:cmd, "apt-get update -qq", sudo: true] }
-  it { should include_sexp [:cmd, "apt-get install -o Dpkg::Options::='--force-confnew' mariadb-server libmariadbclient-dev", sudo: true, echo: true, timing: true] }
+  it { should include_sexp [:cmd, "apt-get install -o Dpkg::Options::='--force-confnew' mariadb-server mariadb-server-10.0 libmariadbclient-dev", sudo: true, echo: true, timing: true] }
   it { should include_sexp [:cmd, "service mysql start", sudo: true, echo: true, timing: true] }
   it { should include_sexp [:cmd, "mysql --version", echo: true] }
 end


### PR DESCRIPTION
This should resolve the errors I'm seeing here, consistent for all three major MariaDB versions:

https://travis-ci.org/brianmario/mysql2/jobs/111612273
https://travis-ci.org/brianmario/mysql2/jobs/111612274
https://travis-ci.org/brianmario/mysql2/jobs/111612275

```
0.25s$ sudo apt-get install -o Dpkg::Options::='--force-confnew' mariadb-server libmariadbclient-dev
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:
The following packages have unmet dependencies:
 mariadb-server : Depends: mariadb-server-5.5 (= 5.5.48+maria-1~trusty) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```