### PR TITLE
Add Rust cache directive, `cache: cargo`

### DIFF
--- a/lib/travis/build/script/rust.rb
+++ b/lib/travis/build/script/rust.rb
@@ -45,6 +45,22 @@ module Travis
           sh.cmd 'cargo test --verbose'
         end
 
+        def setup_cache
+          if data.cache?(:cargo)
+            sh.fold 'cache.cargo' do
+              directory_cache.add "$HOME/.cargo", "target"
+            end
+          end
+        end
+
+        def cache_slug
+          super << "--cargo-" << version
+        end
+
+        def use_directory_cache?
+          super || data.cache?(:cargo)
+        end
+
         private
 
           def version

--- a/spec/build/script/rust_spec.rb
+++ b/spec/build/script/rust_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe Travis::Build::Script::Rust, :sexp do
-  let(:data)   { payload_for(:push, :rust) }
+  let(:data)   { payload_for(:push, :rust, config: config) }
+  let(:config) { {} }
   let(:script) { described_class.new(data) }
   subject      { script.sexp }
   it           { store_example }
@@ -35,5 +36,14 @@ describe Travis::Build::Script::Rust, :sexp do
 
   it 'runs cargo test' do
     should include_sexp [:cmd, 'cargo test --verbose', echo: true, timing: true]
+  end
+
+  context "when cache is configured" do
+    let(:options) { { fetch_timeout: 20, push_timeout: 30, type: 's3', s3: { bucket: 's3_bucket', secret_access_key: 's3_secret_access_key', access_key_id: 's3_access_key_id' } } }
+    let(:data)   { payload_for(:push, :rust, config: { cache: 'cargo' }, cache_options: options) }
+
+    it 'caches desired directories' do
+      should include_sexp [:cmd, 'rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher add $HOME/.cargo target', timing: true]
+    end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/travis-ci/travis-ci/issues/4470

As discussed in that thread, we will add:

```yaml
cache: cargo
```

and equivalent for Rust.

This will add `$HOME/.cargo` and `target` (in
`$TRAVIS_BUILD_DIR`) to the cache.