### PR TITLE
Allow HHVM LTS version specification

### DIFF
--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -84,6 +84,14 @@ module Travis
         end
 
         def configure_hhvm
+          sh.raw <<-HHVM
+declare -A hhvm_lts_versions
+hhvm_lts_versions[0]="trusty-lts-3.3"
+hhvm_lts_versions[1]="trusty-lts-3.6"
+hhvm_lts_versions[2]="trusty-lts-3.9"
+hhvm_lts_versions[3]="trusty-lts-3.12"
+          HHVM
+
           if nightly?
             install_hhvm_nightly
           elsif hhvm?
@@ -99,6 +107,11 @@ module Travis
               sh.if "! $(grep -r hhvm\\.com /etc/apt/sources* 2>/dev/null)" do
                 sh.cmd 'sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0x5a16e7281be7a449'
                 sh.cmd 'echo "deb http://dl.hhvm.com/ubuntu $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list'
+                sh.raw <<-ADD_HHVM_LTS
+for version in ${hhvm_lts_versions[*]}; do
+  echo "deb http://dl.hhvm.com/ubuntu $version main" | sudo tee -a /etc/apt/sources.list
+done
+                ADD_HHVM_LTS
               end
               sh.cmd 'sudo apt-get update -qq'
               vers_suffix = "=#{hhvm_version}" if hhvm_version

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -106,12 +106,16 @@ hhvm_lts_versions[3]="trusty-lts-3.12"
               sh.echo "Updating HHVM", ansi: :yellow
               sh.if "! $(grep -r hhvm\\.com /etc/apt/sources* 2>/dev/null)" do
                 sh.cmd 'sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0x5a16e7281be7a449'
-                sh.cmd 'echo "deb http://dl.hhvm.com/ubuntu $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list'
-                sh.raw <<-ADD_HHVM_LTS
+                if hhvm_version
+                  sh.raw <<-ADD_HHVM_LTS
 for version in ${hhvm_lts_versions[*]}; do
   echo "deb http://dl.hhvm.com/ubuntu $version main" | sudo tee -a /etc/apt/sources.list
 done
-                ADD_HHVM_LTS
+                  ADD_HHVM_LTS
+                else
+                  # use latest
+                  sh.cmd 'echo "deb http://dl.hhvm.com/ubuntu $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list'
+                end
               end
               sh.cmd 'sudo apt-get update -qq'
               vers_suffix = "=#{hhvm_version}" if hhvm_version

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -19,13 +19,15 @@ module Travis
 
         def setup
           super
-          unless hhvm?
+          if hhvm?
+            sh.cmd "phpenv global hhvm", assert: true
+          else
             sh.cmd "phpenv global #{version} 2>/dev/null", assert: false
             sh.if "$? -ne 0" do
               install_php_on_demand(version)
             end
+            sh.cmd "phpenv global #{version}", assert: true
           end
-          sh.cmd "phpenv global #{version}", assert: true
           sh.cmd "phpenv rehash", assert: false, echo: false, timing: false
           composer_self_update
         end

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -106,23 +106,22 @@ hhvm_lts_versions[3]="trusty-lts-3.12"
               sh.echo "Updating HHVM", ansi: :yellow
               sh.raw 'sudo sed -e "/hhvm\\.com/d" -i.bak /etc/apt/sources.list'
 
-              sh.cmd 'sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0x5a16e7281be7a449'
               if hhvm_version
                 sh.raw <<-ADD_HHVM_LTS
 for version in ${hhvm_lts_versions[*]}; do
   echo "deb http://dl.hhvm.com/ubuntu $version main" | sudo tee -a /etc/apt/sources.list
 done
                 ADD_HHVM_LTS
+                sh.raw 'sudo apt-get purge hhvm >&/dev/null'
               else
                 # use latest
                 sh.cmd 'echo "deb http://dl.hhvm.com/ubuntu $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list'
               end
 
+              sh.cmd 'sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0x5a16e7281be7a449'
               sh.cmd 'sudo apt-get update -qq'
-              vers_suffix = "=#{hhvm_version}" if hhvm_version
+              vers_suffix = "=#{hhvm_version}~$(lsb_release -sc)" if hhvm_version
               sh.cmd "sudo apt-get install -y hhvm#{vers_suffix}", timing: true
-              if hhvm_version
-                sh.cmd ""
             end
           end
         end

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -98,10 +98,10 @@ module Travis
           sh.if '"$(lsb_release -sc 2>/dev/null)"' do
             sh.fold 'update.hhvm', ansi: :yellow do
               sh.echo "Updating HHVM", ansi: :yellow
-              sh.raw 'sudo sed -e "/hhvm\\.com/d" -i.bak /etc/apt/sources.list'
+              sh.raw 'sudo find /etc/apt -type f -exec sed -e "/hhvm\\.com/d" -i.bak {} \;'
 
               if hhvm_version
-                sh.raw "echo \"deb http://dl.hhvm.com/ubuntu $(lsb_release -sc)-lts-#{hhvm_version} main\" | sudo tee -a /etc/apt/sources.list"
+                sh.raw "echo \"deb http://dl.hhvm.com/ubuntu $(lsb_release -sc)-lts-#{hhvm_version} main\" | sudo tee -a /etc/apt/sources.list >&/dev/null"
                 sh.raw 'sudo apt-get purge hhvm >&/dev/null'
               else
                 # use latest

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -110,7 +110,7 @@ module Travis
 
               sh.cmd 'sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0x5a16e7281be7a449'
               sh.cmd 'sudo apt-get update -qq'
-              sh.cmd "sudo apt-get install -y hhvm", timing: true
+              sh.cmd "sudo apt-get install -y hhvm", timing: true, echo: true, assert: true
             end
           end
         end

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -104,22 +104,25 @@ hhvm_lts_versions[3]="trusty-lts-3.12"
           sh.if '"$(lsb_release -sc 2>/dev/null)"' do
             sh.fold 'update.hhvm', ansi: :yellow do
               sh.echo "Updating HHVM", ansi: :yellow
-              sh.if "! $(grep -r hhvm\\.com /etc/apt/sources* 2>/dev/null)" do
-                sh.cmd 'sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0x5a16e7281be7a449'
-                if hhvm_version
-                  sh.raw <<-ADD_HHVM_LTS
+              sh.raw 'sudo sed -e "/hhvm\\.com/d" -i.bak /etc/apt/sources.list'
+
+              sh.cmd 'sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0x5a16e7281be7a449'
+              if hhvm_version
+                sh.raw <<-ADD_HHVM_LTS
 for version in ${hhvm_lts_versions[*]}; do
   echo "deb http://dl.hhvm.com/ubuntu $version main" | sudo tee -a /etc/apt/sources.list
 done
-                  ADD_HHVM_LTS
-                else
-                  # use latest
-                  sh.cmd 'echo "deb http://dl.hhvm.com/ubuntu $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list'
-                end
+                ADD_HHVM_LTS
+              else
+                # use latest
+                sh.cmd 'echo "deb http://dl.hhvm.com/ubuntu $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list'
               end
+
               sh.cmd 'sudo apt-get update -qq'
               vers_suffix = "=#{hhvm_version}" if hhvm_version
               sh.cmd "sudo apt-get install -y hhvm#{vers_suffix}", timing: true
+              if hhvm_version
+                sh.cmd ""
             end
           end
         end

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -70,7 +70,7 @@ module Travis
 
         def hhvm_version
           return unless hhvm?
-          if vers = version.scan(/-(\d+(?:\.\d+)?)$/).first
+          if vers = version.scan(/-(\d+(?:\.\d+)*)$/).first
             vers.first
           end
         end

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -65,7 +65,14 @@ module Travis
         end
 
         def hhvm?
-          version.include?('hhvm')
+          version.start_with?('hhvm')
+        end
+
+        def hhvm_version
+          return unless hhvm?
+          if vers = version.scan(/-(\d+(?:\.\d+)?)$/).first
+            vers.first
+          end
         end
 
         def nightly?
@@ -94,7 +101,8 @@ module Travis
                 sh.cmd 'echo "deb http://dl.hhvm.com/ubuntu $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list'
               end
               sh.cmd 'sudo apt-get update -qq'
-              sh.cmd 'sudo apt-get install -y hhvm', timing: true
+              vers_suffix = "=#{hhvm_version}" if hhvm_version
+              sh.cmd "sudo apt-get install -y hhvm#{vers_suffix}", timing: true
             end
           end
         end

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -86,14 +86,6 @@ module Travis
         end
 
         def configure_hhvm
-          sh.raw <<-HHVM
-declare -A hhvm_lts_versions
-hhvm_lts_versions[0]="trusty-lts-3.3"
-hhvm_lts_versions[1]="trusty-lts-3.6"
-hhvm_lts_versions[2]="trusty-lts-3.9"
-hhvm_lts_versions[3]="trusty-lts-3.12"
-          HHVM
-
           if nightly?
             install_hhvm_nightly
           elsif hhvm?
@@ -109,11 +101,7 @@ hhvm_lts_versions[3]="trusty-lts-3.12"
               sh.raw 'sudo sed -e "/hhvm\\.com/d" -i.bak /etc/apt/sources.list'
 
               if hhvm_version
-                sh.raw <<-ADD_HHVM_LTS
-for version in ${hhvm_lts_versions[*]}; do
-  echo "deb http://dl.hhvm.com/ubuntu $version main" | sudo tee -a /etc/apt/sources.list
-done
-                ADD_HHVM_LTS
+                sh.raw "echo \"deb http://dl.hhvm.com/ubuntu $(lsb_release -sc)-lts-#{hhvm_version} main\" | sudo tee -a /etc/apt/sources.list"
                 sh.raw 'sudo apt-get purge hhvm >&/dev/null'
               else
                 # use latest

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -110,8 +110,7 @@ module Travis
 
               sh.cmd 'sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0x5a16e7281be7a449'
               sh.cmd 'sudo apt-get update -qq'
-              vers_suffix = "=#{hhvm_version}~$(lsb_release -sc)" if hhvm_version
-              sh.cmd "sudo apt-get install -y hhvm#{vers_suffix}", timing: true
+              sh.cmd "sudo apt-get install -y hhvm", timing: true
             end
           end
         end

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -72,8 +72,8 @@ module Travis
 
         def hhvm_version
           return unless hhvm?
-          if vers = version.scan(/-(\d+(?:\.\d+)*)$/).first
-            vers.first
+          if match_data = /-(\d+(?:\.\d+)*)$/.match(version)
+            match_data[1]
           end
         end
 

--- a/spec/build/script/php_spec.rb
+++ b/spec/build/script/php_spec.rb
@@ -61,9 +61,10 @@ describe Travis::Build::Script::Php, :sexp do
   end
 
   describe 'installs specific hhvm version' do
-    before { data[:config][:php] = 'hhvm-4.12' }
+    before { data[:config][:php] = 'hhvm-3.12' }
     it { should include_sexp [:cmd, 'sudo apt-get update -qq'] }
-    it { should include_sexp [:cmd, 'sudo apt-get install -y hhvm=4.12', timing: true] }
+    it { should include_sexp [:cmd, 'sudo apt-get install -y hhvm', timing: true] }
+    it { should include_sexp [:raw, "echo \"deb http://dl.hhvm.com/ubuntu $(lsb_release -sc)-lts-3.12 main\" | sudo tee -a /etc/apt/sources.list >&/dev/null"] }
   end
 
   describe 'when desired PHP version is not found' do

--- a/spec/build/script/php_spec.rb
+++ b/spec/build/script/php_spec.rb
@@ -63,7 +63,7 @@ describe Travis::Build::Script::Php, :sexp do
   describe 'installs specific hhvm version' do
     before { data[:config][:php] = 'hhvm-3.12' }
     it { should include_sexp [:cmd, 'sudo apt-get update -qq'] }
-    it { should include_sexp [:cmd, 'sudo apt-get install -y hhvm', timing: true] }
+    it { should include_sexp [:cmd, 'sudo apt-get install -y hhvm', timing: true, assert: true, echo: true] }
     it { should include_sexp [:raw, "echo \"deb http://dl.hhvm.com/ubuntu $(lsb_release -sc)-lts-3.12 main\" | sudo tee -a /etc/apt/sources.list >&/dev/null"] }
   end
 

--- a/spec/build/script/php_spec.rb
+++ b/spec/build/script/php_spec.rb
@@ -60,6 +60,12 @@ describe Travis::Build::Script::Php, :sexp do
     it { should include_sexp [:cmd, 'sudo apt-get install hhvm-nightly -y 2>&1 >/dev/null'] }
   end
 
+  describe 'installs specific hhvm version' do
+    before { data[:config][:php] = 'hhvm-4.12' }
+    it { should include_sexp [:cmd, 'sudo apt-get update -qq'] }
+    it { should include_sexp [:cmd, 'sudo apt-get install -y hhvm=4.12', timing: true] }
+  end
+
   describe 'when desired PHP version is not found' do
     let(:version) { '7.0.0beta2' }
     let(:data) { payload_for(:push, :php, config: { php: version }) }


### PR DESCRIPTION
See https://github.com/travis-ci/travis-ci/issues/6043 for motivation.

This PR allows HHVM LTS versions to be specified in `.travis.yml`, e.g.,

```yaml
language: php
php:
  - hhvm # latest
  - hhvm-3.12 # LTS version
  - hhvm-3.11 # not a valid LTS version, so the build errrors
```