### PR TITLE
Remove duplciate entries from $PATH

### DIFF
--- a/lib/travis/build/appliances/clean_up_path.rb
+++ b/lib/travis/build/appliances/clean_up_path.rb
@@ -6,6 +6,7 @@ module Travis
       class CleanUpPath < Base
         def apply
           sh.export 'PATH', "$(echo $PATH | sed -e 's/::/:/g')", echo: false
+          sh.export 'PATH', "$(echo -n $PATH | perl -e 'print join(\":\", grep { not $seen{$_}++ } split(/:/, scalar <>))')", echo: false
         end
       end
     end

--- a/spec/build/script/shared/appliances/clean_up_path.rb
+++ b/spec/build/script/shared/appliances/clean_up_path.rb
@@ -1,7 +1,10 @@
 shared_examples_for 'cleans up $PATH' do
-  let(:fix_etc_hosts) { "sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 '`hostname`'/' -i'.bak' /etc/hosts" }
 
-  it 'adds an entry to /etc/hosts for localhost' do
+  it 'removes empty path from $PATH' do
     should include_sexp [ :export, ['PATH', "$(echo $PATH | sed -e 's/::/:/g')" ] ]
+  end
+
+  it 'removes duplicates from $PATH' do
+    should include_sexp [ :export, ['PATH', "$(echo -n $PATH | perl -e 'print join(\":\", grep { not $seen{$_}++ } split(/:/, scalar <>))')" ] ]
   end
 end


### PR DESCRIPTION
On containers, we end up with a long $PATH value that can
be a problem for (t)csh:

```
/home/travis/virtualenv/python3.5.2/bin:/home/travis/bin:/home/travis/.local/bin:/home/travis/.gimme/versions/go1.4.1.linux.amd64/bin:/opt/python/2.7.9/bin:/opt/python/2.6.9/bin:/opt/python/3.4.2/bin:/opt/python/3.3.5/bin:/opt/python/3.2.5/bin:/opt/python/pypy-2.5.0/bin:/opt/python/pypy3-2.4.0/bin:/usr/local/phantomjs/bin:/home/travis/.nvm/v0.10.36/bin:./node_modules/.bin:/usr/local/maven-3.2.5/bin:/usr/local/clang-3.4/bin:/home/travis/.gimme/versions/go1.4.1.linux.amd64/bin:/opt/python/2.7.9/bin:/opt/python/2.6.9/bin:/opt/python/3.4.2/bin:/opt/python/3.3.5/bin:/opt/python/3.2.5/bin:/opt/python/pypy-2.5.0/bin:/opt/python/pypy3-2.4.0/bin:/usr/local/phantomjs/bin:./node_modules/.bin:/usr/local/maven-3.2.5/bin:/usr/local/clang-3.4/bin:/home/travis/.gimme/versions/go1.4.1.linux.amd64/bin:/home/travis/.rvm/gems/ruby-1.9.3-p551/bin:/home/travis/.rvm/gems/ruby-1.9.3-p551@global/bin:/home/travis/.rvm/rubies/ruby-1.9.3-p551/bin:/opt/python/2.7.9/bin:/opt/python/2.6.9/bin:/opt/python/3.4.2/bin:/opt/python/3.3.5/bin:/opt/python/3.2.5/bin:/opt/python/pypy-2.5.0/bin:/opt/python/pypy3-2.4.0/bin:/usr/local/phantomjs/bin:./node_modules/.bin:/usr/local/maven-3.2.5/bin:/usr/local/clang-3.4/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/travis/.rvm/bin:/home/travis/.rvm/bin:/home/travis/.rvm/bin
```

The same does not happen on GCE builds, and not on the Docker images
when it is pulled to a local machine. This suggests some issue with
the actual deployment on EC2 and how the container processes are
spawned to run the builds.

While it is a worthwhile endeavor to figure out how this is
happening, we can just as easily remove the duplicates here instead.

The handy Perl one-liner came from http://unix.stackexchange.com/a/149054