### PR TITLE
Allow more liberal use of `apt` addon use on infrastructures where `sudo` is available

### DIFF
--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -106,16 +106,7 @@ module Travis
           def add_apt_packages
             sh.echo "Installing APT Packages (BETA)", ansi: :yellow
 
-            whitelisted = []
-            disallowed = []
-
-            config_packages.each do |package|
-              if package_whitelist.include?(package)
-                whitelisted << package
-              else
-                disallowed << package
-              end
-            end
+            whitelisted, disallowed = config_packages.partition { |pkg| package_whitelist.include? pkg }
 
             unless disallowed.empty?
               sh.echo "Disallowing packages: #{disallowed.map { |package| Shellwords.escape(package) }.join(', ')}", ansi: :red

--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -78,8 +78,11 @@ module Travis
 
             config_sources.each do |source_alias|
               source = source_whitelist[source_alias]
-              whitelisted << source.clone if source && source['sourceline']
-              disallowed << source_alias if source.nil?
+              if (source && source['sourceline']) || !data.disable_sudo?
+                whitelisted << source.clone
+              else
+                disallowed << source_alias
+              end
             end
 
             unless disallowed.empty?

--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -88,8 +88,8 @@ module Travis
                     'key_url' => src[:key_url]
                   }
                 else
-                  sh.echo "Malformed source:", ansi: :yellow
-                  sh.echo src.inspect
+                  sh.echo "`sourceline` key missing:", ansi: :yellow
+                  sh.echo Shellwords.escape(src.inspect)
                 end
               elsif source.nil?
                 disallowed << src

--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -150,7 +150,7 @@ module Travis
           end
 
           def package_whitelisted?(list, pkg)
-            list.include? pkg
+            list.include?(pkg) || !data.disable_sudo?
           end
 
           def package_whitelist

--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -106,7 +106,7 @@ module Travis
           def add_apt_packages
             sh.echo "Installing APT Packages (BETA)", ansi: :yellow
 
-            whitelisted, disallowed = config_packages.partition { |pkg| package_whitelist.include? pkg }
+            whitelisted, disallowed = config_packages.partition { |pkg| package_whitelisted?(package_whitelist, pkg) }
 
             unless disallowed.empty?
               sh.echo "Disallowing packages: #{disallowed.map { |package| Shellwords.escape(package) }.join(', ')}", ansi: :red
@@ -147,6 +147,10 @@ module Travis
 
           def config_packages
             @config_packages ||= Array(config[:packages]).flatten.compact
+          end
+
+          def package_whitelisted?(list, pkg)
+            list.include? pkg
           end
 
           def package_whitelist

--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -78,11 +78,8 @@ module Travis
 
             config_sources.each do |source_alias|
               source = source_whitelist[source_alias]
-              if (source && source['sourceline']) || !data.disable_sudo?
-                whitelisted << source.clone
-              else
-                disallowed << source_alias
-              end
+              whitelisted << source.clone if source && source['sourceline']
+              disallowed << source_alias if source.nil?
             end
 
             unless disallowed.empty?

--- a/spec/build/addons/apt_packages_spec.rb
+++ b/spec/build/addons/apt_packages_spec.rb
@@ -2,10 +2,11 @@ require 'ostruct'
 
 describe Travis::Build::Addons::AptPackages, :sexp do
   let(:script)    { stub('script') }
-  let(:data)      { payload_for(:push, :ruby, config: { addons: { apt_packages: config } }) }
+  let(:data)      { payload_for(:push, :ruby, config: { addons: { apt_packages: config } }, paranoid: paranoid) }
   let(:sh)        { Travis::Shell::Builder.new }
   let(:addon)     { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
   let(:package_whitelist) { ['curl', 'git'] }
+  let(:paranoid)  { true }
   subject         { sh.to_sexp }
 
   before do
@@ -27,6 +28,13 @@ describe Travis::Build::Addons::AptPackages, :sexp do
     let(:config) { ['git', 'curl', 'darkcoin'] }
 
     it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true] }
+  end
+
+  context 'with multiple packages, some whitelisted' do
+    let(:config) { ['git', 'curl', 'darkcoin'] }
+    let(:paranoid) { false }
+
+    it { should include_sexp [:cmd, apt_get_install_command('git', 'curl', 'darkcoin'), echo: true, timing: true] }
   end
 
   context 'with singular whitelisted package' do

--- a/spec/build/addons/apt_spec.rb
+++ b/spec/build/addons/apt_spec.rb
@@ -219,7 +219,7 @@ describe Travis::Build::Addons::Apt, :sexp do
 
       context 'when a malformed source is given' do
         let(:config) { { sources: [{ key_url: 'deadbeef' }] } }
-        it { should include_sexp [:echo, "Malformed source:", ansi: :yellow] }
+        it { should include_sexp [:echo, "`sourceline` key missing:", ansi: :yellow] }
       end
     end
   end

--- a/spec/build/addons/apt_spec.rb
+++ b/spec/build/addons/apt_spec.rb
@@ -3,12 +3,13 @@ require 'json'
 
 describe Travis::Build::Addons::Apt, :sexp do
   let(:script)            { stub('script') }
-  let(:data)              { payload_for(:push, :ruby, config: { addons: { apt: config } }, paranoid: true) }
+  let(:data)              { payload_for(:push, :ruby, config: { addons: { apt: config } }, paranoid: paranoid) }
   let(:sh)                { Travis::Shell::Builder.new }
   let(:addon)             { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
   let(:config)            { {} }
   let(:source_whitelist)  { [{ alias: 'testing', sourceline: 'deb http://example.com/deb repo main' }] }
   let(:package_whitelist) { %w(git curl) }
+  let(:paranoid)          { true }
   subject                 { sh.to_sexp }
 
   before :all do
@@ -108,6 +109,12 @@ describe Travis::Build::Addons::Apt, :sexp do
       let(:config) { { packages: ['git', 'curl', 'darkcoin'] } }
 
       it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true] }
+
+      context 'when sudo is enabled' do
+        let(:paranoid) { false }
+
+        it { should include_sexp [:cmd, apt_get_install_command('git', 'curl', 'darkcoin'), echo: true, timing: true] }
+      end
     end
 
     context 'with singular whitelisted package' do

--- a/spec/build/addons/apt_spec.rb
+++ b/spec/build/addons/apt_spec.rb
@@ -3,7 +3,7 @@ require 'json'
 
 describe Travis::Build::Addons::Apt, :sexp do
   let(:script)            { stub('script') }
-  let(:data)              { payload_for(:push, :ruby, config: { addons: { apt: config } }) }
+  let(:data)              { payload_for(:push, :ruby, config: { addons: { apt: config } }, paranoid: true) }
   let(:sh)                { Travis::Shell::Builder.new }
   let(:addon)             { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
   let(:config)            { {} }


### PR DESCRIPTION
When `sudo` is available, we should allow all APT packages to be installed, and allow any APT source to be added.

In this PR, `addons.apt.sources` can be a sequence of any of the following:

1. any alias defined in https://github.com/travis-ci/apt-source-whitelist/blob/master/ubuntu.json
1. a map with a `sourceline` key-value pair, which is added to `/etc/apt/sources.list`
1. a map with a `sourceline` key-value pair (as above) and a `key_url` key-value pair, which will be fetched and fed to `apt-key add`.

```yaml
addons:
  apt:
    sources:
      - any_whitelisted_alias
      - sourceline: 'ppa: foo/bar'
      - sourceline: 'deb https://packagecloud.io/chef/stable/ubuntu/precise main'
        key_url: 'https://packagecloud.io/gpg.key'
```
