### PR TITLE
Revert "Update APT source for builds on GCE"

### DIFF
--- a/lib/travis/build/appliances/update_glibc.rb
+++ b/lib/travis/build/appliances/update_glibc.rb
@@ -6,7 +6,6 @@ module Travis
       class UpdateGlibc < Base
         def apply
           sh.fold "fix.CVE-2015-7547" do
-            fix_gce_apt_src
             sh.export 'DEBIAN_FRONTEND', 'noninteractive'
             sh.cmd <<-EOF
 if [ ! $(uname|grep Darwin) ]; then
@@ -14,12 +13,6 @@ if [ ! $(uname|grep Darwin) ]; then
   sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install libc6
 fi
             EOF
-          end
-        end
-
-        def fix_gce_apt_src
-          sh.if "`hostname` == testing-gce-*" do
-            sh.cmd "sudo sed -i 's%us-central1.gce.archive.ubuntu.com/ubuntu%us.archive.ubuntu.com/ubuntu%' /etc/apt/sources.list"
           end
         end
       end


### PR DESCRIPTION
Reverts travis-ci/travis-build#671

The GCE mirror issue has been resolved.