### PR TITLE
allow easy using of other smalltalkCI versions

### DIFF
--- a/lib/travis/build/script/smalltalk.rb
+++ b/lib/travis/build/script/smalltalk.rb
@@ -60,7 +60,7 @@ module Travis
           sh.cmd "pushd $HOME > /dev/null", echo: false
           sh.fold 'download_smalltalkci' do
             sh.echo 'Downloading and extracting smalltalkCI', ansi: :yellow
-            sh.cmd "wget -q -O smalltalkCI.zip https://github.com/hpi-swa/smalltalkCI/archive/master.zip"
+            sh.cmd "wget -q -O smalltalkCI.zip https://github.com/" + smalltalk_ci_repo + "/archive/" + smalltalk_ci_branch + ".zip"
             sh.cmd "unzip -q -o smalltalkCI.zip"
             sh.cmd "pushd smalltalkCI-* > /dev/null", echo: false
             sh.cmd "source env_vars"
@@ -75,6 +75,22 @@ module Travis
         end
 
         private
+
+          def smalltalk_ci_repo
+            if config.key?(:smalltalk_edge) and config[:smalltalk_edge].key?(:source)
+              return config[:smalltalk_edge][:source]
+            else
+              return "hpi-swa/smalltalkCI"
+            end
+          end
+
+          def smalltalk_ci_branch
+            if config.key?(:smalltalk_edge) and config[:smalltalk_edge].key?(:branch)
+              return config[:smalltalk_edge][:branch]
+            else
+              return "master"
+            end
+          end
 
           def smalltalk_version
             config[:smalltalk].to_s

--- a/lib/travis/build/script/smalltalk.rb
+++ b/lib/travis/build/script/smalltalk.rb
@@ -77,19 +77,11 @@ module Travis
         private
 
           def smalltalk_ci_repo
-            if config.key?(:smalltalk_edge) and config[:smalltalk_edge].key?(:source)
-              return config[:smalltalk_edge][:source]
-            else
-              return "hpi-swa/smalltalkCI"
-            end
+            config.fetch(:smalltalk_edge, {}).fetch(:source, "hpi-swa/smalltalkCI")
           end
 
           def smalltalk_ci_branch
-            if config.key?(:smalltalk_edge) and config[:smalltalk_edge].key?(:branch)
-              return config[:smalltalk_edge][:branch]
-            else
-              return "master"
-            end
+            config.fetch(:smalltalk_edge, {}).fetch(:branch, "master")
           end
 
           def smalltalk_version

--- a/spec/build/script/smalltalk_spec.rb
+++ b/spec/build/script/smalltalk_spec.rb
@@ -22,7 +22,7 @@ describe Travis::Build::Script::Smalltalk, :sexp do
 
   describe 'using edge versions' do
     before do
-      data[:config][:smalltalk_edge] = Hash.new
+      data[:config][:smalltalk_edge] = {}
       data[:config][:smalltalk_edge][:source] = 'HPI-BP2015H/smalltalkCI'
       data[:config][:smalltalk_edge][:branch] = 'dev'
     end

--- a/spec/build/script/smalltalk_spec.rb
+++ b/spec/build/script/smalltalk_spec.rb
@@ -20,6 +20,17 @@ describe Travis::Build::Script::Smalltalk, :sexp do
     should include_sexp [:cmd, "popd > /dev/null; popd > /dev/null", assert: true, timing: true]
   end
 
+  describe 'using edge versions' do
+    before do
+      data[:config][:smalltalk_edge] = Hash.new
+      data[:config][:smalltalk_edge][:source] = 'HPI-BP2015H/smalltalkCI'
+      data[:config][:smalltalk_edge][:branch] = 'dev'
+    end
+    it 'installs the correct script' do
+      should include_sexp [:cmd, "wget -q -O smalltalkCI.zip https://github.com/HPI-BP2015H/smalltalkCI/archive/dev.zip", assert: true, echo: true, timing: true]
+    end
+  end
+
   describe 'Squeak on Linux' do
     before do
       data[:config][:smalltalk] = 'Squeak-5.0'


### PR DESCRIPTION
This adds easy to use support for testing against edge versions of smalltalkCI. It uses the same format as the [travis dpl](https://github.com/travis-ci/dpl/blob/master/TESTING.md):
```yaml
smalltalk_edge:
  source: HPI-BP2015H/smalltalkCI
  branch: dev
```
/cc @fniephaus 
fix hpi-swa/smalltalkCI#124