### PR TITLE
Set Perl archive URL correctly

### DIFF
--- a/lib/travis/build/script/perl.rb
+++ b/lib/travis/build/script/perl.rb
@@ -62,7 +62,8 @@ module Travis
         end
 
         def install_perl_archive(version)
-          sh.cmd "curl -s -o perl-#{version}.tar.bz2 #{archive_url_for('travis-perl-archives', version)}", echo: false
+          sh.raw archive_url_for('travis-perl-archives', version)
+          sh.cmd "curl -s -o perl-#{version}.tar.bz2 ${archive_url}", echo: false
           sh.cmd "sudo tar xjf perl-#{version}.tar.bz2 --directory /", echo: false
           sh.cmd "rm perl-#{version}.tar.bz2", echo: false
         end


### PR DESCRIPTION
Forgot to fix the Perl URL when I did https://github.com/travis-ci/travis-build/pull/719.