### PR TITLE
Abort builds if Sauce Connect blocks for > 2 min.

### DIFF
--- a/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh
+++ b/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh
@@ -6,7 +6,7 @@ function wait_for_sauce_connect_readyfile() {
   readyfile=$1
   echo "Waiting for Sauce Connect readyfile"
 
-  while [ ! -f ${readyfile} ]; do
+  while [ ! -f "${readyfile}" ]; do
     sleep .5
   done
 }
@@ -27,7 +27,7 @@ function travis_start_sauce_connect() {
 
   sc_tmp="$(mktemp -d -t sc.XXXX)"
   echo "Using temp dir $sc_tmp"
-  pushd $sc_tmp
+  pushd "$sc_tmp"
 
   sc_platform=$(uname | sed -e 's/Darwin/osx/' -e 's/Linux/linux/')
   case "${sc_platform}" in
@@ -45,26 +45,26 @@ function travis_start_sauce_connect() {
     sc_tunnel_id_arg="-i ${TRAVIS_JOB_NUMBER}"
   fi
   echo "Downloading Sauce Connect"
-  wget http://saucelabs.com/downloads/${sc_distro}
-  sc_actual_shasum="$(openssl sha1 ${sc_distro} | cut -d' ' -f2)"
+  wget http://saucelabs.com/downloads/"${sc_distro}"
+  sc_actual_shasum="$(openssl sha1 "${sc_distro}" | cut -d' ' -f2)"
   if [[ "$sc_actual_shasum" != "$sc_distro_shasum" ]]; then
       echo "SHA1 sum of Sauce Connect file didn't match!"
       return 1
   fi
-  sc_dir=$(tar -ztf ${sc_distro} | head -n1)
+  sc_dir=$(tar -ztf "${sc_distro}" | head -n1)
 
   echo "Extracting Sauce Connect"
   case "${sc_distro_fmt}" in
       tar.gz)
-          tar zxf $sc_distro;;
+          tar zxf "$sc_distro";;
       zip)
-          unzip $sc_distro;;
+          unzip "$sc_distro";;
   esac
 
-  ${sc_dir}/bin/sc \
+  "${sc_dir}"/bin/sc \
     ${sc_tunnel_id_arg} \
-    -f ${sc_readyfile} \
-    -l ${sc_logfile} \
+    -f "${sc_readyfile}" \
+    -l "${sc_logfile}" \
     ${SAUCE_NO_SSL_BUMP_DOMAINS} \
     ${SAUCE_DIRECT_DOMAINS} \
     ${SAUCE_TUNNEL_DOMAINS} &
@@ -76,7 +76,7 @@ function travis_start_sauce_connect() {
   wait_for_sauce_connect_readyfile ${sc_readyfile} &>/dev/null &
   local cmd_pid=$!
 
-  travis_jigger $! $timeout $cmd &
+  travis_jigger $! $timeout "$cmd" &
   local jigger_pid=$!
   local result
 


### PR DESCRIPTION
Builds opening a Sauce Connect tunnel currently block until Sauce
Connect has produced a readyfile.  In some cases there is no readyfile
producted; This blocks the build until the global no-output timer (10
minutes as of this commit) terminates it.

Readyfiles are produced once a Sauce Connect tunnel is fully up.  This
can fail to happen for a variety of reasons, including the user having
too many tunnels open at once.

This commit introduces a 2 minute wait time (as advised by @ldx, Sauce
Labs employee and total Sauce Connect smart guy) for the readyfile,
after which the entire build is terminated.

The `travis_jigger` function is used to post a notification to the
console and then ultimately kill the process via `travis_terminate 2`
(similarly to `travis_assert`).  An earlier revision used `travis_wait`
but this produced confusing output.

This commit closes https://github.com/travis-ci/travis-ci/issues/3091.
