### PR TITLE
C++: export /usr/lib/ccache to the PATH

### DIFF
--- a/lib/travis/build/script/cpp.rb
+++ b/lib/travis/build/script/cpp.rb
@@ -10,6 +10,9 @@ module Travis
           super
           sh.export 'CXX', cxx
           sh.export 'CC', cc # some projects also need to compile some C, e.g. Rubinius. MK.
+          if data.cache?(:ccache)
+            sh.export 'PATH', "/usr/lib/ccache:$PATH"
+          end
         end
 
         def announce


### PR DESCRIPTION
C builds already have this feature but this was missing for C++.

Signed-off-by: David Wagner <david.wagner@intel.com>