### PR TITLE
Fix nvm version normalizer function

### DIFF
--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -111,7 +111,7 @@ module Travis
 
           def update_nvm
             return unless ENV['TRAVIS_BUILD_APP_HOST']
-            sh.raw "function vers() {\n  printf \"%03d%03d%03d%03d\" $(echo \"$1\" | tr '.' ' ')\n}"
+            sh.raw "function vers() {\n  printf \"1%03d%03d%03d%03d\" $(echo \"$1\" | tr '.' ' ')\n}"
             nvm_sh_location = "$HOME/.nvm/nvm.sh"
             sh.if "$(vers `nvm --version`) -lt $(vers #{NVM_VERSION})" do
               sh.echo "Updating nvm to v#{NVM_VERSION}", ansi: :yellow, timing: false


### PR DESCRIPTION
Resolves https://github.com/travis-ci/travis-ci/issues/5900                          
                       
Integer comparison with `-lt` considers operands with leading zeros to
be octal. This is a problem when nvm version number includes '8' or
'9'.                      
                           
We solve this problem with leading the operands with `1`, forcing
decimal format.
