### PR TITLE
Consider `deploy.environment` value when finidng default branch

### DIFF
--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -151,7 +151,8 @@ module Travis
             end
 
             def default_branches
-              config[:app].respond_to?(:keys) ? config[:app].keys : 'master'
+              default_branches = config.values.grep(Hash).map(&:keys).flatten(1).uniq.compact
+              default_branches.any? ? default_branches : 'master'
             end
 
             def option(key, value)

--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -151,7 +151,7 @@ module Travis
             end
 
             def default_branches
-              default_branches = config.values.grep(Hash).map(&:keys).flatten(1).uniq.compact
+              default_branches = config.except(:edge).values.grep(Hash).map(&:keys).flatten(1).uniq.compact
               default_branches.any? ? default_branches : 'master'
             end
 

--- a/spec/build/addons/deploy_spec.rb
+++ b/spec/build/addons/deploy_spec.rb
@@ -62,6 +62,13 @@ describe Travis::Build::Addons::Deploy, :sexp do
     it { should match_sexp [:if, '($TRAVIS_BRANCH = bar) && ($TRAVIS_RUST_VERSION = stable)'] }
   end
 
+  context 'when edge dpl is tested' do
+    let(:data)   { super().merge(branch: 'staging') }
+    let(:config) { { provider: 'heroku', edge: { source: 'svenvfuchs/dpl', branch: 'foo' } } }
+
+    it { should match_sexp [:if, '(-z $TRAVIS_PULL_REQUEST) && ($TRAVIS_BRANCH = master)'] }
+  end
+
   describe 'on tags' do
     let(:config) { { provider: 'heroku', on: { tags: true } } }
 

--- a/spec/build/addons/deploy_spec.rb
+++ b/spec/build/addons/deploy_spec.rb
@@ -62,13 +62,6 @@ describe Travis::Build::Addons::Deploy, :sexp do
     it { should match_sexp [:if, '($TRAVIS_BRANCH = bar) && ($TRAVIS_RUST_VERSION = stable)'] }
   end
 
-  context 'when edge dpl is tested' do
-    let(:data)   { super().merge(branch: 'staging') }
-    let(:config) { { provider: 'heroku', edge: { source: 'svenvfuchs/dpl', branch: 'foo' } } }
-
-    it { should match_sexp [:if, '(-z $TRAVIS_PULL_REQUEST) && ($TRAVIS_BRANCH = master)'] }
-  end
-
   describe 'on tags' do
     let(:config) { { provider: 'heroku', on: { tags: true } } }
 


### PR DESCRIPTION
This is a continuation of @39323f0, which addressed the issue of
finding the default branch name for deployment for Heroku.

In addition to the `app` key, we support the `environment` key value
in `engineyard` provider.
This was omitted in the previous commit, leading to
https://github.com/travis-ci/travis-ci/issues/6212

Thus, this commit resolves https://github.com/travis-ci/travis-ci/issues/6212