### PR TITLE
Crystal: Install gmp

### DIFF
--- a/lib/travis/build/script/crystal.rb
+++ b/lib/travis/build/script/crystal.rb
@@ -16,7 +16,7 @@ module Travis
 
             sh.cmd %Q(sudo sh -c 'echo "deb #{version[:url]} crystal main" > /etc/apt/sources.list.d/crystal-nightly.list')
             sh.cmd %q(sudo sh -c 'apt-get update')
-            sh.cmd %Q(sudo apt-get install #{version[:package]})
+            sh.cmd %Q(sudo apt-get install #{version[:package]} libgmp-dev)
 
             sh.echo 'Installing Shards', ansi: :yellow
 

--- a/spec/build/script/crystal_spec.rb
+++ b/spec/build/script/crystal_spec.rb
@@ -23,17 +23,17 @@ describe Travis::Build::Script::Crystal, :sexp do
 
   context "versions" do
     it "installs latest released version by default" do
-      should include_sexp [:cmd, "sudo apt-get install crystal"]
+      should include_sexp [:cmd, "sudo apt-get install crystal libgmp-dev"]
     end
 
     it "installs latest released version when explicitly asked for" do
       data[:config][:crystal] = "latest"
-      should include_sexp [:cmd, "sudo apt-get install crystal"]
+      should include_sexp [:cmd, "sudo apt-get install crystal libgmp-dev"]
     end
 
     it "installs nightly when specified" do
       data[:config][:crystal] = "nightly"
-      should include_sexp [:cmd, "sudo apt-get install crystal-nightly"]
+      should include_sexp [:cmd, "sudo apt-get install crystal-nightly libgmp-dev"]
     end
 
     it 'throws a error with a invalid version' do


### PR DESCRIPTION
So users don't have to in case they want to use the standard library
binding to it.

closes travis-ci/travis-ci#5392

/cc @asterite @waj @will