### PR TITLE
add option to remove preinstalled homebrew

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -31,6 +31,7 @@ module Travis
           bioc: 'https://bioconductor.org/biocLite.R',
           bioc_required: false,
           bioc_use_devel: false,
+          disable_homebrew: false,
           r: 'release'
         }
 
@@ -157,6 +158,9 @@ module Travis
 
               setup_bioc if needs_bioc?
               setup_pandoc if config[:pandoc]
+
+              # Removes preinstalled homebrew
+              disable_homebrew if config[:disable_homebrew]
             end
           end
         end
@@ -481,6 +485,15 @@ module Travis
             # Cleanup
             sh.rm "/tmp/#{pandoc_filename}"
           end
+        end
+
+        # Uninstalls the preinstalled homebrew
+        # See FAQ: https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/FAQ.md
+        def disable_homebrew
+          return unless (config[:os] == 'osx')
+          sh.cmd "curl -sSOL https://raw.githubusercontent.com/Homebrew/install/master/uninstall"
+          sh.cmd "sudo ruby uninstall --force"
+          sh.cmd "rm uninstall"
         end
 
         def r_version


### PR DESCRIPTION
In R we need to explicitly test if a package can build on a vanilla OSX, without homebrew. Sometimes having `brew` installed has side effects on the installation, even if no particular brew packages are installed.

This PR adds the option to remove the preinstalled homebrew installation using the official uninstall script provided by the homebrew FAQ.

@jimhester @hadley @craigcitro 