### PR TITLE
Introduce debug phase

### DIFF
--- a/lib/travis/build/appliances/debug_tools.rb
+++ b/lib/travis/build/appliances/debug_tools.rb
@@ -9,12 +9,10 @@ module Travis
         include Template
         TEMPLATES_PATH = File.expand_path('templates', __FILE__.sub('.rb', ''))
 
-        def enabled?
-          ENV['TRAVIS_ENABLE_DEBUG_TOOLS'] == '1'
-        end
+        def_instance_delegator :script, :debug_enabled?
 
         def apply
-          enabled? ? apply_enabled : apply_disabled
+          debug_enabled? ? apply_enabled : apply_disabled
         end
 
         def apply_enabled

--- a/lib/travis/build/appliances/debug_tools.rb
+++ b/lib/travis/build/appliances/debug_tools.rb
@@ -9,10 +9,10 @@ module Travis
         include Template
         TEMPLATES_PATH = File.expand_path('templates', __FILE__.sub('.rb', ''))
 
-        def_instance_delegator :script, :debug_enabled?
+        def_delegators :script, :debug_enabled?, :debug_build_via_api?
 
         def apply
-          debug_enabled? ? apply_enabled : apply_disabled
+          (debug_enabled? || debug_build_via_api?) ? apply_enabled : apply_disabled
         end
 
         def apply_enabled

--- a/lib/travis/build/data.rb
+++ b/lib/travis/build/data.rb
@@ -153,6 +153,10 @@ module Travis
       def token
         data[:oauth_token]
       end
+
+      def debug_options
+        job[:debug_options] || {}
+      end
     end
   end
 end

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -91,6 +91,14 @@ module Travis
           data.config
         end
 
+        def debug
+          if config[:debug]
+            sh.echo "Debug build initiated by #{config[:debug][:created_by]}", ansi: :yellow
+            apply :debug_tools
+            sh.raw "travis_debug"
+          end
+        end
+
         def run
           stages.run if apply :validate
           sh.raw template('footer.sh')
@@ -111,7 +119,7 @@ module Travis
           apply :put_localhost_first
           apply :home_paths
           apply :disable_ssh_roaming
-          apply :debug_tools
+          apply :debug_tools unless config[:debug]
         end
 
         def checkout

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -184,11 +184,15 @@ module Travis
         end
 
         def debug_build?
-          config[:debug]
+          debug_enabled? && config[:debug]
         end
 
         def debug_quiet?
           debug_build? && config[:debug][:quiet]
+        end
+
+        def debug_enabled?
+          ENV['TRAVIS_ENABLE_DEBUG_TOOLS'] == '1'
         end
     end
   end

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -92,10 +92,15 @@ module Travis
         end
 
         def debug
-          if config[:debug]
+          if debug_build?
             sh.echo "Debug build initiated by #{config[:debug][:created_by]}", ansi: :yellow
             apply :debug_tools
-            sh.raw "travis_debug"
+            sh.raw "PS1"
+            if config[:debug][:quiet]
+              sh.raw "travis_debug --quiet"
+            else
+              sh.raw "travis_debug"
+            end
           end
         end
 
@@ -161,6 +166,10 @@ module Travis
           when /^(?i:darwin)/
             '${$(sw_vers -productVersion)%*.*}'
           end
+        end
+
+        def debug_build?
+          config[:debug]
         end
     end
   end

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -93,7 +93,7 @@ module Travis
 
         def debug
           if debug_build_via_api?
-            sh.echo "Debug build initiated by #{config[:debug][:created_by]}", ansi: :yellow
+            sh.echo "Debug build initiated by #{data.debug_options[:created_by]}", ansi: :yellow
             if debug_quiet?
               sh.raw "travis_debug --quiet"
             else
@@ -145,7 +145,7 @@ module Travis
 
         def reset_state
           if debug_build_via_api?
-            raise "Debug payload does not contain 'previous_state' value." unless previous_state = config[:debug][:previous_state]
+            raise "Debug payload does not contain 'previous_state' value." unless previous_state = data.debug_options[:previous_state]
             sh.echo "This is a debug build. The build result is reset to its previous value, \\\"#{previous_state}\\\".", ansi: :yellow
 
             case previous_state
@@ -183,11 +183,11 @@ module Travis
         end
 
         def debug_build_via_api?
-          debug_enabled? && config[:debug]
+          ! data.debug_options.empty?
         end
 
         def debug_quiet?
-          debug_build_via_api? && config[:debug][:quiet]
+          debug_build_via_api? && data.debug_options[:quiet]
         end
 
         def debug_enabled?

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -94,7 +94,6 @@ module Travis
         def debug
           if debug_build?
             sh.echo "Debug build initiated by #{config[:debug][:created_by]}", ansi: :yellow
-            apply :debug_tools
             if debug_quiet?
               sh.raw "travis_debug --quiet"
             else
@@ -123,7 +122,7 @@ module Travis
           apply :put_localhost_first
           apply :home_paths
           apply :disable_ssh_roaming
-          apply :debug_tools unless debug_build?
+          apply :debug_tools
         end
 
         def checkout

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -123,7 +123,7 @@ module Travis
           apply :put_localhost_first
           apply :home_paths
           apply :disable_ssh_roaming
-          apply :debug_tools unless config[:debug]
+          apply :debug_tools unless debug_build?
         end
 
         def checkout

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -92,7 +92,7 @@ module Travis
         end
 
         def debug
-          if debug_build?
+          if debug_build_via_api?
             sh.echo "Debug build initiated by #{config[:debug][:created_by]}", ansi: :yellow
             if debug_quiet?
               sh.raw "travis_debug --quiet"
@@ -144,7 +144,7 @@ module Travis
         end
 
         def reset_state
-          if debug_build?
+          if debug_build_via_api?
             raise "Debug payload does not contain 'previous_state' value." unless previous_state = config[:debug][:previous_state]
             sh.echo "This is a debug build. The build result is reset to its previous value, \\\"#{previous_state}\\\".", ansi: :yellow
 
@@ -182,12 +182,12 @@ module Travis
           end
         end
 
-        def debug_build?
+        def debug_build_via_api?
           debug_enabled? && config[:debug]
         end
 
         def debug_quiet?
-          debug_build? && config[:debug][:quiet]
+          debug_build_via_api? && config[:debug][:quiet]
         end
 
         def debug_enabled?

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -151,9 +151,9 @@ module Travis
 
             case previous_state
             when "passed"
-              sh.export 'TRAVIS_TEST_RESULT', '0'
+              sh.export 'TRAVIS_TEST_RESULT', '0', echo: false
             when "failed"
-              sh.export 'TRAVIS_TEST_RESULT', '1'
+              sh.export 'TRAVIS_TEST_RESULT', '1', echo: false
             when "errored"
               sh.raw 'travis_terminate 2'
             end

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -147,7 +147,7 @@ module Travis
         def reset_state
           if debug_build?
             raise "Debug payload does not contain 'previous_state' value." unless previous_state = config[:debug][:previous_state]
-            sh.echo "This is a debug build. The build result is reset to its previous value, \"#{previous_state}\".", ansi: :yellow
+            sh.echo "This is a debug build. The build result is reset to its previous value, \\\"#{previous_state}\\\".", ansi: :yellow
 
             case previous_state
             when "passed"

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -25,7 +25,7 @@ module Travis
         announce:       { assert: false, echo: true,  timing: false },
         setup_casher:   { assert: true,  echo: true,  timing: true  },
         setup_cache:    { assert: true,  echo: true,  timing: true  },
-        debug:          { assert: true,  echo: true,  timing: true  },
+        debug:          { assert: false, echo: true,  timing: true  },
         before_install: { assert: true,  echo: true,  timing: true  },
         install:        { assert: true,  echo: true,  timing: true  },
         before_script:  { assert: true,  echo: true,  timing: true  },

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -10,7 +10,7 @@ module Travis
       STAGES = [
         :builtin,     [:header, :configure, :checkout, :prepare, :disable_sudo, :export, :setup, :setup_casher, :setup_cache, :announce, :debug],
         :custom,      [:before_install, :install, :before_script, :script, :before_cache],
-        :builtin,     [:cache],
+        :builtin,     [:cache, :reset_state],
         :conditional, [:after_success],
         # :addon,       [:deploy_all],
         :conditional, [:after_failure],
@@ -35,6 +35,7 @@ module Travis
         after_script:   { assert: false, echo: true,  timing: true  },
         before_cache:   { assert: false, echo: true,  timing: true  },
         cache:          { assert: false, echo: true,  timing: true  },
+        reset_state:    { assert: false, echo: false, timing: false },
         before_deploy:  { assert: true,  echo: true,  timing: true  },
         deploy:         { assert: true,  echo: true,  timing: true  },
         after_deploy:   { assert: false, echo: true,  timing: true  },

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -8,7 +8,7 @@ module Travis
   module Build
     class Stages
       STAGES = [
-        :builtin,     [:header, :configure, :checkout, :prepare, :disable_sudo, :export, :setup, :setup_casher, :setup_cache, :announce],
+        :builtin,     [:header, :configure, :checkout, :prepare, :disable_sudo, :export, :setup, :setup_casher, :setup_cache, :announce, :debug],
         :custom,      [:before_install, :install, :before_script, :script, :before_cache],
         :builtin,     [:cache],
         :conditional, [:after_success],
@@ -25,6 +25,7 @@ module Travis
         announce:       { assert: false, echo: true,  timing: false },
         setup_casher:   { assert: true,  echo: true,  timing: true  },
         setup_cache:    { assert: true,  echo: true,  timing: true  },
+        debug:          { assert: true,  echo: true,  timing: true  },
         before_install: { assert: true,  echo: true,  timing: true  },
         install:        { assert: true,  echo: true,  timing: true  },
         before_script:  { assert: true,  echo: true,  timing: true  },

--- a/spec/build/script/shared/script.rb
+++ b/spec/build/script/shared/script.rb
@@ -52,3 +52,13 @@ shared_examples_for 'a build script sexp' do
     should include_sexp [:raw, 'travis_result $?']
   end
 end
+
+shared_examples_for 'a debug script' do
+  it 'initiates a debug phase' do
+    should include_sexp [:raw, "travis_debug"]
+  end
+
+  it 'resets build status' do
+    should include_sexp [:echo, "This is a debug build. The build result is reset to its previous value, \\\"failed\\\".", ansi: :yellow]
+  end
+end

--- a/spec/build/script/shared/script.rb
+++ b/spec/build/script/shared/script.rb
@@ -36,6 +36,11 @@ shared_examples_for 'a build script sexp' do
     let(:env_type) { 'global_env' }
   end
 
+  it 'does not initiate debug phase' do
+    should_not include_sexp [:raw, "travis_debug"]
+    should_not include_sexp [:raw, "travis_debug --quiet"]
+  end
+
   it_behaves_like 'show system info'
   it_behaves_like 'validates config'
   it_behaves_like 'paranoid mode on/off'
@@ -54,14 +59,14 @@ shared_examples_for 'a build script sexp' do
 end
 
 shared_examples_for 'a debug script' do
-  it 'initiates a debug phase' do
+  it 'initiates debug phase' do
     should include_sexp [:raw, "travis_debug"]
   end
 
   context 'when debug_options sets "quiet" => true' do
     before { payload[:job][:debug_options].merge!({ quiet: true }) }
 
-    it 'initiates a debug phase' do
+    it 'initiates debug phase' do
       should include_sexp [:raw, "travis_debug --quiet"]
     end
   end

--- a/spec/build/script/shared/script.rb
+++ b/spec/build/script/shared/script.rb
@@ -58,6 +58,14 @@ shared_examples_for 'a debug script' do
     should include_sexp [:raw, "travis_debug"]
   end
 
+  context 'when debug_options sets "quiet" => true' do
+    before { payload[:job][:debug_options].merge!({ quiet: true }) }
+
+    it 'initiates a debug phase' do
+      should include_sexp [:raw, "travis_debug --quiet"]
+    end
+  end
+
   it 'resets build status' do
     should include_sexp [:echo, "This is a debug build. The build result is reset to its previous value, \\\"failed\\\".", ansi: :yellow]
   end

--- a/spec/build/script_spec.rb
+++ b/spec/build/script_spec.rb
@@ -56,4 +56,9 @@ describe Travis::Build::Script, :sexp do
       expect { code }.to_not raise_error
     end
   end
+
+  context 'when running a debug build' do
+    let(:payload) { payload_for(:push_debug, :ruby, config: { cache: ['apt', 'bundler'] }).merge(config) }
+    it_behaves_like 'a debug script'
+  end
 end

--- a/spec/support/payloads.rb
+++ b/spec/support/payloads.rb
@@ -12,7 +12,8 @@ PAYLOADS = {
     },
     'build' => {
       'id' => '1',
-      'number' => '1'
+      'number' => '1',
+      'previous_state' => 'failed'
     },
     'job' => {
       'id' => '1',
@@ -22,6 +23,38 @@ PAYLOADS = {
       'commit_range' => '313f61b..313f61a',
       'commit_message' => 'the commit message',
       'secure_env_enabled' => true
+    }
+  },
+  push_debug: {
+    'type' => 'test',
+    'config' => {
+      'os' => 'linux',
+      'env' => ['FOO=foo', 'SECURE BAR=bar']
+    },
+    'repository' => {
+      'github_id' => 42,
+      'slug' => 'travis-ci/travis-ci',
+      'source_url' => 'git://github.com/travis-ci/travis-ci.git'
+    },
+    'build' => {
+      'id' => '1',
+      'number' => '1',
+      'previous_state' => 'failed'
+    },
+    'job' => {
+      'id' => '1',
+      'number' => '1.1',
+      'commit' => '313f61b',
+      'branch' => 'master',
+      'commit_range' => '313f61b..313f61a',
+      'commit_message' => 'the commit message',
+      'secure_env_enabled' => true,
+      'debug_options' => {
+        'stage'           => 'before_install',
+        'previous_state' => 'failed',
+        'created_by'      => 'svenfuchs',
+        'quiet'           => false
+      }
     }
   },
   worker_config: {


### PR DESCRIPTION
Using the `debug_options` field in the job (which is added by the API), we
initiate a debug session before going into `before_install`

Corresponds to https://github.com/travis-ci/travis-api/pull/230.