### PR TITLE
Extract errexit logic into methods

### DIFF
--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -57,7 +57,6 @@ module Travis
           private
             def check_conditions_and_run
               sh.if(conditions) do
-                sh.raw 'set +e'
                 run
               end
 
@@ -125,10 +124,12 @@ module Travis
             end
 
             def run
+              script.save_and_switch_off_errexit
               script.stages.run_stage(:custom, :before_deploy)
               sh.fold('dpl.0') { install }
               cmd(run_command, echo: false, assert: false, timing: true)
               script.stages.run_stage(:custom, :after_deploy)
+              script.restore_errexit
             end
 
             def install(edge = config[:edge])

--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -124,12 +124,12 @@ module Travis
             end
 
             def run
-              script.save_and_switch_off_errexit
-              script.stages.run_stage(:custom, :before_deploy)
-              sh.fold('dpl.0') { install }
-              cmd(run_command, echo: false, assert: false, timing: true)
-              script.stages.run_stage(:custom, :after_deploy)
-              script.restore_errexit
+              sh.with_errexit_off do
+                script.stages.run_stage(:custom, :before_deploy)
+                sh.fold('dpl.0') { install }
+                cmd(run_command, echo: false, assert: false, timing: true)
+                script.stages.run_stage(:custom, :after_deploy)
+              end
             end
 
             def install(edge = config[:edge])

--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -57,6 +57,7 @@ module Travis
           private
             def check_conditions_and_run
               sh.if(conditions) do
+                sh.raw 'set +e'
                 run
               end
 

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -111,6 +111,19 @@ module Travis
         ! data.debug_options.empty?
       end
 
+      def save_and_switch_off_errexit
+        sh.if "$- = *e*" do
+          sh.raw 'ERREXIT_SET=true'
+        end
+        sh.raw 'set +e'
+      end
+
+      def restore_errexit
+        sh.if "-n $ERREXIT_SET" do
+          sh.raw 'set -e'
+        end
+      end
+
       private
 
         def config

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -111,19 +111,6 @@ module Travis
         ! data.debug_options.empty?
       end
 
-      def save_and_switch_off_errexit
-        sh.if "$- = *e*" do
-          sh.raw 'ERREXIT_SET=true'
-        end
-        sh.raw 'set +e'
-      end
-
-      def restore_errexit
-        sh.if "-n $ERREXIT_SET" do
-          sh.raw 'set -e'
-        end
-      end
-
       private
 
         def config

--- a/lib/travis/build/script/shared/directory_cache.rb
+++ b/lib/travis/build/script/shared/directory_cache.rb
@@ -37,7 +37,9 @@ module Travis
 
         def cache
           directory_cache.fold('store build cache') do
-            prepare_cache
+            sh.with_errexit_off do
+              prepare_cache
+            end
             directory_cache.push
           end
         end

--- a/lib/travis/build/script/shared/directory_cache/base.rb
+++ b/lib/travis/build/script/shared/directory_cache/base.rb
@@ -179,6 +179,7 @@ module Travis
             end
 
             def run(command, args, options = {})
+              sh.raw 'set +e'
               sh.if "-f #{BIN_PATH}" do
                 sh.cmd('type rvm &>/dev/null || source ~/.rvm/scripts/rvm', echo: false, assert: false)
                 sh.cmd "rvm #{USE_RUBY} --fuzzy do #{BIN_PATH} #{command} #{Array(args).join(' ')}", options.merge(echo: false, assert: false)

--- a/lib/travis/build/script/shared/directory_cache/base.rb
+++ b/lib/travis/build/script/shared/directory_cache/base.rb
@@ -179,12 +179,12 @@ module Travis
             end
 
             def run(command, args, options = {})
-              save_and_switch_off_errexit
-              sh.if "-f #{BIN_PATH}" do
-                sh.cmd('type rvm &>/dev/null || source ~/.rvm/scripts/rvm', echo: false, assert: false)
-                sh.cmd "rvm #{USE_RUBY} --fuzzy do #{BIN_PATH} #{command} #{Array(args).join(' ')}", options.merge(echo: false, assert: false)
+              sh.with_errexit_off do
+                sh.if "-f #{BIN_PATH}" do
+                  sh.cmd('type rvm &>/dev/null || source ~/.rvm/scripts/rvm', echo: false, assert: false)
+                  sh.cmd "rvm #{USE_RUBY} --fuzzy do #{BIN_PATH} #{command} #{Array(args).join(' ')}", options.merge(echo: false, assert: false)
+                end
               end
-              restore_errexit
             end
 
             def group
@@ -265,19 +265,6 @@ module Travis
 
             def debug_flags
               "-v -w '#{CURL_FORMAT}'" if data.cache[:debug]
-            end
-
-            def save_and_switch_off_errexit
-              sh.if "$- = *e*" do
-                sh.raw 'ERREXIT_SET=true'
-              end
-              sh.raw 'set +e'
-            end
-
-            def restore_errexit
-              sh.if "-n $ERREXIT_SET" do
-                sh.raw 'set -e'
-              end
             end
         end
       end

--- a/lib/travis/shell/builder.rb
+++ b/lib/travis/shell/builder.rb
@@ -163,6 +163,25 @@ module Travis
         @options = options
       end
 
+      def with_errexit_off
+        save_and_switch_off_errexit
+        yield
+        restore_errexit
+      end
+
+      def save_and_switch_off_errexit
+        self.if "$- = *e*" do
+          raw 'ERREXIT_SET=true'
+        end
+        raw 'set +e'
+      end
+
+      def restore_errexit
+        self.if "-n $ERREXIT_SET" do
+          raw 'set -e'
+        end
+      end
+
       private
 
         def merge_options(args)


### PR DESCRIPTION
This PR continues work of #812.

Ensure that caching and deployment occurs with `errexit` option off.

Some builds `source` bash files that set `errexit` (e.g., `set -e`). When our caching and deployment commands fail, this option leads to immediate job termination, which can be very confusing.

An example build is https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/507340.

On https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/507340#L166, caching command fails, and on https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/507340#L196 the deployment (which is just calling `false`) fails. In both of those cases, the job continues to completion.