### PR TITLE
Adds BrowserStack addon

### DIFF
--- a/lib/travis/build/addons.rb
+++ b/lib/travis/build/addons.rb
@@ -13,6 +13,7 @@ require 'travis/build/addons/postgresql'
 require 'travis/build/addons/sauce_connect'
 require 'travis/build/addons/ssh_known_hosts'
 require 'travis/build/addons/sonarqube'
+require 'travis/build/addons/browserstack'
 
 module Travis
   module Build

--- a/lib/travis/build/addons/browserstack.rb
+++ b/lib/travis/build/addons/browserstack.rb
@@ -1,0 +1,166 @@
+require 'travis/build/addons/base'
+
+module Travis
+  module Build
+    class Addons
+      class Browserstack < Base
+        # mark safe for use on containers
+        SUPER_USER_SAFE = true
+        BROWSERSTACK_HOME = '$HOME/.browserstack'
+        BROWSERSTACK_BIN_FILE = 'BrowserStackLocal'
+        BROWSERSTACK_BIN_URL = 'https://www.browserstack.com/browserstack-local'
+        ENV_USER = 'BROWSERSTACK_USER'
+        ENV_KEY = 'BROWSERSTACK_ACCESS_KEY'
+        ENV_LOCAL = 'BROWSERSTACK_LOCAL'
+        ENV_LOCAL_IDENTIFIER = 'BROWSERSTACK_LOCAL_IDENTIFIER'
+
+        def before_before_script
+          browserstack_key = access_key.to_s
+          sh.fold "browserstack.install" do
+            if browserstack_key.empty?
+              sh.echo "access_key is invalid.", ansi: :red
+              return
+            end
+
+            sh.echo "Installing BrowserStack Local", ansi: :yellow
+            case data[:config][:os]
+            when 'linux'
+              bin_package = "#{BROWSERSTACK_BIN_FILE}-linux-x64.zip"
+            when 'osx'
+              bin_package = "#{BROWSERSTACK_BIN_FILE}-darwin-x64.zip"
+            else
+              sh.echo "Unsupported platform: $TRAVIS_OS_NAME.", ansi: :yellow
+              return
+            end
+
+            bin_url = "#{BROWSERSTACK_BIN_URL}/#{bin_package}"
+            sh.cmd "mkdir -p #{BROWSERSTACK_HOME}"
+            sh.cmd "wget -O /tmp/#{bin_package} #{bin_url}", echo: true, timing: true, retry: true
+            sh.cmd "unzip -d #{BROWSERSTACK_HOME}/ /tmp/#{bin_package} 2>&1 > /dev/null", echo: false
+            sh.chmod "+x", "#{BROWSERSTACK_HOME}/#{BROWSERSTACK_BIN_FILE}", echo: false
+          end
+
+          sh.fold 'browserstack.start' do
+            sh.echo 'Starting BrowserStack Local', ansi: :yellow
+            sh.cmd "#{build_start_command(browserstack_key)}"
+            browserstack_user = username.to_s
+            sh.export ENV_USER, browserstack_user, echo: true unless browserstack_user.empty?
+            sh.export ENV_KEY, browserstack_key, echo: false
+            sh.export ENV_LOCAL, 'true', echo: true
+          end
+        end
+
+        def after_after_script
+          sh.if "-f #{BROWSERSTACK_HOME}/#{BROWSERSTACK_BIN_FILE}" do
+            sh.fold 'browserstack.stop' do
+              sh.echo 'Stopping BrowserStack Local', ansi: :yellow
+              sh.cmd "#{build_stop_command}"
+            end
+          end
+        end
+
+        def build_start_command(access_key)
+          args = []
+          options = {
+            :localIdentifier => method(:local_identifier),
+            :v => method(:verbose),
+            :f => method(:folder),
+            :force => method(:force),
+            :only => method(:only),
+            :forcelocal => method(:force_local),
+            :onlyAutomate => method(:only_automate),
+            :proxyHost => method(:proxy_host),
+            :proxyPort => method(:proxy_port),
+            :proxyUser => method(:proxy_user),
+            :proxyPass => method(:proxy_pass)
+          }
+
+          options.each do |arg, fn|
+            v = fn.call
+            if !v.nil?
+              if (!!v == v)
+                args.push("-#{arg}") if v
+              else
+                args.push("-#{arg}")
+                args.push(v)
+              end
+            end
+          end
+
+          local_args = args.empty? ? "" : " #{args.join(' ')}"
+          "#{BROWSERSTACK_HOME}/#{BROWSERSTACK_BIN_FILE} -d start #{access_key}#{local_args}" if !access_key.nil?
+        end
+
+        def build_stop_command
+          "#{BROWSERSTACK_HOME}/#{BROWSERSTACK_BIN_FILE} -d stop"
+        end
+
+        private
+          def username
+            config[:username]
+          end
+
+          def access_key
+            key = config[:access_key] || config[:accessKey]
+            key if key.to_s =~ /^[a-zA-Z0-9]+$/
+          end
+
+          def verbose
+            verbose = config[:verbose] || config[:v]
+            (verbose.to_s == 'true')
+          end
+
+          def force
+            force = config[:force]
+            (force.to_s == 'true')
+          end
+
+          def only
+            config[:only]
+          end
+
+          def local_identifier
+            local_id = (config[:local_identifier] || config[:localIdentifier]).to_s
+            unless local_id.empty?
+              sh.export ENV_LOCAL_IDENTIFIER, local_id, echo: true
+              local_id
+            else
+              sh.export ENV_LOCAL_IDENTIFIER, "travis-${TRAVIS_BUILD_NUMBER}-${TRAVIS_JOB_NUMBER}", echo: true
+              "$#{ENV_LOCAL_IDENTIFIER}"
+            end
+          end
+
+          def folder
+            config[:folder] || config[:f]
+          end
+
+          def force_local
+            force_local = config[:force_local] || config[:forcelocal]
+            (force_local.to_s == 'true')
+          end
+
+          def only_automate
+            only_automate = config[:only_automate] || config[:onlyAutomate]
+            (only_automate.to_s == 'true')
+          end
+
+          def proxy_host
+            config[:proxy_host] || config[:proxyHost]
+          end
+
+          def proxy_port
+            config[:proxy_port] || config[:proxyPort]
+          end
+
+          def proxy_user
+            config[:proxy_user] || config[:proxyUser]
+          end
+
+          def proxy_pass
+            config[:proxy_pass] || config[:proxyPass]
+          end
+        end
+
+    end
+  end
+end

--- a/spec/build/addons/browserstack_spec.rb
+++ b/spec/build/addons/browserstack_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+describe Travis::Build::Addons::Browserstack, :sexp do
+  let(:script) { stub('script') }
+  let(:config) { { access_key: 'accesskey' } }
+  let(:data)   { payload_for(:push, :ruby, config: { addons: { browserstack: config } }) }
+  let(:sh)     { Travis::Shell::Builder.new }
+  let(:addon)  { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
+  subject      { sh.to_sexp }
+  before       { addon.before_before_script }
+
+  shared_examples_for 'installs browserstack local' do
+    zip_package = "#{described_class::BROWSERSTACK_BIN_FILE}-linux-x64.zip"
+    it { should include_sexp [:echo, "Installing BrowserStack Local", ansi: :yellow] }
+    it { should include_sexp [:cmd, "mkdir -p #{described_class::BROWSERSTACK_HOME}"] }
+    it { should include_sexp [:cmd, "wget -O /tmp/#{zip_package} #{described_class::BROWSERSTACK_BIN_URL}/#{zip_package}", echo: true, timing: true, retry: true] }
+    it { should include_sexp [:cmd, "unzip -d #{described_class::BROWSERSTACK_HOME}/ /tmp/#{zip_package} 2>&1 > /dev/null"] }
+    it { should include_sexp [:chmod, ["+x", "#{described_class::BROWSERSTACK_HOME}/BrowserStackLocal"]] }
+
+    it 'sets BROWSERSTACK_ACCESS_KEY and BROWSERSTACK_LOCAL' do
+      should include_sexp [:export, ["#{described_class::ENV_KEY}", config[:access_key]]]
+      should include_sexp [:export, ["#{described_class::ENV_LOCAL}", 'true'], {:echo => true}]
+    end
+  end
+
+  describe 'without access_key' do
+    let(:config) { {} }
+
+    it { should include_sexp [:echo, "access_key is invalid.", ansi: :red] }
+  end
+
+  describe 'with access_key' do
+    let(:config) { { os: 'linux', access_key: 'accesskey' } }
+
+    it_behaves_like 'installs browserstack local'
+    it { should include_sexp [:cmd, "#{described_class::BROWSERSTACK_HOME}/BrowserStackLocal -d start #{config[:access_key]} -localIdentifier $BROWSERSTACK_LOCAL_IDENTIFIER"] }
+  end
+
+  describe 'with username and access_key' do
+    let(:config) { { os: 'linux', username: 'user1', access_key: 'accesskey' } }
+
+    it_behaves_like 'installs browserstack local'
+    it { should include_sexp [:export, ["#{described_class::ENV_USER}", config[:username]], {:echo => true}] }
+    it { should include_sexp [:cmd, "#{described_class::BROWSERSTACK_HOME}/BrowserStackLocal -d start #{config[:access_key]} -localIdentifier $BROWSERSTACK_LOCAL_IDENTIFIER"] }
+  end
+
+  describe 'with access_key and folder path' do
+    let(:config) { { os: 'linux', access_key: 'accesskey', folder: 'path/to/user/folder' } }
+
+    it_behaves_like 'installs browserstack local'
+    it { should include_sexp [:cmd, "#{described_class::BROWSERSTACK_HOME}/BrowserStackLocal -d start #{config[:access_key]} -localIdentifier $BROWSERSTACK_LOCAL_IDENTIFIER -f #{config[:folder]}"] }
+  end
+
+  describe 'with access_key and force_local' do
+    let(:config) { { os: 'linux', access_key: 'accesskey', force_local: true } }
+
+    it_behaves_like 'installs browserstack local'
+    it { should include_sexp [:cmd, "#{described_class::BROWSERSTACK_HOME}/BrowserStackLocal -d start #{config[:access_key]} -localIdentifier $BROWSERSTACK_LOCAL_IDENTIFIER -forcelocal"] }
+  end
+
+  describe 'with access_key and local_identifier' do
+    let(:config) { { os: 'linux', access_key: 'accesskey', local_identifier: '123' } }
+
+    it_behaves_like 'installs browserstack local'
+    it { should include_sexp [:export, ["#{described_class::ENV_LOCAL_IDENTIFIER}", config[:local_identifier]], {:echo=>true}] }
+    it { should include_sexp [:cmd, "#{described_class::BROWSERSTACK_HOME}/BrowserStackLocal -d start #{config[:access_key]} -localIdentifier #{config[:local_identifier]}"] }
+  end
+
+  describe 'with access_key and proxy settings' do
+    let(:config) { { os: 'linux', access_key: 'accesskey', proxy_host: 'localhost', proxy_port: 1234 } }
+
+    it_behaves_like 'installs browserstack local'
+    it { should include_sexp [:cmd, "#{described_class::BROWSERSTACK_HOME}/BrowserStackLocal -d start #{config[:access_key]} -localIdentifier $BROWSERSTACK_LOCAL_IDENTIFIER -proxyHost #{config[:proxy_host]} -proxyPort #{config[:proxy_port]}"] }
+  end
+
+  describe 'with access_key and proxy settings with credentials' do
+    let(:config) { { os: 'linux', access_key: 'accesskey', proxy_host: 'localhost', proxy_port: 1234, proxy_user: 'user', proxy_pass: 'pass' } }
+
+    it_behaves_like 'installs browserstack local'
+    it { should include_sexp [:cmd, "#{described_class::BROWSERSTACK_HOME}/BrowserStackLocal -d start #{config[:access_key]} -localIdentifier $BROWSERSTACK_LOCAL_IDENTIFIER -proxyHost #{config[:proxy_host]} -proxyPort #{config[:proxy_port]} -proxyUser #{config[:proxy_user]} -proxyPass #{config[:proxy_pass]}"] }
+  end
+end


### PR DESCRIPTION
This PR adds support for creating a local testing tunnel from the Travis container to BrowserStack's servers.
````
  browserstack:
    access_key:
      secure: [secure]
    force_local: true
    local_identifier: 123
    only: localhost,8080,0
    ...
````

I'd be happy to answer questions around the features provided or fix any issues in this PR.

For more information on Local Testing with [BrowserStack](https://www.browserstack.com), please [refer to the documentation](https://www.browserstack.com/local-testing).