### PR TITLE
Run `rvm use` at least once before running Ruby with RVM

### DIFF
--- a/lib/travis/build/script/shared/directory_cache/base.rb
+++ b/lib/travis/build/script/shared/directory_cache/base.rb
@@ -90,10 +90,15 @@ module Travis
 
           def setup_casher
             fold 'Setting up build cache' do
+              run_rvm_use
               install
               fetch
               add(directories) if data.cache?(:directories)
             end
+          end
+
+          def run_rvm_use
+            sh.raw "rvm use $(rvm current) >&/dev/null"
           end
 
           def install

--- a/lib/travis/build/script/shared/directory_cache/base.rb
+++ b/lib/travis/build/script/shared/directory_cache/base.rb
@@ -98,7 +98,7 @@ module Travis
           end
 
           def run_rvm_use
-            sh.raw "rvm use $(rvm current) >&/dev/null"
+            sh.raw "rvm use $(rvm current >&/dev/null) >&/dev/null"
           end
 
           def install


### PR DESCRIPTION
Fixes https://github.com/travis-ci/travis-ci/issues/5929

It is not entirely clear why, but this appears to remove the
unsightly warnings about `$PATH` on the Trusty image running on
non-Ruby jobs.