### PR TITLE
Use path-style URL to fetch and store caches on S3V4-compatible caching backends

### DIFF
--- a/lib/travis/build/script/shared/directory_cache/signatures/aws4_signature.rb
+++ b/lib/travis/build/script/shared/directory_cache/signatures/aws4_signature.rb
@@ -23,7 +23,7 @@ module Travis
 
               Addressable::URI.new(
                 scheme: @location.scheme,
-                host: @location.hostname,
+                host: @location.host,
                 path: @location.path,
                 query_values: query,
               )

--- a/spec/build/script/directory_cache/s3_spec.rb
+++ b/spec/build/script/directory_cache/s3_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Travis::Build::Script::DirectoryCache::S3, :sexp do
-  S3_FETCH_URL  = "https://s3_bucket.s3.amazonaws.com/42/%s/example.%s?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=s3_access_key_id%%2F19700101%%2Fus-east-1%%2Fs3%%2Faws4_request&X-Amz-Date=19700101T000010Z"
+  S3_FETCH_URL  = "https://s3.amazonaws.com/s3_bucket/42/%s/example.%s?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=s3_access_key_id%%2F19700101%%2Fus-east-1%%2Fs3%%2Faws4_request&X-Amz-Date=19700101T000010Z"
   S3_SIGNED_URL = "%s&X-Amz-Expires=20&X-Amz-Signature=%s&X-Amz-SignedHeaders=host"
 
   def url_for(branch, ext = 'tbz')
@@ -13,10 +13,10 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
   end
 
   let(:master_fetch_signature) { "163b2a236fcfda37d58c1d50c27d86fbd04efb4a6d97219134f71854e3e0383b" }
-  let(:master_fetch_signature_tgz) { "742726586b6d8c86bdc9fbe6eb412d63818347ad54b4fd32f2447df97efdc468" }
+  let(:master_fetch_signature_tgz) { "b6282b850382aacaf1ce425ca3ed7add79e9ab82bca3099e13e312919fdfd8da" }
   let(:fetch_signature)        { master_fetch_signature }
   let(:fetch_signature_tgz)    { master_fetch_signature_tgz }
-  let(:push_signature)         { "e7e04f36f46920e9011580d53b16f2fc492094a8b4ec89076411a9d6800cf0ac" }
+  let(:push_signature)         { "d388be7ca53fb612892cffe0844c957ee6062efe08c997ddcb5d2e8e1501e339" }
 
   let(:url)           { url_for(branch) }
   let(:url_tgz)       { url_for(branch, 'tgz') }
@@ -112,8 +112,8 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
   describe 'on a different branch' do
     let(:branch)          { 'featurefoo' }
     let(:fetch_signature) { 'cbce59b97e29ba90e1810a9cbedc1d5cd76df8235064c0016a53dea232124d60' }
-    let(:fetch_signature_tgz) { 'f0842c7f68c3b518502a336c5e55cfa368c90f72a06e2b58889cfd844380310b' }
-    let(:push_signature)  { '3642ae12b63114366d42c964e221b7e9dcf736286a6fde1fd93be3fa21acb324' }
+    let(:fetch_signature_tgz) { 'a8b6b4380bd25cd9f402ff3fa896d6cbad6a1f9cdf21a6bcb0b956d04b49f2a5' }
+    let(:push_signature)  { 'ced8bb92b9cf7a2005aacbe9158d239c8500976277faf17ce46597b2d17a8f0c' }
     let(:fallback_url_tgz)    { signed_url_for('master', master_fetch_signature_tgz, 'tgz') }
 
     describe 'fetch' do
@@ -135,8 +135,8 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
   describe 'on a pull request' do
     let(:pull_request)    { 15 }
     let(:fetch_signature) { 'b1db673b9a243ecbc792fd476c4f5b45462449dd73b65987d11710b42f180773' }
-    let(:fetch_signature_tgz) { 'b17be191a6770e15e3b8c598843cd1503a674aab4f8853d303e2d6d694fa1fd6' }
-    let(:push_signature)  { '4aa0c287dca37b5c7f9d14e84be0680c4151c8230b2d0c6e8299d031d4bebd29' }
+    let(:fetch_signature_tgz) { '2641b71927a0e494f925ef3afacbd7083bc4f307a0acc693f8ff3f6d67ea179f' }
+    let(:push_signature)  { '107f513b12c8f93f3a6e08b51ae8efe20f69bc7635f4c488f09bb06f14437cac' }
     let(:url)             { url_for("PR.#{pull_request}") }
     let(:url_tgz)         { url_for("PR.#{pull_request}", 'tgz') }
     let(:fallback_url_tgz)    { signed_url_for('master', master_fetch_signature_tgz, 'tgz') }
@@ -161,12 +161,12 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
     let(:pull_request)    { 15 }
     let(:branch)          { 'foo' }
     let(:fetch_signature) { 'b1db673b9a243ecbc792fd476c4f5b45462449dd73b65987d11710b42f180773' }
-    let(:fetch_signature_tgz) { 'b17be191a6770e15e3b8c598843cd1503a674aab4f8853d303e2d6d694fa1fd6' }
-    let(:push_signature)  { '4aa0c287dca37b5c7f9d14e84be0680c4151c8230b2d0c6e8299d031d4bebd29' }
+    let(:fetch_signature_tgz) { '2641b71927a0e494f925ef3afacbd7083bc4f307a0acc693f8ff3f6d67ea179f' }
+    let(:push_signature)  { '107f513b12c8f93f3a6e08b51ae8efe20f69bc7635f4c488f09bb06f14437cac' }
     let(:url)             { url_for("PR.#{pull_request}") }
     let(:url_tgz)         { url_for("PR.#{pull_request}", 'tgz') }
     let(:fallback_url_tgz)    { signed_url_for('master', master_fetch_signature_tgz, 'tgz') }
-    let(:branch_fallback_url_tgz) { signed_url_for('foo', 'e25b5a05709b557e35140cba079b597faae02da0733d7c18e848ce91140a5331', 'tgz') }
+    let(:branch_fallback_url_tgz) { signed_url_for('foo', '5b2cabde3b2a67563a8e26ded3a000ba8a0bc5c30faa102588d44036d444ec67', 'tgz') }
 
     describe 'fetch' do
       before { cache.fetch }
@@ -190,7 +190,8 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
       location = described_class::Location.new('https', 'us-east-1', 'examplebucket', '/test.txt', 's3.amazonaws.com')
       signature = Travis::Build::Script::DirectoryCache::Signatures::AWS4Signature.new(key: key_pair, http_verb: 'GET', location: location, expires: 86400, timestamp: Time.gm(2013, 5, 24))
 
-      expect(signature.to_uri.query_values['X-Amz-Signature']).to eq('aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404')
+      # note that the computed signature is different from the value shown in http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
+      expect(signature.to_uri.query_values['X-Amz-Signature']).to eq('53fc89bc4880655f485ba948c2b85d096741144d6cd6b314763f84850b5c20fa')
     end
   end
 end


### PR DESCRIPTION
Some S3-compatible caching backends (e.g., [Minio](https://minio.io)) *requires* the bucket name be indicated in the path, while AWS S3 allows both virtual-host-style URL and path-style URL. (See http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro.)

This PR switches the access method for V4-compatible backends to the path-style, so that we can support a wider range of caching backends.

This supersedes #786.