### PR TITLE
Clean up ivy and sbt artifacts

### DIFF
--- a/lib/travis/build/script/shared/jvm.rb
+++ b/lib/travis/build/script/shared/jvm.rb
@@ -8,6 +8,18 @@ module Travis
           jdk: 'default'
         }
 
+        CLEANUPS = [
+          { directory: '$HOME/.ivy2', glob: "ivydata-*.properties"},
+          { directory: '$HOME/.sbt',  glob: "*.lock"}
+        ]
+
+        def setup
+          super
+          CLEANUPS.each do |find_arg|
+            sh.raw "find #{find_arg[:directory]} -name #{find_arg[:glob]} -delete"
+          end
+        end
+
         def install
           sh.if '-f gradlew' do
             sh.cmd './gradlew assemble', retry: true, fold: 'install'


### PR DESCRIPTION
Fixes https://github.com/travis-ci/travis-ci/issues/5016

These files exist on the base JVM build image, so even when they are
removed in `before_cache`, we would detect changes in these files.

The list of files to remove comes from http://www.scala-sbt.org/0.13/docs/Travis-CI-with-sbt.html#%28Experimental%29+Reusing+Ivy+cache.