### PR TITLE
Allow specifying one or many packages to the install functions

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -265,6 +265,7 @@ module Travis
         end
 
         def packages_as_arg(packages)
+          packages = Array(packages)
           quoted_pkgs = packages.collect{|p| "\"#{p}\""}
           "c(#{quoted_pkgs.join(', ')})"
         end
@@ -275,6 +276,7 @@ module Travis
 
         def r_install(packages)
           return if packages.empty?
+          packages = Array(packages)
           sh.echo "Installing R packages: #{packages.join(', ')}"
           pkg_arg = packages_as_arg(packages)
           install_script =
@@ -287,6 +289,7 @@ module Travis
 
         def r_github_install(packages)
           return if packages.empty?
+          packages = Array(packages)
           setup_devtools
           sh.echo "Installing R packages from GitHub: #{packages.join(', ')}"
           pkg_arg = packages_as_arg(packages)
@@ -296,6 +299,7 @@ module Travis
 
         def r_binary_install(packages)
           return if packages.empty?
+          packages = Array(packages)
           if config[:os] == 'linux'
             unless config[:sudo]
               sh.echo "R binary packages not supported with 'sudo: false', "\
@@ -313,6 +317,7 @@ module Travis
 
         def apt_install(packages)
           return if packages.empty?
+          packages = Array(packages)
           return unless (config[:os] == 'linux')
           pkg_arg = packages.join(' ')
           sh.echo "Installing apt packages: #{packages.join(', ')}"
@@ -321,6 +326,7 @@ module Travis
 
         def brew_install(packages)
           return if packages.empty?
+          packages = Array(packages)
           return unless (config[:os] == 'osx')
           pkg_arg = packages.join(' ')
           sh.echo "Installing brew packages: #{packages.join(', ')}"

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -23,6 +23,18 @@ describe Travis::Build::Script::R, :sexp do
     should include_sexp [:export, ['TRAVIS_R_VERSION', '3.2.4']]
   end
 
+  it 'r_packages works with a single package set' do
+    data[:config][:r_packages] = 'test'
+    should include_sexp [:cmd, %r{install\.packages\(c\(\"test\"\)\)},
+                         assert: true, echo: true, timing: true]
+  end
+
+  it 'r_packages works with multiple packages set' do
+    data[:config][:r_packages] = ['test', 'test2']
+    should include_sexp [:cmd, %r{install\.packages\(c\(\"test\", \"test2\"\)\)},
+                         assert: true, echo: true, timing: true]
+  end
+
   it 'exports TRAVIS_R_VERSION' do
     data[:config][:R] = '3.2.4'
     should include_sexp [:export, ['TRAVIS_R_VERSION', '3.2.4']]


### PR DESCRIPTION
Currently if you give

```yaml
language: r
r_github_packages: jimhester/covr
```

Travis returns an error, e.g. (https://travis-ci.org/jimhester/travis-test/builds/120730087#L5) due to tryign to join on a string.

This PR first converts all the inputs to an Array so that the join succeeds. It also adds tests of both the string and array inputs to prevent a regression.