### PR TITLE
Update HHVM at runtime

### DIFF
--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -19,11 +19,13 @@ module Travis
 
         def setup
           super
-          sh.cmd "phpenv global #{version} 2>/dev/null", assert: false
-          sh.if "$? -ne 0" do
-            install_php_on_demand(version)
-            sh.cmd "phpenv global #{version}", assert: true
+          unless hhvm?
+            sh.cmd "phpenv global #{version} 2>/dev/null", assert: false
+            sh.if "$? -ne 0" do
+              install_php_on_demand(version)
+            end
           end
+          sh.cmd "phpenv global #{version}", assert: true
           sh.cmd "phpenv rehash", assert: false, echo: false, timing: false
         end
 
@@ -83,10 +85,16 @@ module Travis
         end
 
         def update_hhvm
-          sh.if '"$(lsb_release -sc 2>/dev/null)" = "precise"' do
-            sh.echo 'Updating HHVM', ansi: :yellow
-            sh.cmd 'sudo apt-get update -qq'
-            sh.cmd 'sudo apt-get install hhvm 2>&1 >/dev/null'
+          sh.if '"$(lsb_release -sc 2>/dev/null)"' do
+            sh.fold 'update.hhvm', ansi: :yellow do
+              sh.echo "Updating HHVM", ansi: :yellow
+              sh.if "! $(grep -r hhvm\\.com /etc/apt/sources* 2>/dev/null)" do
+                sh.cmd 'sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0x5a16e7281be7a449'
+                sh.cmd 'echo "deb http://dl.hhvm.com/ubuntu $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list'
+              end
+              sh.cmd 'sudo apt-get update -qq'
+              sh.cmd 'sudo apt-get install -y hhvm', timing: true
+            end
           end
         end
 
@@ -97,7 +105,7 @@ module Travis
           end
           sh.echo 'Installing HHVM nightly', ansi: :yellow
           sh.cmd 'sudo apt-get update -qq'
-          sh.cmd 'sudo apt-get install hhvm-nightly 2>&1 >/dev/null'
+          sh.cmd 'sudo apt-get install hhvm-nightly -y 2>&1 >/dev/null'
         end
 
         def fix_hhvm_php_ini

--- a/spec/build/script/php_spec.rb
+++ b/spec/build/script/php_spec.rb
@@ -56,7 +56,7 @@ describe Travis::Build::Script::Php, :sexp do
   describe 'installs hhvm-nightly' do
     before { data[:config][:php] = 'hhvm-nightly' }
     it { should include_sexp [:cmd, 'sudo apt-get update -qq'] }
-    it { should include_sexp [:cmd, 'sudo apt-get install hhvm-nightly 2>&1 >/dev/null'] }
+    it { should include_sexp [:cmd, 'sudo apt-get install hhvm-nightly -y 2>&1 >/dev/null'] }
   end
 
   describe 'when desired PHP version is not found' do


### PR DESCRIPTION
This PR reinstates https://github.com/travis-ci/travis-build/pull/571 and resolves https://github.com/travis-ci/travis-ci/issues/5328.

Tested: https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/492408

(Note that for Trusty, you'd need the Edge build image (see https://github.com/BanzaiMan/travis_staging_test/blob/161768976e04417ccd3fc8405f4e1eb83dcc48a4/.travis.yml#L6-L9), which results in https://staging.travis-ci.org/BanzaiMan/travis_staging_test/jobs/492410.