### PR TITLE
Fix Elixir builds: Use HTTPS for installation url

### DIFF
--- a/lib/travis/build/script/elixir.rb
+++ b/lib/travis/build/script/elixir.rb
@@ -27,7 +27,7 @@ module Travis
 
           sh.fold "elixir" do
             sh.if "! -f #{HOME_DIR}/.kiex/elixirs/elixir-#{elixir_version}.env" do
-              archive = "http://repo.hex.pm/builds/elixir/v#{elixir_version}.zip"
+              archive = "https://repo.hex.pm/builds/elixir/v#{elixir_version}.zip"
               sh.echo "Installing Elixir #{elixir_version}"
               sh.cmd "wget #{archive}", assert: true, timing: true
               sh.cmd "unzip -d #{KIEX_ELIXIR_HOME}/elixir-#{elixir_version} v#{elixir_version}.zip 2>&1 > /dev/null", echo: false


### PR DESCRIPTION
Elixir builds are currently broken because of https://github.com/hexpm/hex_web/issues/371.

The build errors with:

> The command "wget http://repo.hex.pm/builds/elixir/v1.3.0.zip" failed and exited with 5 during .

This is the output of that command:

``` sh
wget http://repo.hex.pm/builds/elixir/v1.3.0.zip 
--2016-06-30 02:28:55--  http://repo.hex.pm/builds/elixir/v1.3.0.zip
Resolving repo.hex.pm (repo.hex.pm)... 172.111.75.5
Connecting to repo.hex.pm (repo.hex.pm)|172.111.75.5|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://s3.hex.pm.s3.amazonaws.com/builds/elixir/v1.3.0.zip [following]
--2016-06-30 02:28:56--  https://s3.hex.pm.s3.amazonaws.com/builds/elixir/v1.3.0.zip
Resolving s3.hex.pm.s3.amazonaws.com (s3.hex.pm.s3.amazonaws.com)... 54.231.112.128
Connecting to s3.hex.pm.s3.amazonaws.com (s3.hex.pm.s3.amazonaws.com)|54.231.112.128|:443... connected.
ERROR: no certificate subject alternative name matches
	requested host name ‘s3.hex.pm.s3.amazonaws.com’.
To connect to s3.hex.pm.s3.amazonaws.com insecurely, use `--no-check-certificate'.
```
https version works fine: 

``` sh
wget https://repo.hex.pm/builds/elixir/v1.3.0.zip
--2016-06-30 02:32:23--  https://repo.hex.pm/builds/elixir/v1.3.0.zip
Resolving repo.hex.pm (repo.hex.pm)... 172.111.75.5
Connecting to repo.hex.pm (repo.hex.pm)|172.111.75.5|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 3579706 (3.4M) [application/zip]
Saving to: ‘v1.3.0.zip.3’

100%[====================================================================================================================>] 3,579,706   1.98MB/s   in 1.7s   

2016-06-30 02:32:25 (1.98 MB/s) - ‘v1.3.0.zip.3’ saved [3579706/3579706]
```