### PR TITLE
Modify nvm install behavior when 'nvm install' fails

### DIFF
--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -103,8 +103,13 @@ module Travis
           def install_version(ver)
             sh.cmd "nvm install #{ver}", assert: false
             sh.if '$? -ne 0' do
-              sh.echo "Remote repository may not be reachable", ansi: :yellow
-              sh.cmd "nvm use #{ver}"
+              sh.echo "Failed to install #{ver}. Remote repository may not be reachable.", ansi: :red
+              sh.echo "Using locally available version #{ver}, if applicable."
+              sh.cmd "nvm use #{ver}", assert: false, timing: false
+              sh.if '$? -ne 0' do
+                sh.echo "Unable to use #{ver}", ansi: :red
+                sh.cmd "false", assert: true, echo: false, timing: false
+              end
             end
             sh.export 'TRAVIS_NODE_VERSION', ver, echo: false
           end

--- a/spec/build/script/node_js_spec.rb
+++ b/spec/build/script/node_js_spec.rb
@@ -24,6 +24,22 @@ describe Travis::Build::Script::NodeJs, :sexp do
       it 'sets the version from config :node_js' do
         should include_sexp [:cmd, 'nvm install 0.9', echo: true, timing: true]
       end
+
+      context 'when nvm install fails' do
+        let(:sexp_if)      { sexp_filter(subject, [:if, '$? -ne 0'], [:then]) }
+
+        it 'tries to use locally available version' do
+          expect(sexp_if).to include_sexp [:cmd, 'nvm use 0.9', echo: true]
+        end
+
+        context 'when nvm use fails' do
+          let(:sexp) { sexp_filter(sexp_if, [:if, '$? -ne 0'], [:then]) }
+
+          it 'errors the build' do
+            expect(sexp).to include_sexp [:cmd, 'false', assert: true]
+          end
+        end
+      end
     end
 
     context 'when :node_js is not set in config' do


### PR DESCRIPTION
Fixes https://github.com/travis-ci/travis-ci/issues/5333

With this change:

1. Install the latest version known to nvm if nodejs.org is reachable
2. If nodejs.org is not reachable or 'nvm install' fails for some reason,
   use the locally available and applicable version
3. If there is no version available locally, fail the build immediately