### PR TITLE
Use HEROKU_SLUG_COMMIT instead of SOURCE_VERSION

### DIFF
--- a/lib/travis/build/appliances/show_system_info.rb
+++ b/lib/travis/build/appliances/show_system_info.rb
@@ -27,8 +27,8 @@ module Travis
           end
 
           def show_travis_build_version
-            if ENV['SOURCE_VERSION']
-              sh.echo "travis-build version: #{ENV['SOURCE_VERSION']}".untaint
+            if ENV['HEROKU_SLUG_COMMIT']
+              sh.echo "travis-build version: #{ENV['HEROKU_SLUG_COMMIT']}".untaint
             end
           end
 


### PR DESCRIPTION
HEROKU_SLUG_COMMIT is available without the use of a third-party
buildpack

See https://devcenter.heroku.com/articles/dyno-metadata