### PR TITLE
Fix APT addon when running on GCE and disallowed source is listed

### DIFF
--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -75,6 +75,7 @@ module Travis
 
             whitelisted = []
             disallowed = []
+            disallowed_while_sudo = []
 
             config_sources.each do |src|
               source = source_whitelist[src]
@@ -82,14 +83,18 @@ module Travis
               if source.respond_to?(:[]) && source['sourceline']
                 whitelisted << source.clone
               elsif ! data.disable_sudo?
-                if src.respond_to?(:has_key?) && src.has_key?(:sourceline)
-                  whitelisted << {
-                    'sourceline' => src[:sourceline],
-                    'key_url' => src[:key_url]
-                  }
+                if src.respond_to?(:has_key?)
+                  if src.has_key?(:sourceline)
+                    whitelisted << {
+                      'sourceline' => src[:sourceline],
+                      'key_url' => src[:key_url]
+                    }
+                  else
+                    sh.echo "`sourceline` key missing:", ansi: :yellow
+                    sh.echo Shellwords.escape(src.inspect)
+                  end
                 else
-                  sh.echo "`sourceline` key missing:", ansi: :yellow
-                  sh.echo Shellwords.escape(src.inspect)
+                  disallowed_while_sudo << src
                 end
               elsif source.nil?
                 disallowed << src
@@ -101,6 +106,12 @@ module Travis
               sh.echo 'If you require these sources, please review the source ' \
                 'approval process at: ' \
                 'https://github.com/travis-ci/apt-source-whitelist#source-approval-process'
+            end
+
+            unless disallowed_while_sudo.empty?
+              sh.echo "Disallowing sources: #{disallowed_while_sudo.map { |source| Shellwords.escape(source) }.join(', ')}", ansi: :red
+              sh.echo "To add unlisted APT sources, follow instructions in " \
+                "https://docs.travis-ci.com/user/installing-dependencies#Installing-Packages-with-the-APT-Addon"
             end
 
             unless whitelisted.empty?

--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -82,7 +82,7 @@ module Travis
               if source.respond_to?(:[]) && source['sourceline']
                 whitelisted << source.clone
               elsif ! data.disable_sudo?
-                if src.respond_to?(:[]) && src[:sourceline]
+                if src.respond_to?(:has_key?) && src.has_key?(:sourceline)
                   whitelisted << {
                     'sourceline' => src[:sourceline],
                     'key_url' => src[:key_url]

--- a/spec/build/addons/apt_spec.rb
+++ b/spec/build/addons/apt_spec.rb
@@ -209,7 +209,7 @@ describe Travis::Build::Addons::Apt, :sexp do
 
     context 'when sudo is enabled' do
       let(:paranoid) { false }
-      let(:config) { { sources: ['packagecloud-precise', 'deadsnakes-precise', { sourceline: 'foobar', key_url: 'deadbeef' }] } }
+      let(:config) { { sources: ['packagecloud-precise', 'deadsnakes-precise', 'ppa:archivematica/externals', { sourceline: 'foobar', key_url: 'deadbeef' }] } }
 
       it { should include_sexp [:cmd, apt_sources_append_command(packagecloud['sourceline']), echo: true, assert: true, timing: true] }
       it { should include_sexp [:cmd, apt_add_repository_command(deadsnakes['sourceline']), echo: true, assert: true, timing: true] }

--- a/spec/build/addons/apt_spec.rb
+++ b/spec/build/addons/apt_spec.rb
@@ -153,6 +153,13 @@ describe Travis::Build::Addons::Apt, :sexp do
       }
     end
 
+    let(:evilbadthings) do
+      {
+        'alias' => 'evilbadthings',
+        'sourceline' => 'deb https://evilbadthings.com/chef/stable/ubuntu/ precise main'
+      }
+    end
+
     let(:source_whitelist) do
       {
         'deadsnakes-precise' => deadsnakes,
@@ -185,11 +192,13 @@ describe Travis::Build::Addons::Apt, :sexp do
     end
 
     context 'with multiple sources, some whitelisted' do
-      let(:config) { { sources: ['packagecloud-precise', 'deadsnakes-precise', 'evilbadthings', { sourceline: 'foobar', key_url: 'deadbeef' }] } }
+      let(:config) { { sources: ['packagecloud-precise', 'deadsnakes-precise', 'evilbadthings', 'ppa:evilbadppa', { sourceline: 'foobar', key_url: 'deadbeef' }] } }
 
       it { should include_sexp [:cmd, apt_sources_append_command(packagecloud['sourceline']), echo: true, assert: true, timing: true] }
       it { should include_sexp [:cmd, apt_add_repository_command(deadsnakes['sourceline']), echo: true, assert: true, timing: true] }
       it { should include_sexp [:cmd, apt_key_add_command(packagecloud['key_url']), echo: true, assert: true, timing: true] }
+      it { should_not include_sexp [:cmd, apt_sources_append_command(evilbadthings['sourceline']), echo: true, assert: true, timing: true] }
+      it { should_not include_sexp [:cmd, apt_add_repository_command('ppa:evilbadppa'), echo: true, assert: true, timing: true] }
       it { should_not include_sexp [:cmd, apt_key_add_command(deadsnakes['key_url']), echo: true, assert: true, timing: true] }
       it { should_not include_sexp [:cmd, apt_sources_append_command('foobar'), echo: true, assert: true, timing: true] }
       it { should_not include_sexp [:cmd, apt_key_add_command('deadbeef'), echo: true, assert: true, timing: true] }
@@ -209,13 +218,15 @@ describe Travis::Build::Addons::Apt, :sexp do
 
     context 'when sudo is enabled' do
       let(:paranoid) { false }
-      let(:config) { { sources: ['packagecloud-precise', 'deadsnakes-precise', 'ppa:archivematica/externals', { sourceline: 'foobar', key_url: 'deadbeef' }] } }
+      let(:config) { { sources: ['packagecloud-precise', 'deadsnakes-precise', 'evilbadthings', 'ppa:archivematica/externals', { sourceline: 'foobar', key_url: 'deadbeef' }] } }
 
       it { should include_sexp [:cmd, apt_sources_append_command(packagecloud['sourceline']), echo: true, assert: true, timing: true] }
       it { should include_sexp [:cmd, apt_add_repository_command(deadsnakes['sourceline']), echo: true, assert: true, timing: true] }
       it { should include_sexp [:cmd, apt_key_add_command(packagecloud['key_url']), echo: true, assert: true, timing: true] }
       it { should include_sexp [:cmd, apt_sources_append_command('foobar'), echo: true, assert: true, timing: true] }
       it { should include_sexp [:cmd, apt_key_add_command('deadbeef'), echo: true, assert: true, timing: true] }
+      it { should_not include_sexp [:cmd, apt_sources_append_command(evilbadthings['sourceline']), echo: true, assert: true, timing: true] }
+      it { should_not include_sexp [:cmd, apt_add_repository_command('ppa:evilbadppa'), echo: true, assert: true, timing: true] }
 
       context 'when a malformed source is given' do
         let(:config) { { sources: [{ key_url: 'deadbeef' }] } }


### PR DESCRIPTION
Currently, when a disallowed APT source is listed (https://github.com/BanzaiMan/travis_production_test/blob/31ecb77d0ccdfc8349a88170021049d6d2855735/.travis.yml) and the build runs on GCE, the build script fails to be compiled, and we only get:

```
An error occurred while generating the build script.
```

which is not very helpful.

