### PR TITLE
use official D install script

### DIFF
--- a/lib/travis/build/script/d.rb
+++ b/lib/travis/build/script/d.rb
@@ -8,16 +8,10 @@ module Travis
       class D < Script
         DEFAULTS = {
           d: 'dmd'
-        }
+        }.freeze
 
         def cache_slug
           super << '--d-' << config[:d]
-        end
-
-        def export
-          super
-          sh.export 'DC', compiler_cmd
-          sh.export 'DMD', dmd_cmd
         end
 
         def setup
@@ -31,139 +25,23 @@ module Travis
             sh.echo 'Installing compiler and dub', ansi: :yellow
 
             sh.cmd 'CURL_USER_AGENT="Travis-CI $(curl --version | head -n 1)"'
-            sh.cmd 'curl() { command curl -fsSL --retry 3 -A "${CURL_USER_AGENT}" "$@"; }'
-
-            case compiler_cmd
-            when 'dmd'
-              binpath, libpath = {
-                'linux' => ['dmd2/linux/bin64', 'dmd2/linux/lib64'],
-                'osx' => ['dmd2/osx/bin', 'dmd2/osx/lib'] }[os]
-
-              if compiler_url.end_with? 'tar.xz'
-                sh.cmd "curl #{compiler_url} | tar -C ~ -Jxf -"
-              else
-                sh.cmd "curl #{compiler_url} > ~/dmd.zip"
-                sh.cmd 'unzip -q -d ~ ~/dmd.zip'
-              end
-            when 'ldc2'
-              binpath, libpath = 'ldc/bin', 'ldc/lib'
-
-              sh.cmd 'mkdir ${HOME}/ldc', echo: false
-              sh.cmd "curl #{compiler_url} | tar --strip-components=1 -C ~/ldc -Jxf -"
-            when 'gdc'
-              binpath, libpath = 'gdc/bin', 'gdc/lib'
-
-              sh.cmd 'mkdir ${HOME}/gdc', echo: false
-              sh.cmd "curl #{compiler_url} | tar --strip-components=1 -C ~/gdc -Jxf -"
-              sh.cmd 'curl https://raw.githubusercontent.com/D-Programming-GDC/GDMD/master/dmd-script > '\
-                "~/#{binpath}/gdmd && chmod +x ~/#{binpath}/gdmd"
-            end
-
-            sh.cmd 'LATEST_DUB=$(curl http://code.dlang.org/download/LATEST)', echo: false
-            sh.cmd "curl http://code.dlang.org/files/dub-${LATEST_DUB}-#{os}-x86_64.tar.gz"\
-              " | tar -C ~/#{binpath} -zxf -"
-            sh.cmd "export PATH=\"${HOME}/#{binpath}:${PATH}\""
-            sh.cmd "export LD_LIBRARY_PATH=\"${HOME}/#{libpath}:${LD_LIBRARY_PATH}\""
+            sh.cmd 'source "$(curl -fsS  --retry 3 https://dlang.org/install.sh | '\
+                   "CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash -s #{config[:d]} --activate)\""
           end
         end
 
         def announce
           super
-          if compiler_cmd == 'dmd'
+          if config[:d].start_with?('dmd-') && config[:d] <= 'dmd-2.066.1'
             sh.cmd 'dmd --help | head -n 2'
           else
-            sh.cmd "#{compiler_cmd} --version"
+            sh.cmd '$DC --version'
           end
           sh.cmd 'dub --help | tail -n 1'
         end
 
         def script
-          sh.cmd "dub test --compiler=#{compiler_cmd}"
-        end
-
-        private
-
-        def os
-          config[:os] || 'linux'
-        end
-
-        def compiler_url(compiler = config[:d])
-          case compiler
-          # latest DMD
-          when 'dmd'
-            sh.cmd 'LATEST_DMD=$(curl http://ftp.digitalmars.com/LATEST)', echo: false
-            "http://downloads.dlang.org/releases/2.x/${LATEST_DMD}/dmd.${LATEST_DMD}.#{os}.tar.xz"
-
-          # dmd-2.062, dmd-2.065.0, dmd-2.066.1-rc3
-          when /^dmd-2\.(?<maj>\d{3})(?<min>\.\d)?(?<suffix>-.*)?$/
-            basename = "dmd.2.#{$~[:maj]}#{$~[:min]}#{$~[:suffix]}"
-            version = '2.'+$~[:maj]
-
-            if version >= '2.065'
-              basename += '.'+os # use smaller OS specific archives
-              version += $~[:min] # version uses .minor
-            end
-            arch = version >= '2.068.1' ? 'tar.xz' : 'zip'
-
-            if $~[:suffix] # pre-release
-              "http://downloads.dlang.org/pre-releases/2.x/#{version}/#{basename}.#{arch}"
-            else
-              "http://downloads.dlang.org/releases/2.x/#{version}/#{basename}.#{arch}"
-            end
-
-          # latest LDC
-          when 'ldc'
-            sh.cmd 'LATEST_LDC=$(curl https://ldc-developers.github.io/LATEST)', echo: false
-            'https://github.com/ldc-developers/ldc/releases/download'\
-              "/v${LATEST_LDC}/ldc2-${LATEST_LDC}-#{os}-x86_64.tar.xz"
-
-          # ldc-0.12.1 or ldc-0.15.0-alpha1
-          when /^ldc-(\d+\.\d+\.\d+(-.*)?)$/
-            'https://github.com/ldc-developers/ldc/releases/download'\
-              "/v#{$1}/ldc2-#{$1}-#{os}-x86_64.tar.xz"
-
-          # latest GDC
-          when 'gdc'
-            sh.cmd 'LATEST_GDC=$(curl http://gdcproject.org/downloads/LATEST)', echo: false
-            "http://gdcproject.org/downloads/binaries/#{gdc_host_triplet os}/gdc-${LATEST_GDC}.tar.xz"
-
-          # gdc-4.8.2, gdc-4.9.0-alpha1, gdc-5.2, or gdc-5.2-alpha1
-          when /^gdc-(\d+\.\d+(\.\d+)?(-.*)?)$/
-            "http://gdcproject.org/downloads/binaries/#{gdc_host_triplet os}/gdc-#{$1}.tar.xz"
-          end
-        end
-
-        def gdc_host_triplet os
-          case os
-          when 'linux'
-            'x86_64-linux-gnu'
-          when 'osx'
-            'x86_64-apple-darwin'
-          else
-            fail "GDC is currently not supported on #{os}."
-          end
-        end
-
-        def compiler_cmd
-          case config[:d]
-          when /^ldc/
-            'ldc2'
-          when /^gdc/
-            'gdc'
-          else
-            'dmd'
-          end
-        end
-
-        def dmd_cmd
-          case config[:d]
-          when /^ldc/
-            'ldmd2'
-          when /^gdc/
-            'gdmd'
-          else
-            'dmd'
-          end
+          sh.cmd 'dub test --compiler=$DC'
         end
       end
     end

--- a/spec/build/script/d_spec.rb
+++ b/spec/build/script/d_spec.rb
@@ -11,210 +11,40 @@ describe Travis::Build::Script::D, :sexp do
 
   it_behaves_like 'a build script sexp'
 
-  shared_examples 'dmd' do
-    it 'downloads and installs dmd' do
-      should include_sexp [:cmd, %r{downloads\.dlang\.org/releases/.*/dmd.*},
-                           assert: true, echo: true, timing: true]
-    end
-
-    it 'downloads and installs dub' do
-      should include_sexp [:cmd, %r{code\.dlang\.org/files/dub-.*},
-                           assert: true, echo: true, timing: true]
-    end
-
-    it 'sets DC and DMD to dmd' do
-      should include_sexp [:export, ['DC', 'dmd'], echo: true]
-      should include_sexp [:export, ['DMD', 'dmd'], echo: true]
-    end
-
-    it 'announces dmd' do
-      should include_sexp [:cmd, 'dmd --help | head -n 2', echo: true]
-    end
-
-    it 'announces dub' do
-      should include_sexp [:cmd, 'dub --help | tail -n 1', echo: true]
-    end
-
-    it 'runs dub test with dmd' do
-      should include_sexp [:cmd, 'dub test --compiler=dmd', echo: true, timing: true]
-    end
+  it 'downloads and runs the installer script' do
+    should include_sexp [:cmd, %r{source.*"$\(.*https://dlang\.org/install\.sh.*|.*bash.*--activate\)"},
+                         assert: true, echo: true, timing: true]
   end
 
-  context 'when no specific compiler is configured' do
-    it_behaves_like 'dmd'
+  it 'announces compiler version' do
+    should include_sexp [:cmd, '$DC --version', echo: true]
   end
 
-  context 'when dmd is configured' do
-    before do
-      data[:config][:d] = 'dmd'
-    end
-
-    it_behaves_like 'dmd'
-
-    it 'downloads the latest dmd version' do
-      should include_sexp [:cmd, %r{LATEST_DMD=.*curl.*},
-                           assert: true, timing: true]
-      should include_sexp [:cmd, %r{downloads\.dlang\.org/releases/.*/dmd.*\${LATEST_DMD}.*\.tar\.xz},
-                           assert: true, echo: true, timing: true]
-    end
+  it 'announces dub' do
+    should include_sexp [:cmd, 'dub --help | tail -n 1', echo: true]
   end
 
-  context 'when a dmd version is configured' do
+  it 'runs dub test with DC' do
+    should include_sexp [:cmd, 'dub test --compiler=$DC', echo: true, timing: true]
+  end
+
+  context 'when an old dmd version is configured' do
     before do
       data[:config][:d] = 'dmd-2.066.0'
     end
 
-    it_behaves_like 'dmd'
-
-    it 'downloads a specific dmd version' do
-      should include_sexp [:cmd, %r{downloads\.dlang\.org/releases/.*/dmd.*2\.066\.0.*\.zip},
-                           assert: true, echo: true, timing: true]
+    it 'announces compiler version' do
+      should include_sexp [:cmd, 'dmd --help | head -n 2', echo: true]
     end
   end
 
-  context 'when a prerelease version is configured' do
+  context 'when a compiler is configured' do
     before do
-      data[:config][:d] = 'dmd-2.067.0-rc1'
+      data[:config][:d] = 'ldc-0.17.1'
     end
 
-    it 'downloads from the prerelease path' do
-      should include_sexp [:cmd, %r{downloads\.dlang\.org/pre-releases/2\.x/2\.067\.0/dmd.*2\.067\.0-rc1.*\.zip},
-                           assert: true, echo: true, timing: true]
-    end
-  end
-
-  context 'when a pre 2.065 version is configured' do
-    before do
-      data[:config][:d] = 'dmd-2.064.2'
-    end
-
-    it 'downloads from a folder without minor version' do
-      should include_sexp [:cmd, %r{downloads\.dlang\.org/releases/2\.x/2\.064/dmd.*2\.064\.2.*\.zip},
-                           assert: true, echo: true, timing: true]
-    end
-  end
-
-  context 'when a < 2.068.1 version is configured' do
-    before do
-      data[:config][:d] = 'dmd-2.068.0'
-    end
-
-    it 'downloads a zip archive' do
-      should include_sexp [:cmd, %r{downloads\.dlang\.org/releases/2\.x/2\.068\.0/dmd.*2\.068\.0.*\.zip},
-                           assert: true, echo: true, timing: true]
-      should include_sexp [:cmd, %r{unzip},
-                           assert: true, echo: true, timing: true]
-    end
-  end
-
-  context 'when a >= 2.068.1 version is configured' do
-    before do
-      data[:config][:d] = 'dmd-2.068.1'
-    end
-
-    it 'downloads an LZMA archive' do
-      should include_sexp [:cmd, %r{downloads\.dlang\.org/releases/2\.x/2\.068\.1/dmd.*2\.068\.1.*\.tar\.xz \| tar.*-Jx},
-                           assert: true, echo: true, timing: true]
-    end
-  end
-
-  # LDC
-  shared_examples 'ldc' do
-    it 'sets DC and DMD from config :d' do
-      should include_sexp [:export, ['DC', 'ldc2'], echo: true]
-      should include_sexp [:export, ['DMD', 'ldmd2'], echo: true]
-    end
-
-    it 'announces ldc' do
-      should include_sexp [:cmd, 'ldc2 --version', echo: true]
-    end
-
-    it 'runs dub test with ldc' do
-      should include_sexp [:cmd, 'dub test --compiler=ldc2', echo: true, timing: true]
-    end
-  end
-
-  context 'when ldc is configured' do
-    before do
-      data[:config][:d] = 'ldc'
-    end
-
-    it_behaves_like 'ldc'
-
-    it 'downloads the latest ldc version' do
-      should include_sexp [:cmd, %r{LATEST_LDC=.*curl.*},
-                           assert: true, timing: true]
-      should include_sexp [:cmd, %r{ldc/releases/download/.*/ldc2.*\${LATEST_LDC}.*.tar.*},
-                           assert: true, echo: true, timing: true]
-    end
-  end
-
-  context 'when a ldc version is configured' do
-    before do
-      data[:config][:d] = 'ldc-0.14.0'
-    end
-
-    it_behaves_like 'ldc'
-
-    it 'downloads and installs ldc' do
-      should include_sexp [:cmd, %r{ldc/releases/download/.*/ldc2.*0\.14\.0.*.tar.*},
-                           assert: true, echo: true, timing: true]
-    end
-  end
-
-  # GDC
-  shared_examples 'gdc' do
-    it 'sets DC and DMD from config :d' do
-      should include_sexp [:export, ['DC', 'gdc'], echo: true]
-      should include_sexp [:export, ['DMD', 'gdmd'], echo: true]
-    end
-
-    it 'announces gdc' do
-      should include_sexp [:cmd, 'gdc --version', echo: true]
-    end
-
-    it 'runs dub test with gdc' do
-      should include_sexp [:cmd, 'dub test --compiler=gdc', echo: true, timing: true]
-    end
-  end
-
-  context 'when gdc is configured' do
-    before do
-      data[:config][:d] = 'gdc'
-    end
-
-    it_behaves_like 'gdc'
-
-    it 'downloads and installs gdc' do
-      should include_sexp [:cmd, %r{LATEST_GDC=.*curl.*},
-                           assert: true, timing: true]
-      should include_sexp [:cmd, %r{gdcproject\.org/downloads/.*\${LATEST_GDC}.*\.tar\..*},
-                           assert: true, echo: true, timing: true]
-    end
-  end
-
-  context 'when a gdc version is configured' do
-    before do
-      data[:config][:d] = 'gdc-4.8.2'
-    end
-
-    it_behaves_like 'gdc'
-
-    it 'downloads and installs gdc' do
-      should include_sexp [:cmd, %r{gdcproject\.org/downloads/.*4\.8\.2.*\.tar\..*},
-                           assert: true, echo: true, timing: true]
-    end
-  end
-
-  context 'when a gdc 5.x version is configured' do
-    before do
-      data[:config][:d] = 'gdc-5.2'
-    end
-
-    it_behaves_like 'gdc'
-
-    it 'downloads and installs gdc' do
-      should include_sexp [:cmd, %r{gdcproject\.org/downloads/.*5\.2.*\.tar\..*},
+    it 'passed the compiler to the install script' do
+      should include_sexp [:cmd, %r{install\.sh.*|.*bash.*ldc-0.17.1"},
                            assert: true, echo: true, timing: true]
     end
   end


### PR DESCRIPTION
- outsources all complexity to the official installer script
- allows to cache downloaded compilers in $HOME/dlang

fixes https://github.com/travis-ci/travis-ci/issues/5918
fixes https://github.com/travis-ci/travis-ci/issues/5970