### PR TITLE
Ensure errexit is off for deployment and caching

### DIFF
--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -57,6 +57,7 @@ module Travis
           private
             def check_conditions_and_run
               sh.if(conditions) do
+                sh.raw 'set +e'
                 run
               end
 

--- a/lib/travis/build/script/shared/directory_cache/base.rb
+++ b/lib/travis/build/script/shared/directory_cache/base.rb
@@ -179,6 +179,7 @@ module Travis
             end
 
             def run(command, args, options = {})
+              sh.raw 'set +e'
               sh.if "-f #{BIN_PATH}" do
                 sh.cmd('type rvm &>/dev/null || source ~/.rvm/scripts/rvm', echo: false, assert: false)
                 sh.cmd "rvm #{USE_RUBY} --fuzzy do #{BIN_PATH} #{command} #{Array(args).join(' ')}", options.merge(echo: false, assert: false)


### PR DESCRIPTION
Some builds blindly source third-party build script(s), which sets Bash's errexit flag (`set -e`), which leads to premature exit when the user is least expecting it.

We can document this behavior, but it is also a good idea to safeguard
against this common mistake.