### PR TITLE
Add support for maven wrapper

### DIFF
--- a/lib/travis/build/script/shared/jvm.rb
+++ b/lib/travis/build/script/shared/jvm.rb
@@ -27,6 +27,9 @@ module Travis
           sh.elif '-f build.gradle' do
             sh.cmd 'gradle assemble', retry: true, fold: 'install'
           end
+          sh.elif '-f mvnw' do
+            sh.cmd './mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V', retry: true, fold: 'install'
+          end
           sh.elif '-f pom.xml' do
             sh.cmd 'mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V', retry: true, fold: 'install'
           end
@@ -39,6 +42,9 @@ module Travis
           sh.elif '-f build.gradle' do
             sh.cmd 'gradle check'
           end
+          sh.elif '-f mvnw' do
+            sh.cmd './mvnw test -B'
+          end
           sh.elif '-f pom.xml' do
             sh.cmd 'mvn test -B'
           end
@@ -50,4 +56,3 @@ module Travis
     end
   end
 end
-

--- a/spec/build/script/shared/jvm.rb
+++ b/spec/build/script/shared/jvm.rb
@@ -15,6 +15,11 @@ shared_examples_for 'a jvm build sexp' do
       expect(branch).to include_sexp([:cmd, 'gradle assemble', options])
     end
 
+    it 'runs `./mvnw install` if mvnw exists' do
+      branch = sexp_find(sexp, [:elif, '-f mvnw'])
+      expect(branch).to include_sexp([:cmd, './mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V', options])
+    end
+
     it 'runs `mvn install` if pom.xml exists' do
       branch = sexp_find(sexp, [:elif, '-f pom.xml'])
       expect(branch).to include_sexp([:cmd, 'mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V', options])
@@ -33,6 +38,11 @@ shared_examples_for 'a jvm build sexp' do
     it 'runs `gradle check` if build.gradle exists' do
       branch = sexp_find(sexp, [:elif, '-f build.gradle'])
       expect(branch).to include_sexp([:cmd, 'gradle check', options])
+    end
+
+    it 'runs `./mvnw test` if mvnw exists' do
+      branch = sexp_find(sexp, [:elif, '-f mvnw'])
+      expect(branch).to include_sexp([:cmd, './mvnw test -B', options])
     end
 
     it 'runs `mvn test` if pom.xml exists' do


### PR DESCRIPTION
The [maven wrapper project](https://github.com/takari/maven-wrapper) adds a tiny shell script wrapper to maven builds, much like gradlew does for gradle builds. This way users can choose which maven version should be used by specifying it in a special properties files. Maven wrapper will then download the specified maven version to the m2 repository and use it for building the project. The mvnw wrapper script has the same interface as mvn itself.

This PR adds mvnw detection to JVM builds.