### PR TITLE
Allow multiple API auth tokens to be specified in the config

### DIFF
--- a/lib/travis/api/build/app.rb
+++ b/lib/travis/api/build/app.rb
@@ -16,9 +16,13 @@ module Travis
 
           type, token = env['HTTP_AUTHORIZATION'].to_s.split(' ', 2)
 
-          unless type == 'token' && token == ENV['API_TOKEN']
-            halt 403, 'access denied'
+          ENV['API_TOKEN'].split(',').each do |valid_token|
+            if type == 'token' && token == valid_token
+              return
+            end
           end
+
+          halt 403, 'access denied'
         end
 
         configure(:production, :staging) do

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -4,14 +4,22 @@ require 'travis/api/build/app'
 describe Travis::Api::Build::App, :include_sinatra_helpers do
   before do
     set_app described_class.new
-    ENV['API_TOKEN'] = 'the-token'
+    ENV['API_TOKEN'] = 'the-token,the-other-token'
     header('Content-Type', 'application/json')
   end
 
   context '/script' do
-    context 'with the right token' do
+    context 'with the first token in the list' do
       it 'returns a script' do
         header('Authorization', 'token the-token')
+        response = post '/script', {}, input: PAYLOADS[:push].to_json
+        expect(response.body).to start_with('#!/bin/bash')
+      end
+    end
+
+    context 'with the second token in the list' do
+      it 'returns a script' do
+        header('Authorization', 'token the-other-token')
         response = post '/script', {}, input: PAYLOADS[:push].to_json
         expect(response.body).to start_with('#!/bin/bash')
       end


### PR DESCRIPTION
This makes it easier to rotate the tokens when necessary, since you can add the new token to the config, while keeping the old one valid until you're done swapping out the token.

This should be backwards compatible, since String#split on a string without the given separator will just return the string. For example:

    >> "foo".split(",")
    => ["foo"]