### PR TITLE
Patches travis to use bundle exec for cocoapods when it is running ge…

### DIFF
--- a/lib/travis/build/script/objective_c.rb
+++ b/lib/travis/build/script/objective_c.rb
@@ -59,9 +59,19 @@ module Travis
           sh.if podfile? do
             sh.if "! ([[ -f #{pod_dir}/Podfile.lock && -f #{pod_dir}/Pods/Manifest.lock ]] && cmp --silent #{pod_dir}/Podfile.lock #{pod_dir}/Pods/Manifest.lock)", raw: true do
               sh.fold('install.cocoapods') do
-                sh.echo "Installing Pods with 'pod install'", ansi: :yellow
+
                 sh.cmd "pushd #{pod_dir}"
-                sh.cmd 'pod install', retry: true
+
+                sh.if gemfile? do
+                  sh.echo "Installing Pods with 'bundle exec pod install'", ansi: :yellow
+                  sh.cmd 'bundle exec pod install', retry: true
+                end
+
+                sh.elif gemfile? do
+                  sh.echo "Installing Pods with 'pod install'", ansi: :yellow
+                  sh.cmd 'pod install', retry: true
+                end
+
                 sh.cmd 'popd'
               end
             end

--- a/lib/travis/build/script/objective_c.rb
+++ b/lib/travis/build/script/objective_c.rb
@@ -67,7 +67,7 @@ module Travis
                   sh.cmd 'bundle exec pod install', retry: true
                 end
 
-                sh.elif gemfile? do
+                sh.elf do
                   sh.echo "Installing Pods with 'pod install'", ansi: :yellow
                   sh.cmd 'pod install', retry: true
                 end

--- a/lib/travis/build/script/objective_c.rb
+++ b/lib/travis/build/script/objective_c.rb
@@ -67,7 +67,7 @@ module Travis
                   sh.cmd 'bundle exec pod install', retry: true
                 end
 
-                sh.elf do
+                sh.elif do
                   sh.echo "Installing Pods with 'pod install'", ansi: :yellow
                   sh.cmd 'pod install', retry: true
                 end

--- a/spec/build/script/objective_c_spec.rb
+++ b/spec/build/script/objective_c_spec.rb
@@ -72,12 +72,12 @@ describe Travis::Build::Script::ObjectiveC, :sexp do
     end
 
     it 'runs bundle exec pod install if a Podfile and Gemfile exists' do
-      sexp = sexp_filter(subject, [:if, '-f Podfile'])[1]
+      sexp = sexp_find(sexp_filter(subject, [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}"])[1], [:then])
       expect(sexp).to include_sexp [:cmd, 'bundle exec pod install', assert: true, echo: true, retry: true, timing: true]
     end
 
     it 'runs pod install if a Podfile exists' do
-      sexp = sexp_filter(subject, [:if, "-f Podfile && -f ${BUNDLE_GEMFILE:-Gemfile}"])
+      sexp = sexp_filter(subject, [:if, '-f Podfile'])[1]
       expect(sexp).to include_sexp [:cmd, 'pod install', assert: true, echo: true, retry: true, timing: true]
     end
 

--- a/spec/build/script/objective_c_spec.rb
+++ b/spec/build/script/objective_c_spec.rb
@@ -71,8 +71,13 @@ describe Travis::Build::Script::ObjectiveC, :sexp do
       expect(sexp).to include_sexp [:cmd, 'bundle install --jobs=3 --retry=3', echo: true, timing: true, assert: true, retry: true]
     end
 
-    it 'runs pod install if a Podfile exists' do
+    it 'runs bundle exec pod install if a Podfile and Gemfile exists' do
       sexp = sexp_filter(subject, [:if, '-f Podfile'])[1]
+      expect(sexp).to include_sexp [:cmd, 'bundle exec pod install', assert: true, echo: true, retry: true, timing: true]
+    end
+
+    it 'runs pod install if a Podfile exists' do
+      sexp = sexp_filter(subject, [:if, "-f Podfile && -f ${BUNDLE_GEMFILE:-Gemfile}"])
       expect(sexp).to include_sexp [:cmd, 'pod install', assert: true, echo: true, retry: true, timing: true]
     end
 


### PR DESCRIPTION
…ms from a podfile.

This should fix https://github.com/travis-ci/travis-ci/issues/5694 - When a `Gemfile` is detected we now run `bundler exec pod install` instead of just `pod install` so that the gem is correctly located. When there is no `Gemfile` we default to just `pod install`.