### PR TITLE
Correctly download R-devel only when passed as devel

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -125,8 +125,7 @@ module Travis
                 sh.cmd 'brew update >/dev/null', retry: true
 
                 if r_version == r_latest
-                  # Get R-devel from The AT&T research site
-                  r_url = "https://r.research.att.com/mavericks/R-devel/R-devel-mavericks-signed.pkg"
+                  r_url = "#{repos[:CRAN]}/bin/macosx/R-latest.pkg"
 
                 # 3.2.5 was never built for OS X so
                 # we need to use 3.2.4-revised, which is the same codebase

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -124,7 +124,12 @@ module Travis
                 # output.
                 sh.cmd 'brew update >/dev/null', retry: true
 
-                if r_version == r_latest
+                # R-devel builds available at research.att.com
+                if r_version == 'devel'
+                  r_url = "https://r.research.att.com/mavericks/R-devel/R-devel-mavericks-signed.pkg"
+
+                # The latest release is the only one available in /bin/macosx
+                elsif r_version == r_latest
                   r_url = "#{repos[:CRAN]}/bin/macosx/R-latest.pkg"
 
                 # 3.2.5 was never built for OS X so
@@ -505,8 +510,7 @@ module Travis
           @r_version ||= normalized_r_version
         end
 
-        def normalized_r_version
-          v = config[:r].to_s
+        def normalized_r_version(v=config[:r].to_s)
           case v
           when 'release' then '3.3.1'
           when 'oldrel' then '3.2.5'
@@ -527,7 +531,7 @@ module Travis
         end
 
         def r_latest
-          '3.3.1'
+          normalized_r_version('release')
         end
 
         def repos

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -41,13 +41,13 @@ describe Travis::Build::Script::R, :sexp do
   end
 
   it 'downloads and installs latest R' do
-    should include_sexp [:cmd, %r{^curl.*https://s3.amazonaws.com/rstudio-travis/R-3\.3\.1\.xz},
+    should include_sexp [:cmd, %r{^curl.*https://s3.amazonaws.com/rstudio-travis/R-3.3.1.xz},
                          assert: true, echo: true, retry: true, timing: true]
   end
 
   it 'downloads and installs latest R on OS X' do
     data[:config][:os] = 'osx'
-    should include_sexp [:cmd, %r{^curl.*mavericks/R-devel/R-devel-mavericks-signed\.pkg},
+    should include_sexp [:cmd, %r{^curl.*bin/macosx/R-latest.pkg},
                          assert: true, echo: true, retry: true, timing: true]
   end
 
@@ -66,25 +66,25 @@ describe Travis::Build::Script::R, :sexp do
 
   it 'downloads and installs R 3.1' do
     data[:config][:r] = '3.1'
-    should include_sexp [:cmd, %r{^curl.*https://s3.amazonaws.com/rstudio-travis/R-3\.1\.3\.xz},
+    should include_sexp [:cmd, %r{^curl.*https://s3.amazonaws.com/rstudio-travis/R-3.1.3.xz},
                          assert: true, echo: true, retry: true, timing: true]
   end
 
   it 'downloads and installs R 3.2' do
     data[:config][:r] = '3.2'
-    should include_sexp [:cmd, %r{^curl.*https://s3.amazonaws.com/rstudio-travis/R-3\.2\.5\.xz},
+    should include_sexp [:cmd, %r{^curl.*https://s3.amazonaws.com/rstudio-travis/R-3.2.5.xz},
                          assert: true, echo: true, retry: true, timing: true]
   end
 
   it 'downloads and installs R devel' do
     data[:config][:r] = 'devel'
-    should include_sexp [:cmd, %r{^curl.*https://s3.amazonaws.com/rstudio-travis/R-devel\.xz},
+    should include_sexp [:cmd, %r{^curl.*https://s3.amazonaws.com/rstudio-travis/R-devel.xz},
                          assert: true, echo: true, retry: true, timing: true]
   end
 
   it 'downloads pandoc and installs into /usr/bin/pandoc' do
     data[:config][:pandoc_version] = '1.15.2'
-    should include_sexp [:cmd, %r{curl -Lo /tmp/pandoc-1\.15\.2-1-amd64\.deb https://github\.com/jgm/pandoc/releases/download/1.15.2/pandoc-1\.15\.2-1-amd64\.deb},
+    should include_sexp [:cmd, %r{curl -Lo /tmp/pandoc-1\.15\.2-1-amd64.deb https://github\.com/jgm/pandoc/releases/download/1.15.2/pandoc-1\.15\.2-1-amd64.deb},
                          assert: true, echo: true, timing: true]
 
     should include_sexp [:cmd, %r{sudo dpkg -i /tmp/pandoc-},

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -63,6 +63,12 @@ describe Travis::Build::Script::R, :sexp do
     should include_sexp [:cmd, %r{^curl.*bin/macosx/old/R-3\.1\.3\.pkg},
                          assert: true, echo: true, retry: true, timing: true]
   end
+  it 'downloads and installs R devel on OS X' do
+    data[:config][:os] = 'osx'
+    data[:config][:r] = 'devel'
+    should include_sexp [:cmd, %r{^curl.*r\.research\.att\.com/mavericks/R-devel/R-devel-mavericks-signed\.pkg},
+                         assert: true, echo: true, retry: true, timing: true]
+  end
 
   it 'downloads and installs R 3.1' do
     data[:config][:r] = '3.1'

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -41,50 +41,50 @@ describe Travis::Build::Script::R, :sexp do
   end
 
   it 'downloads and installs latest R' do
-    should include_sexp [:cmd, %r{^curl.*https://s3.amazonaws.com/rstudio-travis/R-3.3.1.xz},
+    should include_sexp [:cmd, %r{^curl.*https://s3\.amazonaws\.com/rstudio-travis/R-3\.3\.1\.xz},
                          assert: true, echo: true, retry: true, timing: true]
   end
 
   it 'downloads and installs latest R on OS X' do
     data[:config][:os] = 'osx'
-    should include_sexp [:cmd, %r{^curl.*bin/macosx/R-latest.pkg},
+    should include_sexp [:cmd, %r{^curl.*bin/macosx/R-latest\.pkg},
                          assert: true, echo: true, retry: true, timing: true]
   end
 
   it 'downloads and installs aliased R 3.2.5 on OS X' do
     data[:config][:os] = 'osx'
     data[:config][:r] = '3.2.5'
-    should include_sexp [:cmd, %r{^curl.*bin/macosx/old/R-3.2.4-revised.pkg},
+    should include_sexp [:cmd, %r{^curl.*bin/macosx/old/R-3\.2\.4-revised\.pkg},
                          assert: true, echo: true, retry: true, timing: true]
   end
   it 'downloads and installs other R versions on OS X' do
     data[:config][:os] = 'osx'
     data[:config][:r] = '3.1.3'
-    should include_sexp [:cmd, %r{^curl.*bin/macosx/old/R-3.1.3.pkg},
+    should include_sexp [:cmd, %r{^curl.*bin/macosx/old/R-3\.1\.3\.pkg},
                          assert: true, echo: true, retry: true, timing: true]
   end
 
   it 'downloads and installs R 3.1' do
     data[:config][:r] = '3.1'
-    should include_sexp [:cmd, %r{^curl.*https://s3.amazonaws.com/rstudio-travis/R-3.1.3.xz},
+    should include_sexp [:cmd, %r{^curl.*https://s3\.amazonaws\.com/rstudio-travis/R-3\.1\.3\.xz},
                          assert: true, echo: true, retry: true, timing: true]
   end
 
   it 'downloads and installs R 3.2' do
     data[:config][:r] = '3.2'
-    should include_sexp [:cmd, %r{^curl.*https://s3.amazonaws.com/rstudio-travis/R-3.2.5.xz},
+    should include_sexp [:cmd, %r{^curl.*https://s3\.amazonaws\.com/rstudio-travis/R-3\.2\.5\.xz},
                          assert: true, echo: true, retry: true, timing: true]
   end
 
   it 'downloads and installs R devel' do
     data[:config][:r] = 'devel'
-    should include_sexp [:cmd, %r{^curl.*https://s3.amazonaws.com/rstudio-travis/R-devel.xz},
+    should include_sexp [:cmd, %r{^curl.*https://s3\.amazonaws\.com/rstudio-travis/R-devel\.xz},
                          assert: true, echo: true, retry: true, timing: true]
   end
 
   it 'downloads pandoc and installs into /usr/bin/pandoc' do
     data[:config][:pandoc_version] = '1.15.2'
-    should include_sexp [:cmd, %r{curl -Lo /tmp/pandoc-1\.15\.2-1-amd64.deb https://github\.com/jgm/pandoc/releases/download/1.15.2/pandoc-1\.15\.2-1-amd64.deb},
+    should include_sexp [:cmd, %r{curl -Lo /tmp/pandoc-1\.15\.2-1-amd64\.deb https://github\.com/jgm/pandoc/releases/download/1\.15\.2/pandoc-1\.15\.2-1-amd64\.deb},
                          assert: true, echo: true, timing: true]
 
     should include_sexp [:cmd, %r{sudo dpkg -i /tmp/pandoc-},


### PR DESCRIPTION
The previous PR I sent changed the URL in the wrong location. This revert the change and fixes it properly.

Fixes https://github.com/travis-ci/travis-ci/issues/6390, https://github.com/travis-ci/travis-ci/issues/6394