### PR TITLE
Add support for non-AWS S3-compatible caching backend

### DIFF
--- a/lib/travis/build/script/shared/directory_cache/base.rb
+++ b/lib/travis/build/script/shared/directory_cache/base.rb
@@ -41,9 +41,13 @@ module Travis
 
           KeyPair = Struct.new(:id, :secret)
 
-          Location = Struct.new(:scheme, :region, :bucket, :path, :host) do
+          Location = Struct.new(:scheme, :region, :bucket, :path, :host, :bucket_name_in_path) do
             def hostname
-              "#{bucket}.#{host}"
+              if bucket_name_in_path
+                host
+              else
+                "#{bucket}.#{host}"
+              end
             end
           end
 
@@ -203,7 +207,8 @@ module Travis
                 region,
                 data_store_options.fetch(:bucket, ''),
                 path,
-                data_store_options.fetch(:hostname, host_proc.call(region))
+                data_store_options.fetch(:hostname, host_proc.call(region)),
+                data_store_options.fetch(:bucket_name_in_path, false)
               )
             end
 

--- a/lib/travis/build/script/shared/directory_cache/base.rb
+++ b/lib/travis/build/script/shared/directory_cache/base.rb
@@ -208,7 +208,7 @@ module Travis
                 data_store_options.fetch(:bucket, ''),
                 path,
                 data_store_options.fetch(:hostname, host_proc.call(region)),
-                data_store_options.fetch(:bucket_name_in_path, false)
+                data_store_options.fetch(:bucket_name_in_path, true)
               )
             end
 

--- a/lib/travis/build/script/shared/directory_cache/base.rb
+++ b/lib/travis/build/script/shared/directory_cache/base.rb
@@ -212,7 +212,11 @@ module Travis
               if ! extras
                 slug_local = slug.gsub(/^cache(.+?)(?=--)/,'cache')
               end
-              args = [data.github_id, branch, slug_local].compact
+              path_name = nil
+              if data_store_options[:bucket_name_in_path]
+                path_name = data_store_options.fetch(:bucket, '')
+              end
+              args = [path_name, data.github_id, branch, slug_local].compact
               args.map! { |arg| arg.to_s.gsub(/[^\w\.\_\-]+/, '') }
               '/' << args.join('/') << '.tgz'
             end

--- a/lib/travis/build/script/shared/directory_cache/base.rb
+++ b/lib/travis/build/script/shared/directory_cache/base.rb
@@ -218,7 +218,7 @@ module Travis
                 slug_local = slug.gsub(/^cache(.+?)(?=--)/,'cache')
               end
               path_name = nil
-              if data_store_options[:bucket_name_in_path]
+              if data_store_options.fetch([:bucket_name_in_path], true)
                 path_name = data_store_options.fetch(:bucket, '')
               end
               args = [path_name, data.github_id, branch, slug_local].compact

--- a/spec/build/script/directory_cache/gcs_spec.rb
+++ b/spec/build/script/directory_cache/gcs_spec.rb
@@ -24,7 +24,7 @@ describe Travis::Build::Script::DirectoryCache::Gcs, :sexp do
   let(:fetch_url_tgz) { url_tgz }
   let(:push_url)      { signed_url_for(branch, push_signature, 'tgz', timeout) }
 
-  let(:gcs_options)   { { bucket: 's3_bucket', secret_access_key: 'google_secret_access_key', access_key_id: 'google_access_key_id', aws_signature_version: '2' } }
+  let(:gcs_options)   { { bucket: 's3_bucket', secret_access_key: 'google_secret_access_key', access_key_id: 'google_access_key_id', aws_signature_version: '2', bucket_name_in_path: false } }
   let(:cache_options) { { fetch_timeout: 20, push_timeout: 30, type: 'gcs', gcs: gcs_options } }
   let(:data)          { PAYLOADS[:push].deep_merge(config: config, cache_options: cache_options, job: { branch: branch, pull_request: pull_request }) }
   let(:config)        { {} }

--- a/spec/build/script/directory_cache/s3_spec.rb
+++ b/spec/build/script/directory_cache/s3_spec.rb
@@ -23,7 +23,7 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
   let(:fetch_url_tgz) { Shellwords.escape "#{url_tgz}&X-Amz-Expires=20&X-Amz-Signature=#{fetch_signature_tgz}&X-Amz-SignedHeaders=host" }
   let(:push_url)      { Shellwords.escape("#{url}&X-Amz-Expires=30&X-Amz-Signature=#{push_signature}&X-Amz-SignedHeaders=host").gsub(/\.tbz(\?)?/, '.tgz\1') }
 
-  let(:s3_options)    { { bucket: 's3_bucket', secret_access_key: 's3_secret_access_key', access_key_id: 's3_access_key_id' } }
+  let(:s3_options)    { { bucket: 's3_bucket', secret_access_key: 's3_secret_access_key', access_key_id: 's3_access_key_id', bucket_name_in_path: false } }
   let(:cache_options) { { fetch_timeout: 20, push_timeout: 30, type: 's3', s3: s3_options } }
   let(:data)          { PAYLOADS[:push].deep_merge(config: config, cache_options: cache_options, job: { branch: branch, pull_request: pull_request }) }
   let(:config)        { {} }


### PR DESCRIPTION
This PR allows users to specify S3-compatible (with V4 signature) caching backend besides AWS S3.

The scheduler's configuration would look like this:

```yaml
cache_settings:
  builds.docker:
    type: s3
    s3:
      access_key_id: KEY_ID
      secret_access_key: SECRET_ACCESS_KEY
      hostname: MINIO_SERVER_HOSTNAME
      bucket: BUCKET_NAME
      scheme: http
      bucket_name_in_path: true
      aws_signature_version: '4'
    fetch_timeout: 1200
    push_timeout: 7200
```

I have tested this with [Minio](https://minio.io).

Note that `bucket_name_in_path: true` is now the default, so for our services, `bucket_name_in_path: false` should be defined.