### PR TITLE
Update leiningen if it matches `/\A[2-9][0-9]*(\.\d+)*\z/`

### DIFF
--- a/lib/travis/build/script/clojure.rb
+++ b/lib/travis/build/script/clojure.rb
@@ -50,9 +50,12 @@ module Travis
 
           def update_lein(version)
             sh.if "! -f $HOME/.lein/self-installs/home/travis/.lein/leiningen-#{version}-standalone.jar" do
-              sh.cmd "env LEIN_ROOT=true curl -L -o /usr/local/bin/lein https://raw.githubusercontent.com/technomancy/leiningen/#{version}/bin/lein", echo: true, assert: true, sudo: true
-              sh.cmd "rm -rf $HOME/.lein", echo: false
-              sh.cmd "lein self-install", echo: true, assert: true
+              sh.fold "leiningen.update" do
+                sh.echo "Updating leiningen to #{version}", ansi: :yellow
+                sh.cmd "env LEIN_ROOT=true curl -L -o /usr/local/bin/lein https://raw.githubusercontent.com/technomancy/leiningen/#{version}/bin/lein", echo: true, assert: true, sudo: true
+                sh.cmd "rm -rf $HOME/.lein", echo: false
+                sh.cmd "lein self-install", echo: true, assert: true
+              end
             end
           end
       end

--- a/lib/travis/build/script/clojure.rb
+++ b/lib/travis/build/script/clojure.rb
@@ -49,7 +49,7 @@ module Travis
           end
 
           def update_lein(version)
-            sh.if "! -f $HOME/.lein/self-installs/leiningen-#{version}-standalone.jar" do
+            sh.if "! -f $HOME/.lein/self-installs/home/travis/.lein/leiningen-#{version}-standalone.jar" do
               sh.cmd "env LEIN_ROOT=true curl -L -o /usr/local/bin/lein https://raw.githubusercontent.com/technomancy/leiningen/#{version}/bin/lein", echo: true, assert: true, sudo: true
               sh.cmd "rm -rf $HOME/.lein", echo: false
               sh.cmd "lein self-install", echo: true, assert: true


### PR DESCRIPTION
This PR is a do-over of https://github.com/travis-ci/travis-build/pull/803.

Here, we accept `/\A[2-9][0-9]*(\.\d+)*\z/` as `lein` value, and if so, installs the specified leiningen version and moves on.

Tests:
1. [lein1](https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/507154#L139)
1. [`2.6.1`](https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/507156#L150) (In https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/507156#L110, you see that it is getting installed.)
1. [`2.5.1`](https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/507158#L138) which is the current pre-installed leiningen version on the container image. No additional install happens. 