### PR TITLE
Fix typo in jvm spec.

### DIFF
--- a/spec/build/script/shared/jvm.rb
+++ b/spec/build/script/shared/jvm.rb
@@ -10,7 +10,7 @@ shared_examples_for 'a jvm build sexp' do
       expect(branch).to include_sexp([:cmd, './gradlew assemble', options])
     end
 
-    it 'runs `gradlew assemble` if build.gradle exists' do
+    it 'runs `gradle assemble` if build.gradle exists' do
       branch = sexp_find(sexp, [:elif, '-f build.gradle'])
       expect(branch).to include_sexp([:cmd, 'gradle assemble', options])
     end


### PR DESCRIPTION
The test checks whether plain gradle is called when no gradle
wrapper is available but the test name talks about gradlew.