### PR TITLE
Fix path to be proper for BasicTex

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -420,7 +420,7 @@ module Travis
             sh.export 'PATH', '/usr/texbin:$PATH'
 
             # set tlpkg writable so no sudo is needed
-            sh.cmd "sudo chmod 757 /usr/local/texlive/2015/tlpkg/"
+            sh.cmd "sudo chmod 757 /usr/local/texlive/2015basic/tlpkg/"
             sh.cmd 'tlmgr update --self'
 
             # Install common packages


### PR DESCRIPTION
Turns out BasicTex installs to `/usr/local/texlive/2015basic/tlpkg/` rather than `/usr/local/texlive/2015/tlpkg/` like the full installation.

Fixes https://github.com/craigcitro/r-travis/issues/174#issuecomment-188626739