### PR TITLE
Allow deployment condition shortcuts for versioned languages

### DIFF
--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -6,7 +6,28 @@ module Travis
     class Addons
       class Deploy < Base
         class Script
-          VERSIONED_RUNTIMES = [:jdk, :node, :perl, :php, :python, :ruby, :scala, :go]
+          VERSIONED_RUNTIMES = %w(
+            d
+            dart
+            elixir
+            ghc
+            go
+            haxe
+            jdk
+            julia
+            mono
+            node
+            otp_release
+            perl
+            php
+            python
+            r
+            ruby
+            rust
+            scala
+            smalltalk
+          ).map(&:to_sym)
+
           USE_RUBY           = '1.9.3'
 
           attr_accessor :script, :sh, :data, :config, :allow_failure

--- a/spec/build/addons/deploy_spec.rb
+++ b/spec/build/addons/deploy_spec.rb
@@ -49,6 +49,19 @@ describe Travis::Build::Addons::Deploy, :sexp do
     it { should match_sexp [:if, '(-z $TRAVIS_PULL_REQUEST) && ($TRAVIS_BRANCH = staging || $TRAVIS_BRANCH = production)'] }
   end
 
+  describe 'option specific Ruby version' do
+    let(:config) { { provider: 'heroku', on: { ruby: 'foo' } } }
+
+    it { should match_sexp [:if, '($TRAVIS_BRANCH = master) && ($TRAVIS_RUBY_VERSION = foo)'] }
+  end
+
+  describe 'option specific Rust version' do
+    let(:data)   { super().merge(language: 'rust') }
+    let(:config) { { provider: 'heroku', on: { rust: 'stable', branch: 'bar' } } }
+
+    it { should match_sexp [:if, '($TRAVIS_BRANCH = bar) && ($TRAVIS_RUST_VERSION = stable)'] }
+  end
+
   context 'when edge dpl is tested' do
     let(:data)   { super().merge(branch: 'staging') }
     let(:config) { { provider: 'heroku', edge: { source: 'svenvfuchs/dpl', branch: 'foo' } } }


### PR DESCRIPTION
Resolves https://github.com/travis-ci/travis-ci/issues/4878

This adds language shortcuts for deployment conditions:

```yaml
deploy:
  provider: script
  script: do-something.sh
  skip_cleanup: true
  on:
    tags: true
    rust: stable
```