### PR TITLE
expose event_type as environment variable 

### DIFF
--- a/lib/travis/build/env/builtin.rb
+++ b/lib/travis/build/env/builtin.rb
@@ -23,6 +23,7 @@ module Travis
               CI:                     true,
               CONTINUOUS_INTEGRATION: true,
               HAS_JOSH_K_SEAL_OF_APPROVAL: true,
+              TRAVIS_EVENT_TYPE:      build[:event_type],
               TRAVIS_PULL_REQUEST:    pull_request || false,
               TRAVIS_SECURE_ENV_VARS: env.secure_env_vars? || false,
               TRAVIS_BUILD_ID:        build[:id],

--- a/spec/build/env_spec.rb
+++ b/spec/build/env_spec.rb
@@ -22,7 +22,7 @@ describe Travis::Build::Env do
 
   it 'includes travis env vars' do
     travis_vars = vars.select { |v| v.key =~ /^TRAVIS_/ }
-    expect(travis_vars.length).to eq(14)
+    expect(travis_vars.length).to eq(15)
   end
 
   describe 'config env vars' do


### PR DESCRIPTION
This is helpful to detect a cron job (see travis-ci/travis-api#225)

Unfortunately I do not know how this could be tested easily, maybe we could look into this next Friday?