### PR TITLE
Update gimme version, go default, and go version normalization

### DIFF
--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -9,11 +9,11 @@ module Travis
           gimme_config: {
             url: "#{ENV.fetch(
               'TRAVIS_BUILD_GIMME_URL',
-              'https://raw.githubusercontent.com/travis-ci/gimme/v0.2.4/gimme'
+              'https://raw.githubusercontent.com/travis-ci/gimme/v1.0.0/gimme'
             )}".untaint,
             force_reinstall: !!ENV['TRAVIS_BUILD_GIMME_FORCE_REINSTALL']
           },
-          go: "#{ENV.fetch('TRAVIS_BUILD_GO_VERSION', '1.4.1')}".untaint
+          go: "#{ENV.fetch('TRAVIS_BUILD_GO_VERSION', '1.6.2')}".untaint
         }
 
         def export
@@ -132,11 +132,15 @@ module Travis
             v = config[:go].to_s
             case v
             when 'default' then DEFAULTS[:go]
-            when '1' then '1.4.1'
+            when '1', '1.x', '1.x.x' then '1.6.2'
             when '1.0' then '1.0.3'
-            when '1.2' then '1.2.2'
-            when 'go1' then v
-            when 'tip' then v
+            when '1.1.x' then '1.1.2'
+            when '1.2', '1.2.x' then '1.2.2'
+            when '1.3.x' then '1.3.3'
+            when '1.4.x' then '1.4.3'
+            when '1.5.x' then '1.5.4'
+            when '1.6.x' then '1.6.2'
+            when 'go1', 'tip', 'master' then v
             when /^go/ then v.sub(/^go/, '')
             else v
             end
@@ -171,7 +175,7 @@ module Travis
             sh.cmd "chmod +x #{HOME_DIR}/bin/gimme", echo: false
             sh.export 'PATH', "#{HOME_DIR}/bin:$PATH", retry: false, echo: false
             # install bootstrap version so that tip/master/whatever can be used immediately
-            sh.cmd %Q'gimme 1.4.1 >/dev/null 2>&1'
+            sh.cmd %Q'gimme #{DEFAULTS[:go]} &>/dev/null'
           end
 
           def gimme_config

--- a/spec/build/script/go_spec.rb
+++ b/spec/build/script/go_spec.rb
@@ -19,7 +19,7 @@ describe Travis::Build::Script::Go, :sexp do
   end
 
   it 'sets TRAVIS_GO_VERSION' do
-    should include_sexp [:export, ['TRAVIS_GO_VERSION', '1.4.1']]
+    should include_sexp [:export, ['TRAVIS_GO_VERSION', '1.6.2']]
   end
 
   it 'conditionally sets GOMAXPROCS to 2' do
@@ -27,7 +27,7 @@ describe Travis::Build::Script::Go, :sexp do
   end
 
   it 'sets the default go version if not :go config given' do
-    should include_sexp [:cmd, 'GIMME_OUTPUT=$(gimme 1.4.1) && eval "$GIMME_OUTPUT"', assert: true, echo: true, timing: true]
+    should include_sexp [:cmd, 'GIMME_OUTPUT=$(gimme 1.6.2) && eval "$GIMME_OUTPUT"', assert: true, echo: true, timing: true]
   end
 
   it 'sets the go version from config :go' do
@@ -64,9 +64,16 @@ describe Travis::Build::Script::Go, :sexp do
 
   {
     'default' => Travis::Build::Script::Go::DEFAULTS[:go],
-    '1' => '1.4.1',
+    '1' => '1.6.2',
+    '1.x' => '1.6.2',
+    '1.x.x' => '1.6.2',
     '1.0' => '1.0.3',
     '1.2' => '1.2.2',
+    '1.2.x' => '1.2.2',
+    '1.3.x' => '1.3.3',
+    '1.4.x' => '1.4.3',
+    '1.5.x' => '1.5.4',
+    '1.6.x' => '1.6.2',
     'go1' => 'go1',
     'go1.4.1' => '1.4.1'
   }.each do |version_alias, version|

--- a/spec/build/script/go_spec.rb
+++ b/spec/build/script/go_spec.rb
@@ -32,7 +32,7 @@ describe Travis::Build::Script::Go, :sexp do
 
   it 'sets the go version from config :go' do
     data[:config][:go] = 'go1.2'
-    should include_sexp [:cmd, 'GIMME_OUTPUT=$(gimme 1.2) && eval "$GIMME_OUTPUT"', assert: true, echo: true, timing: true]
+    should include_sexp [:cmd, 'GIMME_OUTPUT=$(gimme 1.2.2) && eval "$GIMME_OUTPUT"', assert: true, echo: true, timing: true]
   end
 
   shared_examples 'gopath fix' do
@@ -68,6 +68,7 @@ describe Travis::Build::Script::Go, :sexp do
     '1.x' => '1.6.2',
     '1.x.x' => '1.6.2',
     '1.0' => '1.0.3',
+    '1.0.x' => '1.0.3',
     '1.2' => '1.2.2',
     '1.2.x' => '1.2.2',
     '1.3.x' => '1.3.3',


### PR DESCRIPTION
There's an announcement-worthy change in the version normalization, imho, which will allow folks to do this in their `.travis.yml` in addition to passing any strings understood by `gimme`:

``` yaml
language: go
go:
- 1.2.x
- 1.3.x
- 1.4.x
- 1.5.x
- 1.6.x
```