### PR TITLE
Start 'mongod' service on !Precise

### DIFF
--- a/lib/travis/build/appliances/services.rb
+++ b/lib/travis/build/appliances/services.rb
@@ -15,6 +15,15 @@ module Travis
 
         def apply
           sh.fold 'services' do
+            if services.delete('mongodb')
+              sh.if "$(lsb_release -cs) != 'precise'" do
+                sh.cmd "sudo service mongod start", assert: false, echo: true, timing: true
+              end
+              sh.else do
+                sh.cmd "sudo service mongodb start", assert: false, echo: true, timing: true
+              end
+            end
+
             services.each do |name|
               sh.cmd "sudo service #{name.shellescape} start", assert: false, echo: true, timing: true
             end

--- a/spec/build/script/shared/appliances/services.rb
+++ b/spec/build/script/shared/appliances/services.rb
@@ -23,6 +23,14 @@ shared_examples_for 'starts services' do
       it { should include_sexp [:cmd, 'sudo service redis-server start', echo: true, timing: true] }
     end
 
+    describe 'mongodb' do
+      let(:services) { [:mongodb] }
+      it "starts appropriate service based on lsb_release value" do
+        expect(sexp_find(subject, [:if, "$(lsb_release -cs) != 'precise'"])).to include_sexp [:cmd, 'sudo service mongod start', echo: true, timing: true]
+        expect(sexp_find(subject, [:if, "$(lsb_release -cs) != 'precise'"], [:else])).to include_sexp [:cmd, 'sudo service mongodb start', echo: true, timing: true]
+      end
+    end
+
     describe 'sleeps 3 secs after starting the services' do
       it { should include_sexp [:raw, 'sleep 3'] }
     end


### PR DESCRIPTION
We install MongoDB 3.x on distributions other than Precise.
With MongoDB 3.x, the name of the service is 'mongod', whereas
previously it was 'mongodb'.