### PR TITLE
Fix sexp matcher bug

### DIFF
--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -101,8 +101,11 @@ module Travis
 
             def branch_condition
               return if on[:all_branches] || on[:tags]
-              branches  = Array(on[:branch] || default_branches)
-              branches.map { |b| "$TRAVIS_BRANCH = #{Array(b).first}" }.join(' || ')
+
+              branch_config = on[:branch].respond_to?(:keys) ? on[:branch].keys : on[:branch]
+
+              branches  = Array(branch_config || default_branches)
+              branches.map { |b| "$TRAVIS_BRANCH = #{b}" }.join(' || ')
             end
 
             def tags_condition

--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -102,7 +102,7 @@ module Travis
             def branch_condition
               return if on[:all_branches] || on[:tags]
               branches  = Array(on[:branch] || default_branches)
-              branches.map { |b| "$TRAVIS_BRANCH = #{b}" }.join(' || ')
+              branches.map { |b| "$TRAVIS_BRANCH = #{Array(b).first}" }.join(' || ')
             end
 
             def tags_condition

--- a/spec/build/addons/deploy_spec.rb
+++ b/spec/build/addons/deploy_spec.rb
@@ -80,7 +80,7 @@ describe Travis::Build::Addons::Deploy, :sexp do
   describe 'on tags' do
     let(:config) { { provider: 'heroku', on: { tags: true } } }
 
-    it { should match_sexp [:if, '($TRAVIS_BRANCH = master) && (-n $TRAVIS_TAG)'] }
+    it { should match_sexp [:if, '("$TRAVIS_TAG" != "")'] }
   end
 
   describe 'multiple providers' do

--- a/spec/spec_helpers/sexp.rb
+++ b/spec/spec_helpers/sexp.rb
@@ -26,7 +26,7 @@ module SpecHelpers
     end
 
     def sexp_find(sexp, *parts)
-      parts.map { |part| sexp = sexp_filter(sexp, part).first }.last || []
+      parts.inject(sexp) { |sexp, part| sexp_filter(sexp, part).first } || []
     end
 
     def sexp_filter(sexp, part, result = [])

--- a/spec/support/matchers/sexp.rb
+++ b/spec/support/matchers/sexp.rb
@@ -1,6 +1,6 @@
 RSpec::Matchers.define :match_sexp do |expected|
   match do |sexp|
-    sexp_find(sexp, expected)
+    sexp_find(sexp, expected).any?
   end
 
   failure_message do |sexp|


### PR DESCRIPTION
This PR does the following to the specs concerning deployment conditions

1. Fix `match_sexp` matcher. The intention of this matcher is to return success if the result returned by `sexp_find` is not empty, but we were only testing if it was a truthy value. Since `[]` is, this matcher always succeeded.
1. Fix incorrect specs. The issue above resulted in many specs that were giving incorrect results; specs had fallen out of sync with the code, but they were not manifest in previous builds.
1. Tweak the `sexp_find` helper. The change makes its recursive nature more readily apparent.

Huge props to @joshcheek, who paired with me and worked out some confusing parts of the code.