### PR TITLE
bump default neko version for "language: haxe" to 2.1.0

### DIFF
--- a/lib/travis/build/script/haxe.rb
+++ b/lib/travis/build/script/haxe.rb
@@ -18,7 +18,7 @@ module Travis
       class Haxe < Script
         DEFAULTS = {
           haxe: '3.2.1',
-          neko: '2.0.0'
+          neko: '2.1.0'
         }
 
         def configure


### PR DESCRIPTION
Neko 2.1.0 has been released. Existing Neko programs should run fine with this new release, so let's bump the default Neko version.