### PR TITLE
Update APT source for builds on GCE

### DIFF
--- a/lib/travis/build/appliances/update_glibc.rb
+++ b/lib/travis/build/appliances/update_glibc.rb
@@ -6,6 +6,7 @@ module Travis
       class UpdateGlibc < Base
         def apply
           sh.fold "fix.CVE-2015-7547" do
+            fix_gce_apt_src
             sh.export 'DEBIAN_FRONTEND', 'noninteractive'
             sh.cmd <<-EOF
 if [ ! $(uname|grep Darwin) ]; then
@@ -13,6 +14,12 @@ if [ ! $(uname|grep Darwin) ]; then
   sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install libc6
 fi
             EOF
+          end
+        end
+
+        def fix_gce_apt_src
+          sh.if "`hostname` == testing-gce-*" do
+            sh.cmd "sudo sed -i 's%us-central1.gce.archive.ubuntu.com/ubuntu%us.archive.ubuntu.com/ubuntu%' /etc/apt/sources.list"
           end
         end
       end


### PR DESCRIPTION
This addresses https://www.traviscistatus.com/incidents/pqjf4k106hf1.

Tested on staging: https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/492154