### PR TITLE
Fix https://github.com/travis-ci/travis-ci/issues/6394

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -124,8 +124,12 @@ module Travis
                 # output.
                 sh.cmd 'brew update >/dev/null', retry: true
 
+                # Get latest version of R from mirror
                 if r_version == r_latest
-                  # Get R-devel from The AT&T research site
+                  r_url = "#{repos[:CRAN]}/bin/macosx/R-#{r_version}.pkg"
+
+                # Get R-devel from The AT&T research site
+                elsif r_version == r_devel
                   r_url = "https://r.research.att.com/mavericks/R-devel/R-devel-mavericks-signed.pkg"
 
                 # 3.2.5 was never built for OS X so
@@ -528,7 +532,18 @@ module Travis
         end
 
         def r_latest
-          '3.3.1'
+          v = open('https://cran.r-project.org/sources.html').readlines
+          v = v.grep(/base/)[0]
+          v = v.split('-')[2]
+          v = v.split('.tar')[0]
+          v
+        end
+
+        def r_devel
+          v = open('https://r.research.att.com/mavericks/R-devel/x86_64/build').readlines
+          v = v.grep(/current_version/)[0].split(' ')
+          v = v[v.index('-current_version')+1]
+          v
         end
 
         def repos

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -47,6 +47,13 @@ describe Travis::Build::Script::R, :sexp do
 
   it 'downloads and installs latest R on OS X' do
     data[:config][:os] = 'osx'
+    should include_sexp [:cmd, %r{^curl.*bin/macosx/R-3\.3\.1\.pkg},
+                         assert: true, echo: true, retry: true, timing: true]
+  end
+
+  it 'downloads and installs developmental R on OS X' do
+    data[:config][:os] = 'osx'
+    data[:config][:r] = '3.4.0'
     should include_sexp [:cmd, %r{^curl.*mavericks/R-devel/R-devel-mavericks-signed\.pkg},
                          assert: true, echo: true, retry: true, timing: true]
   end


### PR DESCRIPTION
This pull request fixes travis-ci/travis-ci#6394

Specifically, the latest and developmental versions are scraped from web-pages and build logs, and then used to determine which version of R should be installed for checking R packages.