### PR TITLE
Bump go aliases and default to 1.6.3

### DIFF
--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -13,10 +13,10 @@ module Travis
             )}".untaint,
             force_reinstall: !!ENV['TRAVIS_BUILD_GIMME_FORCE_REINSTALL']
           },
-          go: "#{ENV.fetch('TRAVIS_BUILD_GO_VERSION', '1.6.2')}".untaint
+          go: "#{ENV.fetch('TRAVIS_BUILD_GO_VERSION', '1.6.3')}".untaint
         }
         GO_VERSION_ALIASES = {
-          '1' => '1.6.2',
+          '1' => '1.6.3',
           '1.0' => '1.0.3',
           '1.0.x' => '1.0.3',
           '1.1.x' => '1.1.2',
@@ -25,9 +25,9 @@ module Travis
           '1.3.x' => '1.3.3',
           '1.4.x' => '1.4.3',
           '1.5.x' => '1.5.4',
-          '1.6.x' => '1.6.2',
-          '1.x' => '1.6.2',
-          '1.x.x' => '1.6.2',
+          '1.6.x' => '1.6.3',
+          '1.x' => '1.6.3',
+          '1.x.x' => '1.6.3',
           'default' => DEFAULTS[:go]
         }.freeze
 

--- a/spec/build/script/go_spec.rb
+++ b/spec/build/script/go_spec.rb
@@ -19,7 +19,7 @@ describe Travis::Build::Script::Go, :sexp do
   end
 
   it 'sets TRAVIS_GO_VERSION' do
-    should include_sexp [:export, ['TRAVIS_GO_VERSION', '1.6.2']]
+    should include_sexp [:export, ['TRAVIS_GO_VERSION', '1.6.3']]
   end
 
   it 'conditionally sets GOMAXPROCS to 2' do
@@ -27,7 +27,7 @@ describe Travis::Build::Script::Go, :sexp do
   end
 
   it 'sets the default go version if not :go config given' do
-    should include_sexp [:cmd, 'GIMME_OUTPUT=$(gimme 1.6.2) && eval "$GIMME_OUTPUT"', assert: true, echo: true, timing: true]
+    should include_sexp [:cmd, 'GIMME_OUTPUT=$(gimme 1.6.3) && eval "$GIMME_OUTPUT"', assert: true, echo: true, timing: true]
   end
 
   it 'sets the go version from config :go' do
@@ -63,7 +63,7 @@ describe Travis::Build::Script::Go, :sexp do
   end
 
   {
-    '1' => '1.6.2',
+    '1' => '1.6.3',
     '1.0' => '1.0.3',
     '1.0.x' => '1.0.3',
     '1.1.x' => '1.1.2',
@@ -72,9 +72,9 @@ describe Travis::Build::Script::Go, :sexp do
     '1.3.x' => '1.3.3',
     '1.4.x' => '1.4.3',
     '1.5.x' => '1.5.4',
-    '1.6.x' => '1.6.2',
-    '1.x' => '1.6.2',
-    '1.x.x' => '1.6.2',
+    '1.6.x' => '1.6.3',
+    '1.x' => '1.6.3',
+    '1.x.x' => '1.6.3',
     'default' => Travis::Build::Script::Go::DEFAULTS[:go],
     'go1' => 'go1',
     'go1.4.1' => '1.4.1'


### PR DESCRIPTION
as it is a security release

https://groups.google.com/forum/#!topic/golang-nuts/kfzBGiAcxME