### PR TITLE
[Feature] PyPy on demand with cpython builder

### DIFF
--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -97,10 +97,19 @@ module Travis
           end
 
           def install_python_archive(version = 'nightly')
-            sh.raw archive_url_for('travis-python-archives', version)
-            sh.cmd "curl -s -o python-#{version}.tar.bz2 ${archive_url}", echo: false, assert: true
-            sh.cmd "sudo tar xjf python-#{version}.tar.bz2 --directory /", echo: false, assert: true
-            sh.cmd "rm python-#{version}.tar.bz2", echo: false
+            if version =~ /^pypy/
+              if md = /^(?<interpreter>pypy[^-]*)-(?<version>.*)/.match(version)
+                lang = md[:interpreter]
+                vers = md[:version]
+              end
+            else
+              lang = 'python'
+              vers = version
+            end
+            sh.raw archive_url_for('travis-python-archives', vers, lang)
+            sh.cmd "curl -s -o #{lang}-#{vers}.tar.bz2 ${archive_url}", assert: true
+            sh.cmd "sudo tar xjf #{lang}-#{vers}.tar.bz2 --directory /", echo: false, assert: true
+            sh.cmd "rm #{vers}.tar.bz2", echo: false
           end
 
           def setup_path(version = 'nightly')

--- a/spec/build/script/python_spec.rb
+++ b/spec/build/script/python_spec.rb
@@ -28,6 +28,18 @@ describe Travis::Build::Script::Python, :sexp do
     should include_sexp [:cmd,  'source ~/virtualenv/pypy/bin/activate', assert: true, echo: true, timing: true]
   end
 
+  it 'sets up the python version (pypy-5.3.1)' do
+    data[:config][:python] = 'pypy-5.3.1'
+    should include_sexp [:cmd,  'source ~/virtualenv/pypy-5.3.1/bin/activate', assert: true, echo: true, timing: true]
+    should include_sexp [:cmd,  "curl -s -o pypy-5.3.1.tar.bz2 ${archive_url}", assert: true]
+  end
+
+  it 'sets up the python version (pypy3.3-5.2-alpha1)' do
+    data[:config][:python] = 'pypy3.3-5.2-alpha1'
+    should include_sexp [:cmd,  'source ~/virtualenv/pypy3.3-5.2-alpha1/bin/activate', assert: true, echo: true, timing: true]
+    should include_sexp [:cmd,  "curl -s -o pypy3.3-5.2-alpha1.tar.bz2 ${archive_url}", assert: true]
+  end
+
   it 'sets up the python version (pypy3)' do
     data[:config][:python] = 'pypy3'
     should include_sexp [:cmd,  'source ~/virtualenv/pypy3/bin/activate', assert: true, echo: true, timing: true]


### PR DESCRIPTION
PyPy archives are named `pypy*`, instead of `python-pypy*`, violating the archive URL naming scheme we use here.

Corresponds to https://github.com/travis-ci/cpython-builder/pull/13.