### PR TITLE
PyPy on demand

### DIFF
--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -13,7 +13,7 @@ module Travis
         PYENV_PATH_FILE      = '/etc/profile.d/pyenv.sh'
         TEMP_PYENV_PATH_FILE = '/tmp/pyenv.sh'
 
-        PYPY_VERSION_REGEX   = /\Apypy(?<python_compat_version>\d+)?(-(?<pypy_version>\d+(?:\.\d)*))?\z/
+        PYPY_VERSION_REGEX   = /\Apypy(?<python_compat_version>\d+(\.\d)*)?(-(?<pypy_version>\d+(?:\.\d)*(-[a-z0-9]*)?))?\z/
 
         def export
           super
@@ -124,7 +124,7 @@ module Travis
           end
 
           def pypy_archive_url(vers=config[:python], arch='linux64')
-            pypy? && md = PYPY_VERSION_REGEX.match(vers)
+            return unless pypy? && md = PYPY_VERSION_REGEX.match(vers)
             if md[:python_compat_version] && md[:pypy_version]
               "https://bitbucket.org/pypy/pypy/downloads/pypy%s-v%s-%s.tar.bz2" % [md[:python_compat_version], md[:pypy_version], arch]
             end

--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -110,21 +110,22 @@ module Travis
           end
 
           def install_pypy(version)
-            if pypy_archive_url
-              archive = "pypy.tar.bz2"
-              install_dir = "/usr/local/pypy"
-              sh.cmd "curl -s -L -o #{archive} #{pypy_archive_url}"
-              sh.cmd "mkdir #{install_dir}", sudo: true, echo: false
-              sh.cmd "tar xjf #{archive} -C #{install_dir} --strip-components=1", sudo: true
-              sh.export "PATH", "#{install_dir}/bin:$PATH", echo: true
-              sh.cmd "rm #{archive}", echo: false
-              sh.cmd "rm -f $HOME/virtualenv/pypy{,3}"
-              sh.cmd "virtualenv --distribute --python=/usr/local/pypy/bin/pypy $HOME/virtualenv/#{virtualenv}"
-            end
+            return unless pypy_archive_url
+
+            archive = "pypy.tar.bz2"
+            install_dir = "/usr/local/pypy"
+            sh.cmd "curl -s -L -o #{archive} #{pypy_archive_url}"
+            sh.cmd "mkdir #{install_dir}", sudo: true, echo: false
+            sh.cmd "tar xjf #{archive} -C #{install_dir} --strip-components=1", sudo: true
+            sh.export "PATH", "#{install_dir}/bin:$PATH", echo: true
+            sh.cmd "rm #{archive}", echo: false
+            sh.cmd "rm -f $HOME/virtualenv/pypy{,3}"
+            sh.cmd "virtualenv --distribute --python=/usr/local/pypy/bin/pypy $HOME/virtualenv/#{virtualenv}"
           end
 
           def pypy_archive_url(vers=config[:python], arch='linux64')
             return unless pypy? && md = PYPY_VERSION_REGEX.match(vers)
+
             if md[:python_compat_version] && md[:pypy_version]
               "https://bitbucket.org/pypy/pypy/downloads/pypy%s-v%s-%s.tar.bz2" % [md[:python_compat_version], md[:pypy_version], arch]
             end

--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -118,6 +118,8 @@ module Travis
               sh.cmd "tar xjf #{archive} -C #{install_dir} --strip-components=1", sudo: true
               sh.export "PATH", "#{install_dir}/bin:$PATH", echo: true
               sh.cmd "rm #{archive}", echo: false
+              sh.cmd "rm -f $HOME/virtualenv/pypy{,3}"
+              sh.cmd "virtualenv --distribute --python=/usr/local/pypy/bin/python $HOME/virtualenv/#{virtualenv}"
             end
           end
 

--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -112,8 +112,11 @@ module Travis
           def install_pypy(version)
             if pypy_archive_url
               archive = "pypy.tar.bz2"
+              install_dir = "/usr/local/pypy"
               sh.cmd "curl -s -L -o #{archive} #{pypy_archive_url}"
-              sh.cmd "tar xjf #{archive} -C /usr/local/pypy --strip-components=1", sudo: true
+              sh.cmd "mkdir #{install_dir}", sudo: true, echo: false
+              sh.cmd "tar xjf #{archive} -C #{install_dir} --strip-components=1", sudo: true
+              sh.export "PATH", "#{install_dir}/bin:$PATH", echo: true
               sh.cmd "rm #{archive}", echo: false
             end
           end

--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -119,7 +119,7 @@ module Travis
               sh.export "PATH", "#{install_dir}/bin:$PATH", echo: true
               sh.cmd "rm #{archive}", echo: false
               sh.cmd "rm -f $HOME/virtualenv/pypy{,3}"
-              sh.cmd "virtualenv --distribute --python=/usr/local/pypy/bin/python $HOME/virtualenv/#{virtualenv}"
+              sh.cmd "virtualenv --distribute --python=/usr/local/pypy/bin/pypy $HOME/virtualenv/#{virtualenv}"
             end
           end
 

--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -120,7 +120,13 @@ module Travis
             sh.export "PATH", "#{install_dir}/bin:$PATH", echo: true
             sh.cmd "rm #{archive}", echo: false
             sh.cmd "rm -f $HOME/virtualenv/pypy{,3}"
-            sh.cmd "virtualenv --distribute --python=/usr/local/pypy/bin/pypy $HOME/virtualenv/#{virtualenv}"
+            sh.if "-f /usr/local/pypy/bin/pypy" do
+              sh.cmd "virtualenv --distribute --python=/usr/local/pypy/bin/pypy $HOME/virtualenv/#{virtualenv}"
+            end
+            sh.elif "-f /usr/local/pypy/bin/pypy3" do
+              sh.cmd "virtualenv --distribute --python=/usr/local/pypy/bin/pypy3 $HOME/virtualenv/#{virtualenv}"
+            end
+
           end
 
           def pypy_archive_url(vers=config[:python], arch='linux64')

--- a/spec/build/script/python_spec.rb
+++ b/spec/build/script/python_spec.rb
@@ -78,10 +78,20 @@ describe Travis::Build::Script::Python, :sexp do
     end
 
     context "when pypy version is specified" do
-      it 'fetches PyPy archive' do
-        data[:config][:python] = 'pypy2-5.3.1'
-        should include_sexp [:cmd, "curl -s -L -o pypy.tar.bz2 https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.1-linux64.tar.bz2"]
-        should include_sexp [:cmd, "tar xjf pypy.tar.bz2 -C /usr/local/pypy --strip-components=1", sudo: true ]
+      context "with pypy2-5.3.1" do
+        it 'fetches PyPy archive' do
+          data[:config][:python] = 'pypy2-5.3.1'
+          should include_sexp [:cmd, "curl -s -L -o pypy.tar.bz2 https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.1-linux64.tar.bz2"]
+          should include_sexp [:cmd, "tar xjf pypy.tar.bz2 -C /usr/local/pypy --strip-components=1", sudo: true ]
+        end
+      end
+
+      context "with pypy3.3-5.2.0-alpha1" do
+        it 'fetches PyPy archive' do
+          data[:config][:python] = 'pypy3.3-5.2.0-alpha1'
+          should include_sexp [:cmd, "curl -s -L -o pypy.tar.bz2 https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.2.0-alpha1-linux64.tar.bz2"]
+          should include_sexp [:cmd, "tar xjf pypy.tar.bz2 -C /usr/local/pypy --strip-components=1", sudo: true ]
+        end
       end
     end
   end

--- a/spec/build/script/python_spec.rb
+++ b/spec/build/script/python_spec.rb
@@ -26,11 +26,13 @@ describe Travis::Build::Script::Python, :sexp do
   it 'sets up the python version (pypy)' do
     data[:config][:python] = 'pypy'
     should include_sexp [:cmd,  'source ~/virtualenv/pypy/bin/activate', assert: true, echo: true, timing: true]
+    should_not include_sexp [:cmd, "tar xjf pypy.tar.bz2 -C /usr/local/pypy --strip-components=1", sudo: true]
   end
 
   it 'sets up the python version (pypy3)' do
     data[:config][:python] = 'pypy3'
     should include_sexp [:cmd,  'source ~/virtualenv/pypy3/bin/activate', assert: true, echo: true, timing: true]
+    should_not include_sexp [:cmd, "tar xjf pypy.tar.bz2 -C /usr/local/pypy --strip-components=1", sudo: true]
   end
 
   it 'sets up the python version (2.7)' do
@@ -73,6 +75,14 @@ describe Travis::Build::Script::Python, :sexp do
 
     it 'adds $HOME/.cache/pip to directory cache' do
       should include_sexp [:cmd, 'rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher add $HOME/.cache/pip', timing: true]
+    end
+
+    context "when pypy version is specified" do
+      it 'fetches PyPy archive' do
+        data[:config][:python] = 'pypy2-5.3.1'
+        should include_sexp [:cmd, "curl -s -L -o pypy.tar.bz2 https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.1-linux64.tar.bz2"]
+        should include_sexp [:cmd, "tar xjf pypy.tar.bz2 -C /usr/local/pypy --strip-components=1", sudo: true ]
+      end
     end
   end
 


### PR DESCRIPTION
This PR allows installation of PyPy (both 2 and 3).

With this, users can specify PyPy versions in this way:

```yaml
language: python

python:
  - pypy2-5.3.1
  - pypy3.3-5.2.0-alpha1 # with optional trailing "-[a-z0-9]*"
```