### PR TITLE
Optionally turn off appliances with configuration

### DIFF
--- a/lib/travis/build/appliances/base.rb
+++ b/lib/travis/build/appliances/base.rb
@@ -1,4 +1,5 @@
 require 'forwardable'
+require 'active_support/core_ext/string/inflections.rb'
 
 module Travis
   module Build
@@ -9,7 +10,13 @@ module Travis
         def_delegators :script, :sh, :data, :config
 
         def apply?
-          true
+          data.appliances_switches.fetch( to_key, true)
+        end
+
+        private
+
+        def to_key
+          self.class.name.split('::').last.underscore.to_sym
         end
       end
     end

--- a/lib/travis/build/data.rb
+++ b/lib/travis/build/data.rb
@@ -156,6 +156,10 @@ module Travis
       def debug_options
         job[:debug_options] || {}
       end
+
+      def appliances_switches
+        data[:appliances_switches] || {}
+      end
     end
   end
 end

--- a/spec/build/script/shared/appliances/update_glibc.rb
+++ b/spec/build/script/shared/appliances/update_glibc.rb
@@ -1,0 +1,21 @@
+shared_examples_for 'update glibc' do
+  let(:update_glibc) {
+    <<-EOF
+if [ ! $(uname|grep Darwin) ]; then
+  sudo -E apt-get -yq update 2>&1 >> ~/apt-get-update.log
+  sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install libc6
+fi
+    EOF
+  }
+  it 'updates glibc' do
+    should include_sexp [:cmd, update_glibc]
+  end
+
+  it 'skips updating glibc if disabled in config' do
+    data[:appliances_switches] = {
+      :update_glibc => false
+    }
+    should_not include_sexp [:cmd, update_glibc]
+  end
+
+end

--- a/spec/build/script/shared/script.rb
+++ b/spec/build/script/shared/script.rb
@@ -48,6 +48,7 @@ shared_examples_for 'a build script sexp' do
   it_behaves_like 'fix ps4'
   it_behaves_like 'fix etc/hosts'
   it_behaves_like 'fix resolve.conf'
+  it_behaves_like 'update glibc'
   it_behaves_like 'put localhost first in etc/hosts'
   it_behaves_like 'starts services'
   it_behaves_like 'build script stages'


### PR DESCRIPTION
Under some circumstances, it is desirable to skip running appliances;
e.g., for Travis Enterprise, running update_glibc appliances
can be considered unnecessary, because the builds run inside a
firewall.