### PR TITLE
Warn about LLVM APT source if C/C++ compiler is clang

### DIFF
--- a/lib/travis/build/script/c.rb
+++ b/lib/travis/build/script/c.rb
@@ -5,6 +5,9 @@ module Travis
         DEFAULTS = {
           compiler: 'gcc'
         }
+        LLVM_APT_REPO_MSG = "The LLVM APT rpository is currently available. " \
+          "Your builds may fail if your build updates LLVM/clang to a newer version with 'apt'. " \
+          "Please see https://github.com/travis-ci/travis-ci/issues/6120#issuecomment-224072540 for a workaround."
 
         def export
           super
@@ -16,6 +19,9 @@ module Travis
 
         def announce
           super
+          if compiler.include? 'clang'
+            sh.echo LLVM_APT_REPO_MSG, ansi: :yellow
+          end
           sh.cmd "#{compiler} --version"
         end
 

--- a/lib/travis/build/script/cpp.rb
+++ b/lib/travis/build/script/cpp.rb
@@ -5,6 +5,9 @@ module Travis
         DEFAULTS = {
           compiler: 'g++'
         }
+        LLVM_APT_REPO_MSG = "The LLVM APT rpository is currently available. " \
+          "Your builds may fail if your build updates LLVM/clang to a newer version with 'apt'. " \
+          "Please see https://github.com/travis-ci/travis-ci/issues/6120#issuecomment-224072540 for a workaround."
 
         def export
           super
@@ -17,6 +20,9 @@ module Travis
 
         def announce
           super
+          if compiler.include? 'clang'
+            sh.echo LLVM_APT_REPO_MSG, ansi: :yellow
+          end
           sh.cmd "#{compiler} --version"
         end
 


### PR DESCRIPTION
When one of the following conditions holds, we display a warning message to raise awareness to the unavailability of the LLVM APT source:

* When the `apt` addon is used to add `llvm-*` sources
* When the build proceeds to the `announce` stage (because `apt` addon runs successfully, meaning that the configured sources are fine), and the `compiler` value includes `clang`.

The message is:

```
The LLVM APT rpository is currently available. Your builds may fail if your build updates LLVM/clang to a newer version with 'apt'. Please see https://github.com/travis-ci/travis-ci/issues/6120#issuecomment-224072540 for a workaround.
```

See https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/494117#L130 for an example build.