### PR TITLE
Run 'npm config delete prefix' only if ~/.npmrc exists

### DIFF
--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -127,7 +127,7 @@ module Travis
           end
 
           def npm_disable_prefix
-            sh.if "$(command -v sw_vers)" do
+            sh.if "$(command -v sw_vers) && -f $HOME/.npmrc" do
               sh.cmd "npm config delete prefix"
             end
           end


### PR DESCRIPTION
Because Node.js 0.8 can't do it.

Resolves https://github.com/travis-ci/travis-ci/issues/6315