### PR TITLE
Define BUNDLE_GEMFILE in all cases

### DIFF
--- a/lib/travis/build/script/shared/bundler.rb
+++ b/lib/travis/build/script/shared/bundler.rb
@@ -11,9 +11,7 @@ module Travis
         def setup
           super
 
-          sh.if gemfile? do
-            sh.export 'BUNDLE_GEMFILE', "$PWD/#{config[:gemfile]}"
-          end
+          sh.export 'BUNDLE_GEMFILE', "$PWD/#{config[:gemfile]}"
         end
 
         def announce

--- a/spec/build/script/objective_c_spec.rb
+++ b/spec/build/script/objective_c_spec.rb
@@ -67,7 +67,7 @@ describe Travis::Build::Script::ObjectiveC, :sexp do
 
   describe 'install' do
     it 'runs bundle install if the project is a RubyMotion project' do
-      sexp = sexp_find(sexp_filter(subject, [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}"])[1], [:then])
+      sexp = sexp_find(sexp_filter(subject, [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}"])[0], [:then])
       expect(sexp).to include_sexp [:cmd, 'bundle install --jobs=3 --retry=3', echo: true, timing: true, assert: true, retry: true]
     end
 

--- a/spec/build/script/ruby_spec.rb
+++ b/spec/build/script/ruby_spec.rb
@@ -65,8 +65,7 @@ describe Travis::Build::Script::Ruby, :sexp do
   end
 
   it 'sets BUNDLE_GEMFILE if a gemfile exists' do
-    sexp = sexp_find(subject, [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}"], [:then])
-    expect(sexp).to include_sexp [:export, ['BUNDLE_GEMFILE', '$PWD/Gemfile'], echo: true]
+    should include_sexp [:export, ['BUNDLE_GEMFILE', '$PWD/Gemfile'], echo: true]
   end
 
   it 'sets BUNDLE_GEMFILE from config' do
@@ -88,12 +87,12 @@ describe Travis::Build::Script::Ruby, :sexp do
 
   describe 'install' do
     it 'runs bundle install --deployment if there is a Gemfile and a Gemfile.lock' do
-      sexp = sexp_find(sexp_filter(subject, [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}"])[1], [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}.lock"], [:then])
+      sexp = sexp_find(sexp_filter(subject, [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}"])[0], [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}.lock"], [:then])
       expect(sexp).to include_sexp [:cmd, 'bundle install --jobs=3 --retry=3 --deployment', assert: true, echo: true, timing: true, retry: true]
     end
 
     it "runs bundle install if a Gemfile exists" do
-      sexp = sexp_find(sexp_filter(subject, [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}"])[2], [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}.lock"], [:else])
+      sexp = sexp_find(sexp_filter(subject, [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}"])[1], [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}.lock"], [:else])
       should include_sexp [:cmd, 'bundle install --jobs=3 --retry=3', assert: true, echo: true, timing: true, retry: true]
     end
   end


### PR DESCRIPTION
Even when the file does not exist.

This allows `before_script` to generate the file, and `install` to
use the generated file.