### PR TITLE
fix travis-ci/travis-ci#6012 - better retry for curl failures

### DIFF
--- a/lib/travis/build/script/d.rb
+++ b/lib/travis/build/script/d.rb
@@ -25,8 +25,8 @@ module Travis
             sh.echo 'Installing compiler and dub', ansi: :yellow
 
             sh.cmd 'CURL_USER_AGENT="Travis-CI $(curl --version | head -n 1)"'
-            sh.cmd 'source "$(curl -fsS  --retry 3 https://dlang.org/install.sh | '\
-                   "CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash -s #{config[:d]} --activate)\""
+            sh.cmd 'for i in {0..4}; do curl -fsS -A "$CURL_USER_AGENT" --max-time 5 https://dlang.org/install.sh -O && break || [ $i -ge 4 ] || sleep $((1 << $i)); done'
+            sh.cmd "source \"$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash install.sh #{config[:d]} --activate)\""
           end
         end
 

--- a/spec/build/script/d_spec.rb
+++ b/spec/build/script/d_spec.rb
@@ -12,7 +12,9 @@ describe Travis::Build::Script::D, :sexp do
   it_behaves_like 'a build script sexp'
 
   it 'downloads and runs the installer script' do
-    should include_sexp [:cmd, %r{source.*"$\(.*https://dlang\.org/install\.sh.*|.*bash.*--activate\)"},
+    should include_sexp [:cmd, %r{curl.*https://dlang\.org/install\.sh},
+                         assert: true, echo: true, timing: true]
+    should include_sexp [:cmd, %r{source.*bash.*install\.sh.*--activate},
                          assert: true, echo: true, timing: true]
   end
 
@@ -44,7 +46,7 @@ describe Travis::Build::Script::D, :sexp do
     end
 
     it 'passed the compiler to the install script' do
-      should include_sexp [:cmd, %r{install\.sh.*|.*bash.*ldc-0.17.1"},
+      should include_sexp [:cmd, %r{source.*bash.*install\.sh.*ldc-0.17.1.*--activate},
                            assert: true, echo: true, timing: true]
     end
   end


### PR DESCRIPTION
- limit total time to 5 seconds (fixes stuck downloads)
- move retry logic to shell (to retry non-transient errors, e.g. empty reply)