### PR TITLE
Expose `SOURCE_VERSION`

### DIFF
--- a/lib/travis/build/appliances/show_system_info.rb
+++ b/lib/travis/build/appliances/show_system_info.rb
@@ -25,7 +25,7 @@ module Travis
             end
 
             if ENV['SOURCE_VERSION']
-              sh.echo "travis-build version: #{ENV['SOURCE_VERSION']}"
+              sh.echo "travis-build version: #{ENV['SOURCE_VERSION']}".untaint
             end
           end
 

--- a/lib/travis/build/appliances/show_system_info.rb
+++ b/lib/travis/build/appliances/show_system_info.rb
@@ -8,9 +8,8 @@ module Travis
         def apply
           sh.fold 'system_info' do
             header
-            sh.if "-f #{info_file}" do
-              sh.cmd "cat #{info_file}"
-            end
+            show_travis_build_version
+            show_system_info_file
           end
           sh.newline
         end
@@ -23,9 +22,17 @@ module Travis
               value = data.send(name)
               sh.echo "Build #{name}: #{Shellwords.escape(value)}" if value
             end
+          end
 
+          def show_travis_build_version
             if ENV['SOURCE_VERSION']
               sh.echo "travis-build version: #{ENV['SOURCE_VERSION']}".untaint
+            end
+          end
+
+          def show_system_info_file
+            sh.if "-f #{info_file}" do
+              sh.cmd "cat #{info_file}"
             end
           end
 

--- a/lib/travis/build/appliances/show_system_info.rb
+++ b/lib/travis/build/appliances/show_system_info.rb
@@ -23,6 +23,10 @@ module Travis
               value = data.send(name)
               sh.echo "Build #{name}: #{Shellwords.escape(value)}" if value
             end
+
+            if ENV['SOURCE_VERSION']
+              sh.echo "travis-build version: #{ENV['SOURCE_VERSION']}"
+            end
           end
 
           def info_file


### PR DESCRIPTION
Expose Heroku's `SOURCE_VERSION` environment variable to the build log with the help from a third-party buildpack such as https://github.com/ianpurvis/heroku-buildpack-version.