### PR TITLE
Fix Crystal builds

### DIFF
--- a/lib/travis/build/script/crystal.rb
+++ b/lib/travis/build/script/crystal.rb
@@ -12,7 +12,7 @@ module Travis
             version = select_version
             return unless version
 
-            sh.cmd %q(wget '#{version[:key][:url]}' -O "$HOME/crystal_repository_key.asc")
+            sh.cmd %Q(wget '#{version[:key][:url]}' -O "$HOME/crystal_repository_key.asc")
             sh.if %q("$(gpg --with-fingerprint "$HOME/crystal_repository_key.asc" | grep "Key fingerprint" | cut -d "=" -f2 | tr -d " ")" != "#{version[:key][:fingerprint]}") do
               sh.failure "The repository key needed to install Crystal did not have the expected fingerprint. Your build was aborted."
             end


### PR DESCRIPTION
We need to use double-quoted string since it contains expansion.