### PR TITLE
Take config's OS, Dist, OS X image name, known Env var values into cache slug computation

### DIFF
--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -85,6 +85,7 @@ module Travis
           'cache',
           config[:os],
           config[:dist],
+          config[:osx_image],
           OpenSSL::Digest::SHA256.hexdigest(plain_env_vars.sort.join('='))
         ]
       end

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -78,7 +78,7 @@ module Travis
       end
 
       def cache_slug_keys
-        plain_env_vars = Array(config[:env]).delete_if {|env| env.start_with? 'SECURE '}
+        plain_env_vars = Array(config[:env].dup).delete_if {|env| env.start_with? 'SECURE '}
 
         [
           'cache',

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -78,7 +78,7 @@ module Travis
       end
 
       def cache_slug_keys
-        plain_env_vars = Array(config[:env].dup).delete_if {|env| env.start_with? 'SECURE '}
+        plain_env_vars = Array((config[:env] || []).dup).delete_if {|env| env.start_with? 'SECURE '}
 
         [
           'cache',

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -3,7 +3,6 @@ require 'core_ext/hash/deep_symbolize_keys'
 require 'core_ext/object/false'
 require 'erb'
 require 'rbconfig'
-require 'base64'
 
 require 'travis/build/addons'
 require 'travis/build/appliances'

--- a/lib/travis/build/script/shared/directory_cache/base.rb
+++ b/lib/travis/build/script/shared/directory_cache/base.rb
@@ -210,7 +210,7 @@ module Travis
             def prefixed(branch, extras = false)
               slug_local = slug.dup
               if ! extras
-                slug_local = slug.gsub(/^cache(.*)--/,'cache--')
+                slug_local = slug.gsub(/^cache(.+?)(?=--)/,'cache')
               end
               args = [data.github_id, branch, slug_local].compact
               args.map! { |arg| arg.to_s.gsub(/[^\w\.\_\-]+/, '') }

--- a/lib/travis/build/script/shared/directory_cache/base.rb
+++ b/lib/travis/build/script/shared/directory_cache/base.rb
@@ -203,10 +203,11 @@ module Travis
             end
 
             def prefixed(branch, extras = false)
+              slug_local = slug.dup
               if ! extras
-                slug.gsub!(/^cache(.*)--/,'cache--')
+                slug_local = slug.gsub(/^cache(.*)--/,'cache--')
               end
-              args = [data.github_id, branch, slug].compact
+              args = [data.github_id, branch, slug_local].compact
               args.map! { |arg| arg.to_s.gsub(/[^\w\.\_\-]+/, '') }
               '/' << args.join('/') << '.tgz'
             end

--- a/lib/travis/build/script/shared/directory_cache/base.rb
+++ b/lib/travis/build/script/shared/directory_cache/base.rb
@@ -120,24 +120,27 @@ module Travis
 
           def fetch_urls
             urls = [
+              fetch_url(group, true),
               fetch_url
             ]
             if data.pull_request
+              urls << fetch_url(data.branch, true)
               urls << fetch_url(data.branch)
             end
             if data.branch != 'master'
+              urls << fetch_url('master', true)
               urls << fetch_url('master')
             end
 
-            urls
+            urls.uniq
           end
 
           def push
             run('push', Shellwords.escape(push_url.to_s), assert: false, timing: true)
           end
 
-          def fetch_url(branch = group)
-            url('GET', prefixed(branch), expires: fetch_timeout)
+          def fetch_url(branch = group, extras = false)
+            url('GET', prefixed(branch, extras), expires: fetch_timeout)
           end
 
           def push_url(branch = group)
@@ -199,7 +202,10 @@ module Travis
               )
             end
 
-            def prefixed(branch)
+            def prefixed(branch, extras = false)
+              if ! extras
+                slug.gsub!(/^cache(.*)--/,'cache--')
+              end
               args = [data.github_id, branch, slug].compact
               args.map! { |arg| arg.to_s.gsub(/[^\w\.\_\-]+/, '') }
               ('/' << args.join('/') << '.tgz')

--- a/lib/travis/build/script/shared/directory_cache/base.rb
+++ b/lib/travis/build/script/shared/directory_cache/base.rb
@@ -144,7 +144,7 @@ module Travis
           end
 
           def push_url(branch = group)
-            url('PUT', prefixed(branch), expires: push_timeout)
+            url('PUT', prefixed(branch, true), expires: push_timeout)
           end
 
           def fold(message = nil)

--- a/spec/build/script/c_spec.rb
+++ b/spec/build/script/c_spec.rb
@@ -27,7 +27,7 @@ describe Travis::Build::Script::C, :sexp do
 
   describe '#cache_slug' do
     subject { described_class.new(data).cache_slug }
-    it { should eq('cache--compiler-gcc') }
+    it { should eq("cache-#{CACHE_SLUG_EXTRAS}--compiler-gcc") }
   end
 
   context 'when cache requires ccache' do

--- a/spec/build/script/clojure_spec.rb
+++ b/spec/build/script/clojure_spec.rb
@@ -51,7 +51,7 @@ describe Travis::Build::Script::Clojure, :sexp do
 
   describe '#cache_slug' do
     subject { described_class.new(data).cache_slug }
-    it { is_expected.to eq('cache--jdk-default--lein-lein') }
+    it { is_expected.to eq("cache-#{CACHE_SLUG_EXTRAS}--jdk-default--lein-lein") }
   end
 end
 

--- a/spec/build/script/cpp_spec.rb
+++ b/spec/build/script/cpp_spec.rb
@@ -94,6 +94,6 @@ describe Travis::Build::Script::Cpp, :sexp do
 
   describe '#cache_slug' do
     subject { described_class.new(data).cache_slug }
-    it { is_expected.to eq('cache--compiler-gpp') }
+    it { is_expected.to eq("cache-#{CACHE_SLUG_EXTRAS}--compiler-gpp") }
   end
 end

--- a/spec/build/script/directory_cache_spec.rb
+++ b/spec/build/script/directory_cache_spec.rb
@@ -76,4 +76,34 @@ describe Travis::Build::Script::DirectoryCache, :sexp do
       it { expect(sexp).to include_sexp [:cmd, 'rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher add foo/foo/bar', timing: true] }
     end
   end
+
+  describe '#fetch_url' do
+    context 'Given "cache: bundler"' do
+      let(:config) { { cache: 'bundler' } }
+      let(:file_name) { URI(cache.fetch_url).path.split('/').last }
+
+      it { expect(file_name).to eq 'cache--gemfile-Gemfile.tgz' }
+
+      context 'when looking for cache with extra information' do
+        let(:file_name) { URI(cache.fetch_url('', true)).path.split('/').last }
+
+        it { expect(file_name).to eq "cache-#{CACHE_SLUG_EXTRAS}--rvm-default--gemfile-Gemfile.tgz" }
+      end
+    end
+  end
+
+  describe '#push_url' do
+    context 'Given "cache: bundler"' do
+      let(:config) { { cache: 'bundler' } }
+      let(:file_name) { URI(cache.push_url).path.split('/').last }
+
+      it { expect(file_name).to eq "cache-#{CACHE_SLUG_EXTRAS}--rvm-default--gemfile-Gemfile.tgz" }
+
+      context 'and "os: osx"' do
+        let(:config) { { cache: 'bundler', os: 'osx' } }
+
+        it { expect(file_name).to eq "cache-#{CACHE_SLUG_EXTRAS.gsub('linux','osx')}--rvm-default--gemfile-Gemfile.tgz" }
+      end
+    end
+  end
 end

--- a/spec/build/script/directory_cache_spec.rb
+++ b/spec/build/script/directory_cache_spec.rb
@@ -82,7 +82,7 @@ describe Travis::Build::Script::DirectoryCache, :sexp do
       let(:config) { { cache: 'bundler' } }
       let(:file_name) { URI(cache.fetch_url).path.split('/').last }
 
-      it { expect(file_name).to eq 'cache--gemfile-Gemfile.tgz' }
+      it { expect(file_name).to eq 'cache--rvm-default--gemfile-Gemfile.tgz' }
 
       context 'when looking for cache with extra information' do
         let(:file_name) { URI(cache.fetch_url('', true)).path.split('/').last }

--- a/spec/build/script/elixir_spec.rb
+++ b/spec/build/script/elixir_spec.rb
@@ -40,7 +40,7 @@ describe Travis::Build::Script::Elixir, :sexp do
 
   describe '#cache_slug' do
     subject { described_class.new(data).cache_slug }
-    it { is_expected.to eq('cache--otp-17.4--elixir-1.0.2') }
+    it { is_expected.to eq("cache-#{CACHE_SLUG_EXTRAS}--otp-17.4--elixir-1.0.2") }
   end
 
   def self.installs_required_otp_release(elixir_version, otp_release_wanted, otp_release_required)

--- a/spec/build/script/erlang_spec.rb
+++ b/spec/build/script/erlang_spec.rb
@@ -64,7 +64,7 @@ describe Travis::Build::Script::Erlang, :sexp do
 
   describe '#cache_slug' do
     subject { described_class.new(data).cache_slug }
-    it { is_expected.to eq('cache--otp-R14B04') }
+    it { is_expected.to eq("cache-#{CACHE_SLUG_EXTRAS}--otp-R14B04") }
   end
 end
 

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -143,7 +143,7 @@ describe Travis::Build::Script::R, :sexp do
     subject { described_class.new(data).cache_slug }
     it {
       data[:config][:r] = '3.3.0'
-      should eq('cache--R-3.3.0')
+      should eq("cache-#{CACHE_SLUG_EXTRAS}--R-3.3.0")
     }
     it {
       data[:config][:r] = '3.2'
@@ -151,11 +151,11 @@ describe Travis::Build::Script::R, :sexp do
     }
     it {
       data[:config][:r] = 'release'
-      should eq('cache--R-3.3.0')
+      should eq("cache-#{CACHE_SLUG_EXTRAS}--R-3.3.0")
     }
     it {
       data[:config][:r] = 'oldrel'
-      should eq('cache--R-3.2.5')
+      should eq("cache-#{CACHE_SLUG_EXTRAS}--R-3.2.5")
     }
     it {
       data[:config][:r] = '3.1'

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -143,23 +143,23 @@ describe Travis::Build::Script::R, :sexp do
     subject { described_class.new(data).cache_slug }
     it {
       data[:config][:r] = '3.2.5'
-      should eq('cache--R-3.2.5')
+      should eq("cache-#{CACHE_SLUG_EXTRAS}--R-3.2.5")
     }
     it {
       data[:config][:r] = '3.2'
-      should eq('cache--R-3.2.5')
+      should eq("cache-#{CACHE_SLUG_EXTRAS}--R-3.2.5")
     }
     it {
       data[:config][:r] = 'release'
-      should eq('cache--R-3.2.5')
+      should eq("cache-#{CACHE_SLUG_EXTRAS}--R-3.2.5")
     }
     it {
       data[:config][:r] = '3.1'
-      should eq('cache--R-3.1.3')
+      should eq("cache-#{CACHE_SLUG_EXTRAS}--R-3.1.3")
     }
     it {
       data[:config][:r] = 'devel'
-      should eq('cache--R-devel')
+      should eq("cache-#{CACHE_SLUG_EXTRAS}--R-devel")
     }
   end
 end

--- a/spec/build/script/ruby_spec.rb
+++ b/spec/build/script/ruby_spec.rb
@@ -115,25 +115,25 @@ describe Travis::Build::Script::Ruby, :sexp do
 
     describe 'default' do
       subject { script.cache_slug }
-      it { is_expected.to eq('cache--rvm-default--gemfile-Gemfile') }
+      it { is_expected.to eq("cache-#{CACHE_SLUG_EXTRAS}--rvm-default--gemfile-Gemfile") }
     end
 
     describe 'with custom gemfile' do
       before { data[:config][:gemfile] = 'Gemfile.ci' }
       subject { script.cache_slug }
-      it { is_expected.to eq('cache--rvm-default--gemfile-Gemfile.ci') }
+      it { is_expected.to eq("cache-#{CACHE_SLUG_EXTRAS}--rvm-default--gemfile-Gemfile.ci") }
     end
 
     describe 'with custom ruby version' do
       before { data[:config][:rvm] = 'jruby' }
       subject { script.cache_slug }
-      it { is_expected.to eq('cache--rvm-jruby--gemfile-Gemfile') }
+      it { is_expected.to eq("cache-#{CACHE_SLUG_EXTRAS}--rvm-jruby--gemfile-Gemfile") }
     end
 
     describe 'with custom jdk version' do
       before { data.deep_merge!(config: { rvm: 'jruby', jdk: 'openjdk7' }) }
       subject { script.cache_slug }
-      it { is_expected.to eq('cache--jdk-openjdk7--rvm-jruby--gemfile-Gemfile') }
+      it { is_expected.to eq("cache-#{CACHE_SLUG_EXTRAS}--jdk-openjdk7--rvm-jruby--gemfile-Gemfile") }
     end
   end
 

--- a/spec/support/cache_slug_extras.rb
+++ b/spec/support/cache_slug_extras.rb
@@ -1,0 +1,7 @@
+# concatenation of:
+#   1. config[:os], ('linux' for specs)
+#   2. config[:dist], (nil for specs)
+#   3. SHA256 digest of env var array ["FOO=foo"], joined with '='
+#      i.e., OpenSSL::Digest::SHA256.hexdigest(Array(["FOO=foo"]).sort.join('='))
+# with '-'
+CACHE_SLUG_EXTRAS='linux-d5b6dcf6629e552946e7baf3fc0aca4de552e1cd76b596a2800194fe085a53f7'


### PR DESCRIPTION
This PR addresses the issue with cache name collisions by taking into account extra pieces of information known at the build script compilation time.

Related issues:

https://github.com/travis-ci/travis-ci/issues/4393
https://github.com/travis-ci/travis-ci/issues/3023
https://github.com/travis-ci/travis-ci/issues/5460