### PR TITLE
Set language runtime archive URL on the build VM, not on `travis-build`

### DIFF
--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -82,7 +82,15 @@ module Travis
       end
 
       def archive_url_for(bucket, version, lang = self.class.name.split('::').last.downcase, ext = 'bz2')
-        "https://s3.amazonaws.com/#{bucket}/binaries/#{host_os}/#{rel_version}/$(uname -m)/#{lang}-#{version}.tar.#{ext}"
+        sh.if "$(uname) = 'Linux'" do
+          sh.raw "host=linux"
+          sh.raw "rel_version=$(lsb_release -rs)"
+        end
+        sh.elif "$(uname) = 'Darwin'" do
+          sh.raw "host_os=osx"
+          sh.raw "rel_version=${$(sw_vers -productVersion)%*.*}"
+        end
+        "archive_url=https://s3.amazonaws.com/#{bucket}/binaries/${host_os}/${rel_version}/$(uname -m)/#{lang}-#{version}.tar.#{ext}"
       end
 
       def debug_build_via_api?

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -83,7 +83,7 @@ module Travis
 
       def archive_url_for(bucket, version, lang = self.class.name.split('::').last.downcase, ext = 'bz2')
         sh.if "$(uname) = 'Linux'" do
-          sh.raw "travis_host_os=linux"
+          sh.raw "travis_host_os=$(lsb_release -is | tr 'A-Z' 'a-z')"
           sh.raw "travis_rel_version=$(lsb_release -rs)"
         end
         sh.elif "$(uname) = 'Darwin'" do

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -88,7 +88,8 @@ module Travis
         end
         sh.elif "$(uname) = 'Darwin'" do
           sh.raw "host_os=osx"
-          sh.raw "rel_version=${$(sw_vers -productVersion)%*.*}"
+          sh.raw "rel=$(sw_vers -productVersion)"
+          sh.raw "rel_version=${rel%*.*}"
         end
         "archive_url=https://s3.amazonaws.com/#{bucket}/binaries/${host_os}/${rel_version}/$(uname -m)/#{lang}-#{version}.tar.#{ext}"
       end

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -83,15 +83,15 @@ module Travis
 
       def archive_url_for(bucket, version, lang = self.class.name.split('::').last.downcase, ext = 'bz2')
         sh.if "$(uname) = 'Linux'" do
-          sh.raw "host=linux"
-          sh.raw "rel_version=$(lsb_release -rs)"
+          sh.raw "travis_host_os=linux"
+          sh.raw "travis_rel_version=$(lsb_release -rs)"
         end
         sh.elif "$(uname) = 'Darwin'" do
-          sh.raw "host_os=osx"
-          sh.raw "rel=$(sw_vers -productVersion)"
-          sh.raw "rel_version=${rel%*.*}"
+          sh.raw "travis_host_os=osx"
+          sh.raw "travis_rel=$(sw_vers -productVersion)"
+          sh.raw "travis_rel_version=${travis_rel%*.*}"
         end
-        "archive_url=https://s3.amazonaws.com/#{bucket}/binaries/${host_os}/${rel_version}/$(uname -m)/#{lang}-#{version}.tar.#{ext}"
+        "archive_url=https://s3.amazonaws.com/#{bucket}/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/#{lang}-#{version}.tar.#{ext}"
       end
 
       def debug_build_via_api?

--- a/lib/travis/build/script/erlang.rb
+++ b/lib/travis/build/script/erlang.rb
@@ -63,14 +63,15 @@ module Travis
           end
 
           def install_erlang(release)
-            archive = archive_url_for('travis-otp-releases',release, 'erlang').sub(/\.tar\.bz2/, '-nonroot.tar.bz2')
+            sh.raw archive_url_for('travis-otp-releases',release, 'erlang').sub(/\.tar\.bz2/, '-nonroot.tar.bz2')
             sh.echo "#{release} is not installed. Downloading and installing pre-build binary.", ansi: :yellow
-            sh.cmd "wget #{archive}"
+
+            sh.cmd "wget -o $HOME/erlang.tar.bz2 ${archive_url}"
             sh.cmd "mkdir -p ~/otp && tar -xf #{archive_name(release)} -C ~/otp/"
             sh.cmd "mkdir -p ~/.kerl"
             sh.cmd "echo '#{release},#{release}' >> ~/.kerl/otp_builds", echo: false
             sh.cmd "echo '#{release} #{HOME_DIR}/otp/#{release}' >> ~/.kerl/otp_builds", echo: false
-            sh.raw "rm -f #{archive}"
+            sh.raw "rm -f $HOME/erlang.tar.bz2"
           end
       end
     end

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -129,7 +129,8 @@ hhvm.libxml.ext_entity_whitelist=file,http,https
             setup_alias(version, '7.0')
             version = '7.0'
           end
-          sh.cmd "curl -s -o archive.tar.bz2 #{archive_url_for('travis-php-archives', version)} && tar xjf archive.tar.bz2 --directory /", echo: false, assert: false
+          sh.raw archive_url_for('travis-php-archives', version)
+          sh.cmd "curl -s -o archive.tar.bz2 $archive_url && tar xjf archive.tar.bz2 --directory /", echo: false, assert: false
           sh.cmd "rm -f archive.tar.bz2", echo: false
         end
 

--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -97,7 +97,8 @@ module Travis
           end
 
           def install_python_archive(version = 'nightly')
-            sh.cmd "curl -s -o python-#{version}.tar.bz2 #{archive_url_for('travis-python-archives', version)}", echo: false, assert: true
+            sh.raw archive_url_for('travis-python-archives', version)
+            sh.cmd "curl -s -o python-#{version}.tar.bz2 ${archive_url}", echo: false, assert: true
             sh.cmd "sudo tar xjf python-#{version}.tar.bz2 --directory /", echo: false, assert: true
             sh.cmd "rm python-#{version}.tar.bz2", echo: false
           end

--- a/spec/build/script/elixir_spec.rb
+++ b/spec/build/script/elixir_spec.rb
@@ -58,14 +58,16 @@ describe Travis::Build::Script::Elixir, :sexp do
           describe "wanted OTP release #{otp_release_wanted}" do
             xit "is installed" do
               sexp = sexp_find(subject, [:if, "! -f #{Travis::Build::HOME_DIR}/otp/#{otp_release_wanted}/activate"], [:then])
-              expect(sexp).to include_sexp([:cmd, "wget https://s3.amazonaws.com/travis-otp-releases/ubuntu/$(lsb_release -rs)/erlang-#{otp_release_wanted}-x86_64.tar.bz2", assert: true, echo: true, timing: true])
+              expect(sexp).to include_sexp([:raw, "archive_url=https://s3.amazonaws.com/travis-otp-releases/ubuntu/$(lsb_release -rs)/erlang-#{otp_release_wanted}-x86_64.tar.bz2"])
+              expect(sexp).to include_sexp([:cmd, "wget $archive_url", assert: true, echo: true, timing: true])
             end
           end
         else
           describe "required OTP release #{otp_release_required}" do
             xit "is installed" do
               sexp = sexp_find(subject, [:if, "! -f #{Travis::Build::HOME_DIR}/otp/#{otp_release_required}/activate"], [:then])
-              expect(sexp).to include_sexp([:cmd, "wget https://s3.amazonaws.com/travis-otp-releases/ubuntu/$(lsb_release -rs)/erlang-#{otp_release_required}-x86_64.tar.bz2", assert: true, echo: true, timing: true])
+              expect(sexp).to include_sexp([:raw, "archive_url=https://s3.amazonaws.com/travis-otp-releases/ubuntu/$(lsb_release -rs)/erlang-#{otp_release_required}-x86_64.tar.bz2"])
+              expect(sexp).to include_sexp([:cmd, "wget $archive_url", assert: true, echo: true, timing: true])
             end
           end
         end

--- a/spec/build/script/php_spec.rb
+++ b/spec/build/script/php_spec.rb
@@ -36,7 +36,8 @@ describe Travis::Build::Script::Php, :sexp do
 
   describe 'installs php nightly' do
     before { data[:config][:php] = 'nightly' }
-    xit { should include_sexp [:cmd, 'curl -s -o archive.tar.bz2 https://s3.amazonaws.com/travis-php-archives/php-nightly-archive.tar.bz2 && tar xjf archive.tar.bz2 --directory /', timing: true] }
+    # expect(sexp).to include_sexp [:raw, "archive_url=https://s3.amazonaws.com/travis-php-archives/php-#{version}-archive.tar.bz2"]
+    xit { should include_sexp [:cmd, 'curl -s -o archive.tar.bz2 $archive_url && tar xjf archive.tar.bz2 --directory /', timing: true] }
   end
 
   describe 'installs php 7' do
@@ -65,7 +66,8 @@ describe Travis::Build::Script::Php, :sexp do
     let(:sexp) { sexp_find(subject, [:if, "$? -ne 0"], [:then]) }
 
     xit 'installs PHP version on demand' do
-      expect(sexp).to include_sexp [:cmd, "curl -s -o archive.tar.bz2 https://s3.amazonaws.com/travis-php-archives/php-#{version}-archive.tar.bz2 && tar xjf archive.tar.bz2 --directory /", timing: true]
+      expect(sexp).to include_sexp [:raw, "archive_url=https://s3.amazonaws.com/travis-php-archives/php-#{version}-archive.tar.bz2"]
+      expect(sexp).to include_sexp [:cmd, "curl -s -o archive.tar.bz2 $archive_url && tar xjf archive.tar.bz2 --directory /", timing: true]
     end
   end
 


### PR DESCRIPTION
Currently, the S3 archive location is set on the `travis-build` app, leading to incorrect value when the build script is executed on the Mac.

The problem is not a serious one at the moment, because the languages involved are not functioning on the Mac any way. However, we should fix this if we want to add support for these languages on the Mac.