### PR TITLE
[csharp] Fix Mono 4.4.1 commands not being available in PATH, causing failed builds

### DIFF
--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -48,6 +48,7 @@ module Travis
               when 'osx'
                 sh.cmd "curl -o \"/tmp/mdk.pkg\" -L #{mono_osx_url}", timing: true, assert: true
                 sh.cmd 'sudo installer -package "/tmp/mdk.pkg" -target "/"', timing: true, assert: true
+                sh.cmd 'eval $(/usr/libexec/path_helper -s)', timing: false, assert: true
               else
                 sh.failure "Operating system not supported: #{config[:os]}"
               end


### PR DESCRIPTION
Mono 4.4.1 switched from installing binaries to /usr/local/bin to adding an entry via /etc/paths.d on OSX.
This has the unfortunate consequence that `mono`, `xbuild` etc. won't be available right away in the same shell session as before (which was the case because /usr/local/bin is in the PATH).

On Travis this then makes the build fail as none of the commands work.
Fixing this by running the path_helper script to update the PATH.

@BanzaiMan can I please get a staging deploy of this when you have time? Thanks.