### PR TITLE
Pass the correct archive filename to rm after Python install

### DIFF
--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -107,9 +107,10 @@ module Travis
               vers = version
             end
             sh.raw archive_url_for('travis-python-archives', vers, lang)
-            sh.cmd "curl -s -o #{lang}-#{vers}.tar.bz2 ${archive_url}", assert: true
-            sh.cmd "sudo tar xjf #{lang}-#{vers}.tar.bz2 --directory /", echo: false, assert: true
-            sh.cmd "rm #{vers}.tar.bz2", echo: false
+            archive_filename = "#{lang}-#{vers}.tar.bz2"
+            sh.cmd "curl -s -o #{archive_filename} ${archive_url}", assert: true
+            sh.cmd "sudo tar xjf #{archive_filename} --directory /", echo: false, assert: true
+            sh.cmd "rm #{archive_filename}", echo: false
           end
 
           def setup_path(version = 'nightly')

--- a/spec/build/script/python_spec.rb
+++ b/spec/build/script/python_spec.rb
@@ -32,12 +32,14 @@ describe Travis::Build::Script::Python, :sexp do
     data[:config][:python] = 'pypy-5.3.1'
     should include_sexp [:cmd,  'source ~/virtualenv/pypy-5.3.1/bin/activate', assert: true, echo: true, timing: true]
     should include_sexp [:cmd,  "curl -s -o pypy-5.3.1.tar.bz2 ${archive_url}", assert: true]
+    should include_sexp [:cmd,  "rm pypy-5.3.1.tar.bz2"]
   end
 
   it 'sets up the python version (pypy3.3-5.2-alpha1)' do
     data[:config][:python] = 'pypy3.3-5.2-alpha1'
     should include_sexp [:cmd,  'source ~/virtualenv/pypy3.3-5.2-alpha1/bin/activate', assert: true, echo: true, timing: true]
     should include_sexp [:cmd,  "curl -s -o pypy3.3-5.2-alpha1.tar.bz2 ${archive_url}", assert: true]
+    should include_sexp [:cmd,  "rm pypy3.3-5.2-alpha1.tar.bz2"]
   end
 
   it 'sets up the python version (pypy3)' do


### PR DESCRIPTION
After #781, the Python install step outputs:

> 2.7.11 is not installed; attempting download
> rm: cannot remove `2.7.11.tar.bz2': No such file or directory

...since the correct filename is actually `python-2.7.11.tar.bz2`.

This change factors out the filename to fix the `rm` instance, reduce duplication and to avoid different filenames inadvertently being used with each command in the future.

Fixes travis-ci/travis-ci#6416.