### PR TITLE
Update leiningen on the fly

### DIFF
--- a/lib/travis/build/script/clojure.rb
+++ b/lib/travis/build/script/clojure.rb
@@ -11,6 +11,13 @@ module Travis
           jdk:  'default'
         }
 
+        LEIN_VERSION = '2.6.1'
+
+        def configure
+          super
+          update_lein LEIN_VERSION
+        end
+
         def announce
           super
           sh.cmd "#{lein} version"
@@ -32,6 +39,14 @@ module Travis
 
           def lein
             config[:lein].to_s
+          end
+
+          def update_lein(version)
+            sh.if "! -f $HOME/.lein/self-installs/leiningen-#{version}-standalone.jar" do
+              sh.cmd "env LEIN_ROOT=true curl -L -o /usr/local/bin/lein https://raw.githubusercontent.com/technomancy/leiningen/#{version}/bin/lein", echo: true, assert: true, sudo: true
+              sh.cmd "rm -rf $HOME/.lein", echo: false
+              sh.cmd "lein self-install", echo: true, assert: true
+            end
           end
       end
     end


### PR DESCRIPTION
Note that we the version to update to is fixed at this time.

It is not clear to me, though, that *always updating* if the desired leiningen version is unavailable is a good idea.

This resolves https://github.com/travis-ci/travis-ci/issues/4791.