### PR TITLE
Skip updating libc6 when sudo is available

### DIFF
--- a/lib/travis/build/appliances/update_glibc.rb
+++ b/lib/travis/build/appliances/update_glibc.rb
@@ -5,7 +5,7 @@ module Travis
     module Appliances
       class UpdateGlibc < Base
         def apply?
-          ENV['TRAVIS_UPDATE_GLIBC']
+          ENV['TRAVIS_UPDATE_GLIBC'] || data.disable_sudo?
         end
 
         def apply

--- a/spec/build/script/shared/appliances/update_glibc.rb
+++ b/spec/build/script/shared/appliances/update_glibc.rb
@@ -8,8 +8,17 @@ fi
   ]}
 
   context "when TRAVIS_UPDATE_GLIBC is unset" do
-    it 'updates libc6' do
-      should_not include_sexp(command)
+    context "when sudo is available" do
+      it 'does not update libc6' do
+        should_not include_sexp(command)
+      end
+    end
+
+    context "when sudo is disabled" do
+      before { data[:paranoid] = true }
+      it 'updates libc6' do
+        should include_sexp(command)
+      end
     end
   end
 


### PR DESCRIPTION
The new GCE images are up to date with [CVE-2015-7547](https://cve.mitre.org/cgi-bin/cvename.cgi?name=cve-2015-7547),
so this is not necessary.