### PR TITLE
Overwrite global.gems

### DIFF
--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -112,7 +112,7 @@ module Travis
 
           def write_default_gems
             sh.mkdir '$rvm_path/gemsets', recursive: true, echo: false
-            sh.cmd 'test -f $rvm_path/gemsets/global.gems || echo -e "gem-wrappers\nrubygems-bundler\nbundler\nrake\nrvm\n" >> $rvm_path/gemsets/global.gems', echo: false, timing: false
+            sh.cmd 'echo -e "gem-wrappers\nrubygems-bundler\nbundler\nrake\nrvm\n" > $rvm_path/gemsets/global.gems', echo: false, timing: false
           end
       end
     end


### PR DESCRIPTION
Resolves https://github.com/travis-ci/travis-ci/issues/5698.

Looks like the Trusty image has `$rvm_path/gemsets/global.gems`, and we are not overwriting that file to ensure Bundler is available for Rubies installed on demand.

before: https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/492159
after: https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/492161