### PR TITLE
Skip `deploy.edge` when looking for branch names for deployment

### DIFF
--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -151,7 +151,8 @@ module Travis
             end
 
             def default_branches
-              config[:app].respond_to?(:keys) ? config[:app].keys : 'master'
+              default_branches = config.except(:edge).values.grep(Hash).map(&:keys).flatten(1).uniq.compact
+              default_branches.any? ? default_branches : 'master'
             end
 
             def option(key, value)


### PR DESCRIPTION
Instead of gathering the branches in `deploy.*.app` key values,
we revert to the old logic of scraping `deploy.*.*`, except
`deploy.edge.*`.
`deploy.edge` is used for dpl testing instead. Using it for
inspecting branch names is wrong, and can lead to
https://github.com/travis-ci/travis-ci/issues/6212.