### PR TITLE
Move JWT addon to run before before_install

### DIFF
--- a/lib/travis/build/addons/jwt.rb
+++ b/lib/travis/build/addons/jwt.rb
@@ -7,7 +7,7 @@ module Travis
       class Jwt < Base
         SUPER_USER_SAFE = true
 
-        def export
+        def before_before_install
           tokens = {}
           Array(config).each do |secret|
             pull_request = self.data.pull_request ? self.data.pull_request : ""

--- a/lib/travis/build/addons/jwt.rb
+++ b/lib/travis/build/addons/jwt.rb
@@ -7,7 +7,7 @@ module Travis
       class Jwt < Base
         SUPER_USER_SAFE = true
 
-        def before_before_script
+        def before_before_install
           tokens = {}
           Array(config).each do |secret|
             pull_request = self.data.pull_request ? self.data.pull_request : ""

--- a/lib/travis/build/addons/jwt.rb
+++ b/lib/travis/build/addons/jwt.rb
@@ -7,7 +7,7 @@ module Travis
       class Jwt < Base
         SUPER_USER_SAFE = true
 
-        def before_before_install
+        def export
           tokens = {}
           Array(config).each do |secret|
             pull_request = self.data.pull_request ? self.data.pull_request : ""

--- a/spec/build/addons/jwt_spec.rb
+++ b/spec/build/addons/jwt_spec.rb
@@ -7,7 +7,7 @@ describe Travis::Build::Addons::Jwt, :sexp do
   let(:addon)  { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
   subject      { sh.to_sexp }
   before       { Time.stubs(:now).returns(Time.at(28800)) }
-  before       { addon.export }
+  before       { addon.before_before_install }
 
   describe 'jwt token' do
     describe 'one secret' do

--- a/spec/build/addons/jwt_spec.rb
+++ b/spec/build/addons/jwt_spec.rb
@@ -7,7 +7,7 @@ describe Travis::Build::Addons::Jwt, :sexp do
   let(:addon)  { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
   subject      { sh.to_sexp }
   before       { Time.stubs(:now).returns(Time.at(28800)) }
-  before       { addon.before_before_script }
+  before       { addon.before_before_install }
 
   describe 'jwt token' do
     describe 'one secret' do

--- a/spec/build/addons/jwt_spec.rb
+++ b/spec/build/addons/jwt_spec.rb
@@ -7,7 +7,7 @@ describe Travis::Build::Addons::Jwt, :sexp do
   let(:addon)  { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
   subject      { sh.to_sexp }
   before       { Time.stubs(:now).returns(Time.at(28800)) }
-  before       { addon.before_before_install }
+  before       { addon.export }
 
   describe 'jwt token' do
     describe 'one secret' do


### PR DESCRIPTION
https://github.com/travis-ci/travis-ci/issues/6383

switch to before_install so if people want to use the credentials in installs steps (or before_install steps) it is available