### PR TITLE
Fix https://github.com/travis-ci/travis-ci/issues/5996

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -360,7 +360,7 @@ module Travis
         def install_deps
           setup_devtools
           install_script =
-            'deps <- devtools::dev_package_deps(dependencies = TRUE);'\
+            'deps <- devtools::dev_package_deps(dependencies = NA);'\
             'devtools::install_deps(dependencies = TRUE);'\
             'if (!all(deps$package %in% installed.packages())) {'\
             ' message("missing: ", paste(setdiff(deps$package, installed.packages()), collapse=", "));'\


### PR DESCRIPTION
R Travis builds fail when packages when reference other packages in the Suggests field that are not available on CRAN. This behaviour is undesirable, and prevents users from testing packages that are legal according to CRAN guidelines. This issue is documented in travis-ci/travis-ci#5996.

For instance the [cherry package](https://cran.r-project.org/web/packages/cherry/index.html) has the "gurobi" package listed under Suggests. The "gurobi" package is not available on CRAN. So, this package would currently fail given the current version of R-Travis.

Here is an example of a failed build because the package contains a package under Suggests (also "gurobi") that is not on CRAN:

https://travis-ci.org/paleo13/raptr/jobs/145781438

The pull request fixes this issue by checking for the successful installation of packages from CRAN that listed only under Imports, Depends, and Linking To.