### PR TITLE
Fix travis compile with arguments

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -44,7 +44,7 @@ module Travis
           set_up_env(config, global_env)
         end
 
-        puts Travis::Build.script(push_down_deploy(config)).compile(true)
+        puts Travis::Build.script(push_down_deploy(@config)).compile(true)
       end
 
       private


### PR DESCRIPTION
We noticed that `travis compile N` and `travis compile M.N` (as described [here](https://github.com/travis-ci/travis-build/blob/master/README.md)) do not work.

```
// repository is HPI-BP2015H/test, but we also tried this with HPI-BP2015H/SWT-Demo
user@host:~/test$ travis compile 8
undefined method `delete' for nil:NilClass
for a full error report, run travis report
user@host:~/test$ travis report
System
Ruby:                     Ruby 1.9.3-p484
Operating System:         Ubuntu 14.04
RubyGems:                 RubyGems 1.8.23

CLI
Version:                  1.8.2
Plugins:                  "travis-build"
Auto-Completion:          yes
Last Version Check:       2016-03-31 15:25:01 +0200

Session
API Endpoint:             https://api.travis-ci.org/
Logged In:                no
Verify SSL:               yes
Enterprise:               no

Endpoints
org:                      https://api.travis-ci.org/ (current)

Last Exception
An error occurred running `travis compile`:
    NoMethodError: undefined method `delete' for nil:NilClass
        from /home/user/.travis/travis-build/init.rb:102:in `push_down_deploy'
        from /home/user/.travis/travis-build/init.rb:47:in `run'
        from /var/lib/gems/1.9.1/gems/travis-1.8.2/lib/travis/cli/command.rb:198:in `execute'
        from /var/lib/gems/1.9.1/gems/travis-1.8.2/lib/travis/cli.rb:64:in `run'
        from /var/lib/gems/1.9.1/gems/travis-1.8.2/bin/travis:18:in `<top (required)>'
        from /usr/local/bin/travis:23:in `load'
        from /usr/local/bin/travis:23:in `<main>'
```

Adding a `@` fixed the problem for us.