### PR TITLE
Ignore .tbz caches

### DIFF
--- a/lib/travis/build/script/shared/directory_cache/base.rb
+++ b/lib/travis/build/script/shared/directory_cache/base.rb
@@ -120,15 +120,12 @@ module Travis
 
           def fetch_urls
             urls = [
-              fetch_url(group, '.tgz'),
               fetch_url
             ]
             if data.pull_request
-              urls << fetch_url(data.branch, '.tgz')
               urls << fetch_url(data.branch)
             end
             if data.branch != 'master'
-              urls << fetch_url('master', '.tgz')
               urls << fetch_url('master')
             end
 
@@ -139,12 +136,12 @@ module Travis
             run('push', Shellwords.escape(push_url.to_s), assert: false, timing: true)
           end
 
-          def fetch_url(branch = group, ext = '.tbz')
-            url('GET', prefixed(branch, ext), expires: fetch_timeout)
+          def fetch_url(branch = group)
+            url('GET', prefixed(branch), expires: fetch_timeout)
           end
 
           def push_url(branch = group)
-            url('PUT', prefixed(branch, '.tgz'), expires: push_timeout)
+            url('PUT', prefixed(branch), expires: push_timeout)
           end
 
           def fold(message = nil)
@@ -202,10 +199,10 @@ module Travis
               )
             end
 
-            def prefixed(branch, ext = '.tgz')
+            def prefixed(branch)
               args = [data.github_id, branch, slug].compact
               args.map! { |arg| arg.to_s.gsub(/[^\w\.\_\-]+/, '') }
-              '/' << args.join('/') << ext
+              ('/' << args.join('/') << '.tgz')
             end
 
             def url(verb, path, options = {})

--- a/lib/travis/build/script/shared/directory_cache/base.rb
+++ b/lib/travis/build/script/shared/directory_cache/base.rb
@@ -202,7 +202,7 @@ module Travis
             def prefixed(branch)
               args = [data.github_id, branch, slug].compact
               args.map! { |arg| arg.to_s.gsub(/[^\w\.\_\-]+/, '') }
-              ('/' << args.join('/') << '.tgz')
+              '/' << args.join('/') << '.tgz'
             end
 
             def url(verb, path, options = {})

--- a/spec/build/script/directory_cache/gcs_spec.rb
+++ b/spec/build/script/directory_cache/gcs_spec.rb
@@ -20,9 +20,7 @@ describe Travis::Build::Script::DirectoryCache::Gcs, :sexp do
 
   let(:test_time)     { 10 }
   let(:timeout)       { cache_options[:push_timeout] + test_time }
-  let(:url)           { signed_url_for(branch, fetch_signature) }
   let(:url_tgz)       { signed_url_for(branch, fetch_signature_tgz, 'tgz') }
-  let(:fetch_url)     { url }
   let(:fetch_url_tgz) { url_tgz }
   let(:push_url)      { signed_url_for(branch, push_signature, 'tgz', timeout) }
 
@@ -92,7 +90,7 @@ describe Travis::Build::Script::DirectoryCache::Gcs, :sexp do
   describe 'fetch' do
     let(:timeout) { cache_options[:fetch_timeout] }
     before { cache.fetch }
-    it { should include_sexp [:cmd, "rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher fetch #{url_tgz} #{url}", timing: true] }
+    it { should include_sexp [:cmd, "rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher fetch #{url_tgz}", timing: true] }
   end
 
   describe 'add' do
@@ -126,12 +124,11 @@ describe Travis::Build::Script::DirectoryCache::Gcs, :sexp do
     let(:fetch_signature) { 'RCp7Cd2IKLRCvEC%2F1sZRVBUBKx8%3D' }
     let(:fetch_signature_tgz) { 'GWX9Uh4HiQ9UDasvRB9pqRoq%2FI4%3D' }
     let(:push_signature)  { 'PHCIJ5h7qNkwVF9FceW%2F52ds%2Fw0%3D' }
-    let(:fallback_url)    { signed_url_for('master', master_fetch_signature) }
     let(:fallback_url_tgz)    { signed_url_for('master', master_fetch_signature_tgz, 'tgz') }
 
     describe 'fetch' do
       before { cache.fetch }
-      it { should include_sexp [:cmd, "rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher fetch #{fetch_url_tgz} #{fetch_url} #{fallback_url_tgz} #{fallback_url}", timing: true] }
+      it { should include_sexp [:cmd, "rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher fetch #{fetch_url_tgz} #{fallback_url_tgz}", timing: true] }
     end
 
     describe 'add' do
@@ -150,15 +147,13 @@ describe Travis::Build::Script::DirectoryCache::Gcs, :sexp do
     let(:fetch_signature) { '4xhck0G2%2BSCjz%2BGFkpEA1pj27I8%3D' }
     let(:fetch_signature_tgz) { 'N0qlG8k9ihBVE9uGemKdvVVuHLA%3D' }
     let(:push_signature)  { 'gF%2Ba%2Fu559%2B97Sxy3UzGBgjThAgo%3D' }
-    let(:url)             { signed_url_for("PR.#{pull_request}", fetch_signature) }
     let(:url_tgz)         { signed_url_for("PR.#{pull_request}", fetch_signature_tgz, 'tgz') }
     let(:push_url)        { signed_url_for("PR.#{pull_request}", push_signature, 'tgz', timeout) }
-    let(:fallback_url)    { signed_url_for('master', master_fetch_signature) }
     let(:fallback_url_tgz)    { signed_url_for('master', master_fetch_signature_tgz, 'tgz') }
 
     describe 'fetch' do
       before { cache.fetch }
-      it { should include_sexp [:cmd, "rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher fetch #{fetch_url_tgz} #{fetch_url} #{fallback_url_tgz} #{fallback_url}", timing: true] }
+      it { should include_sexp [:cmd, "rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher fetch #{fetch_url_tgz} #{fallback_url_tgz}", timing: true] }
     end
 
     describe 'add' do
@@ -178,17 +173,14 @@ describe Travis::Build::Script::DirectoryCache::Gcs, :sexp do
     let(:fetch_signature) { '4xhck0G2%2BSCjz%2BGFkpEA1pj27I8%3D' }
     let(:fetch_signature_tgz) { 'N0qlG8k9ihBVE9uGemKdvVVuHLA%3D' }
     let(:push_signature)  { 'gF%2Ba%2Fu559%2B97Sxy3UzGBgjThAgo%3D' }
-    let(:url)             { signed_url_for("PR.#{pull_request}", fetch_signature) }
     let(:url_tgz)         { signed_url_for("PR.#{pull_request}", fetch_signature_tgz, 'tgz') }
     let(:push_url)        { signed_url_for("PR.#{pull_request}", push_signature, 'tgz', timeout) }
-    let(:fallback_url)    { signed_url_for('master', master_fetch_signature) }
     let(:fallback_url_tgz)    { signed_url_for('master', master_fetch_signature_tgz, 'tgz') }
-    let(:branch_fallback_url) { signed_url_for('foo', 'PSZ0uPS7zxkpliqPQReRfRW%2BJEk%3D') }
     let(:branch_fallback_url_tgz) { signed_url_for('foo', 'aEutjpVj13QxPYd7VRO%2BDdhr3cg%3D', 'tgz') }
 
     describe 'fetch' do
       before { cache.fetch }
-      it { should include_sexp [:cmd, "rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher fetch #{fetch_url_tgz} #{fetch_url} #{branch_fallback_url_tgz} #{branch_fallback_url} #{fallback_url_tgz} #{fallback_url}", timing: true] }
+      it { should include_sexp [:cmd, "rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher fetch #{fetch_url_tgz} #{branch_fallback_url_tgz} #{fallback_url_tgz}", timing: true] }
     end
 
     describe 'add' do

--- a/spec/build/script/directory_cache/s3_spec.rb
+++ b/spec/build/script/directory_cache/s3_spec.rb
@@ -20,7 +20,6 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
 
   let(:url)           { url_for(branch) }
   let(:url_tgz)       { url_for(branch, 'tgz') }
-  let(:fetch_url)     { Shellwords.escape "#{url}&X-Amz-Expires=20&X-Amz-Signature=#{fetch_signature}&X-Amz-SignedHeaders=host" }
   let(:fetch_url_tgz) { Shellwords.escape "#{url_tgz}&X-Amz-Expires=20&X-Amz-Signature=#{fetch_signature_tgz}&X-Amz-SignedHeaders=host" }
   let(:push_url)      { Shellwords.escape("#{url}&X-Amz-Expires=30&X-Amz-Signature=#{push_signature}&X-Amz-SignedHeaders=host").gsub(/\.tbz(\?)?/, '.tgz\1') }
 
@@ -82,7 +81,7 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
 
   describe 'fetch' do
     before { cache.fetch }
-    it { should include_sexp [:cmd, "rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher fetch #{fetch_url_tgz} #{fetch_url}", timing: true] }
+    it { should include_sexp [:cmd, "rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher fetch #{fetch_url_tgz}", timing: true] }
   end
 
   describe 'add' do
@@ -115,12 +114,11 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
     let(:fetch_signature) { 'cbce59b97e29ba90e1810a9cbedc1d5cd76df8235064c0016a53dea232124d60' }
     let(:fetch_signature_tgz) { 'f0842c7f68c3b518502a336c5e55cfa368c90f72a06e2b58889cfd844380310b' }
     let(:push_signature)  { '3642ae12b63114366d42c964e221b7e9dcf736286a6fde1fd93be3fa21acb324' }
-    let(:fallback_url)    { signed_url_for('master', master_fetch_signature) }
     let(:fallback_url_tgz)    { signed_url_for('master', master_fetch_signature_tgz, 'tgz') }
 
     describe 'fetch' do
       before { cache.fetch }
-      it { should include_sexp [:cmd, "rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher fetch #{fetch_url_tgz} #{fetch_url} #{fallback_url_tgz} #{fallback_url}", timing: true] }
+      it { should include_sexp [:cmd, "rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher fetch #{fetch_url_tgz} #{fallback_url_tgz}", timing: true] }
     end
 
     describe 'add' do
@@ -141,12 +139,11 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
     let(:push_signature)  { '4aa0c287dca37b5c7f9d14e84be0680c4151c8230b2d0c6e8299d031d4bebd29' }
     let(:url)             { url_for("PR.#{pull_request}") }
     let(:url_tgz)         { url_for("PR.#{pull_request}", 'tgz') }
-    let(:fallback_url)    { signed_url_for('master', master_fetch_signature) }
     let(:fallback_url_tgz)    { signed_url_for('master', master_fetch_signature_tgz, 'tgz') }
 
     describe 'fetch' do
       before { cache.fetch }
-      it { should include_sexp [:cmd, "rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher fetch #{fetch_url_tgz} #{fetch_url} #{fallback_url_tgz} #{fallback_url}", timing: true] }
+      it { should include_sexp [:cmd, "rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher fetch #{fetch_url_tgz} #{fallback_url_tgz}", timing: true] }
     end
 
     describe 'add' do
@@ -168,14 +165,12 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
     let(:push_signature)  { '4aa0c287dca37b5c7f9d14e84be0680c4151c8230b2d0c6e8299d031d4bebd29' }
     let(:url)             { url_for("PR.#{pull_request}") }
     let(:url_tgz)         { url_for("PR.#{pull_request}", 'tgz') }
-    let(:fallback_url)    { signed_url_for('master', master_fetch_signature) }
     let(:fallback_url_tgz)    { signed_url_for('master', master_fetch_signature_tgz, 'tgz') }
-    let(:branch_fallback_url) { signed_url_for('foo', 'd72269ea040415d06cea7382c25f211f05b5a701c68299c03bbecd861a5e820b') }
     let(:branch_fallback_url_tgz) { signed_url_for('foo', 'e25b5a05709b557e35140cba079b597faae02da0733d7c18e848ce91140a5331', 'tgz') }
 
     describe 'fetch' do
       before { cache.fetch }
-      it { should include_sexp [:cmd, "rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher fetch #{fetch_url_tgz} #{fetch_url} #{branch_fallback_url_tgz} #{branch_fallback_url} #{fallback_url_tgz} #{fallback_url}", timing: true] }
+      it { should include_sexp [:cmd, "rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher fetch #{fetch_url_tgz} #{branch_fallback_url_tgz} #{fallback_url_tgz}", timing: true] }
     end
 
     describe 'add' do


### PR DESCRIPTION
It has been a while since we switched to .tgz; .tbz caches are no
longer in use, so it is safe to cease looking for them.