### PR TITLE
Check for Go 1.5 vendoring before Godeps init.

### DIFF
--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -67,12 +67,12 @@ module Travis
           sh.if uses_15_vendoring do
             sh.echo 'Using Go 1.5 Vendoring, not checking for Godeps'
           end
-	  sh.else do
-	    sh .if '-f Godeps/Godeps.json' do
+          sh.else do
+            sh .if '-f Godeps/Godeps.json' do
               sh.export 'GOPATH', '${TRAVIS_BUILD_DIR}/Godeps/_workspace:$GOPATH', retry: false
               sh.export 'PATH', '${TRAVIS_BUILD_DIR}/Godeps/_workspace/bin:$PATH', retry: false
 
-              if go_version >= '1.1'
+              if go_version != 'go1' && comparable_go_version >= Gem::Version.new('1.1')
                 sh.if '! -d Godeps/_workspace/src' do
                   sh.cmd "#{go_get_cmd} github.com/tools/godep", echo: true, retry: true, timing: true, assert: true
                   sh.cmd 'godep restore', retry: true, timing: true, assert: true, echo: true
@@ -107,12 +107,13 @@ module Travis
           def uses_make
             '-f GNUmakefile || -f makefile || -f Makefile || -f BSDmakefile'
           end
-
-	  def uses_15_vendoring
-            if (go_version < '1.5' || go_version == 'go1')
-              'false'
+          
+          # see https://golang.org/doc/go1.6#go_command
+          def uses_15_vendoring
+            if (go_version == 'go1' || comparable_go_version < Gem::Version.new('1.5'))
+              return 'false'
             end
-	    (go_version < '1.6') ? '$GO15VENDOREXPERIMENT == 1' : '$GO15VENDOREXPERIMENT != 0'
+            (comparable_go_version < Gem::Version.new('1.6')) ? '$GO15VENDOREXPERIMENT == 1' : '$GO15VENDOREXPERIMENT != 0'
           end
 
           def gobuild_args
@@ -140,8 +141,15 @@ module Travis
             end
           end
 
+          def comparable_go_version
+            if !go_version[/^[0-9]/] # if we don't have a semver version that Gem::Version can read
+              return Gem::Version.new('0.0.1') # return a consistent result
+            end
+            Gem::Version.new(go_version)
+          end
+
           def go_get_cmd
-            (go_version < '1.2' || go_version == 'go1') ? 'go get' : 'go get -t'
+            (go_version == 'go1' || comparable_go_version < Gem::Version.new('1.2')) ? 'go get' : 'go get -t'
           end
 
           def ensure_gvm_wiped

--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -64,14 +64,19 @@ module Travis
         end
 
         def install
-          sh.if '-f Godeps/Godeps.json' do
-            sh.export 'GOPATH', '${TRAVIS_BUILD_DIR}/Godeps/_workspace:$GOPATH', retry: false
-            sh.export 'PATH', '${TRAVIS_BUILD_DIR}/Godeps/_workspace/bin:$PATH', retry: false
+          sh.if uses_15_vendoring do
+            sh.echo 'Using Go 1.5 Vendoring, not checking for Godeps'
+          end
+	  sh.else do
+	    sh .if '-f Godeps/Godeps.json' do
+              sh.export 'GOPATH', '${TRAVIS_BUILD_DIR}/Godeps/_workspace:$GOPATH', retry: false
+              sh.export 'PATH', '${TRAVIS_BUILD_DIR}/Godeps/_workspace/bin:$PATH', retry: false
 
-            if go_version >= '1.1'
-              sh.if '! -d Godeps/_workspace/src' do
-                sh.cmd "#{go_get_cmd} github.com/tools/godep", echo: true, retry: true, timing: true, assert: true
-                sh.cmd 'godep restore', retry: true, timing: true, assert: true, echo: true
+              if go_version >= '1.1'
+                sh.if '! -d Godeps/_workspace/src' do
+                  sh.cmd "#{go_get_cmd} github.com/tools/godep", echo: true, retry: true, timing: true, assert: true
+                  sh.cmd 'godep restore', retry: true, timing: true, assert: true, echo: true
+                end
               end
             end
           end
@@ -101,6 +106,13 @@ module Travis
 
           def uses_make
             '-f GNUmakefile || -f makefile || -f Makefile || -f BSDmakefile'
+          end
+
+	  def uses_15_vendoring
+            if (go_version < '1.5' || go_version == 'go1')
+              'false'
+            end
+	    (go_version < '1.6') ? '$GO15VENDOREXPERIMENT == 1' : '$GO15VENDOREXPERIMENT != 0'
           end
 
           def gobuild_args


### PR DESCRIPTION
If we are using Go 1.5's vendoring method, we could have a
Godeps/Godeps.json file and _not_ want to run `godep restore`. Godep is
used as a tool to manage dependencies under Go 1.5's vendoring method,
and `godep restore` is _not_ supposed to be run in those cases.

This fixes that by adding a check to see if we're using Go 1.5's
vendoring method before we check if godep is being used, and skipping
the godep section if we're using 1.5's vendoring method instead.

See travis-ci/travis-ci#5702.