### PR TITLE
Adapt sbt-extras for older versions of sbt

### DIFF
--- a/lib/travis/build/script/scala.rb
+++ b/lib/travis/build/script/scala.rb
@@ -18,7 +18,8 @@ module Travis
           super
           if use_sbt?
             sh.echo "Updating sbt", ansi: :green
-            sh.cmd "sudo curl -sS -o #{SBT_PATH} #{SBT_URL}"
+            sh.cmd "sudo curl -sS -o sbt.tmp #{SBT_URL}"
+            sh.raw "sed -e '/addSbt \\(warn\\|info\\)/d' sbt.tmp | sudo tee #{SBT_PATH} > /dev/null && rm -f sbt.tmp"
           end
         end
 

--- a/spec/build/script/scala_spec.rb
+++ b/spec/build/script/scala_spec.rb
@@ -33,7 +33,7 @@ describe Travis::Build::Script::Scala, :sexp do
     let(:sexp) { sexp_find(subject, [:if, '-d project || -f build.sbt']) }
 
     it "updates SBT" do
-      should include_sexp [:cmd, "sudo curl -sS -o #{sbt_path} #{sbt_url}"]
+      should include_sexp [:cmd, "sudo curl -sS -o sbt.tmp #{sbt_url}"]
     end
 
     it 'sets JVM_OPTS' do


### PR DESCRIPTION
Since 'addSbt warn' and 'addSbt info' are not defined in older
versions of sbt, we remove them.

See https://github.com/paulp/sbt-extras/issues/99