### PR TITLE
Install Rebar as well as Hex in Elixir builds

### DIFF
--- a/lib/travis/build/script/elixir.rb
+++ b/lib/travis/build/script/elixir.rb
@@ -44,6 +44,7 @@ export MIX_ARCHIVES=#{KIEX_MIX_HOME}elixir-#{elixir_version}' > #{KIEX_ELIXIR_HO
 
         def install
           sh.cmd 'mix local.hex --force', fold: "install.hex"
+          sh.cmd 'mix local.rebar --force', fold: "install.rebar"
           sh.cmd 'mix deps.get', fold: "install.deps"
         end
 


### PR DESCRIPTION
Use case: https://travis-ci.org/zackehh/siphash-elixir/jobs/139247149

Right now if an Elixir dependency requires Rebar, a build will simply hang waiting for input. I think it would be better to have the build script install this the same way it does Hex, rather than having users need to know to add it to their install setups.