### PR TITLE
Introduce TRAVIS_BUILD_APT_WHITELIST_SKIP env var

### DIFF
--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -68,6 +68,10 @@ module Travis
           end
         end
 
+        def skip_whitelist?
+          ENV['TRAVIS_BUILD_APT_WHITELIST_SKIP']
+        end
+
         private
 
           def add_apt_sources
@@ -82,7 +86,7 @@ module Travis
 
               if source.respond_to?(:[]) && source['sourceline']
                 whitelisted << source.clone
-              elsif ! data.disable_sudo?
+              elsif !(data.disable_sudo?) || skip_whitelist?
                 if src.respond_to?(:has_key?)
                   if src.has_key?(:sourceline)
                     whitelisted << {
@@ -175,7 +179,7 @@ module Travis
           end
 
           def package_whitelisted?(list, pkg)
-            list.include?(pkg) || !data.disable_sudo?
+            list.include?(pkg) || !data.disable_sudo? || skip_whitelist?
           end
 
           def package_whitelist

--- a/spec/build/addons/apt_spec.rb
+++ b/spec/build/addons/apt_spec.rb
@@ -117,6 +117,19 @@ describe Travis::Build::Addons::Apt, :sexp do
 
         it { should include_sexp [:cmd, apt_get_install_command('git', 'curl', 'darkcoin'), echo: true, timing: true] }
       end
+
+      context 'when TRAVIS_BUILD_APT_WHITELIST_SKIP is set' do
+        let(:paranoid) { true }
+        before :all do
+          ENV['TRAVIS_BUILD_APT_WHITELIST_SKIP'] = '1'
+        end
+
+        after :all do
+          ENV.delete 'TRAVIS_BUILD_APT_WHITELIST_SKIP'
+        end
+
+        it { should include_sexp [:cmd, apt_get_install_command('git', 'curl', 'darkcoin'), echo: true, timing: true] }
+      end
     end
 
     context 'with singular whitelisted package' do
@@ -221,6 +234,32 @@ describe Travis::Build::Addons::Apt, :sexp do
     context 'when sudo is enabled' do
       let(:paranoid) { false }
       let(:config) { { sources: ['packagecloud-precise', 'deadsnakes-precise', 'evilbadthings', 'ppa:archivematica/externals', { sourceline: 'foobar', key_url: 'deadbeef' }] } }
+
+      it { should include_sexp [:cmd, apt_sources_append_command(packagecloud['sourceline']), echo: true, assert: true, timing: true] }
+      it { should include_sexp [:cmd, apt_add_repository_command(deadsnakes['sourceline']), echo: true, assert: true, timing: true] }
+      it { should include_sexp [:cmd, apt_key_add_command(packagecloud['key_url']), echo: true, assert: true, timing: true] }
+      it { should include_sexp [:cmd, apt_sources_append_command('foobar'), echo: true, assert: true, timing: true] }
+      it { should include_sexp [:cmd, apt_key_add_command('deadbeef'), echo: true, assert: true, timing: true] }
+      it { should_not include_sexp [:cmd, apt_sources_append_command(evilbadthings['sourceline']), echo: true, assert: true, timing: true] }
+      it { should_not include_sexp [:cmd, apt_add_repository_command('ppa:evilbadppa'), echo: true, assert: true, timing: true] }
+
+      context 'when a malformed source is given' do
+        let(:config) { { sources: [{ key_url: 'deadbeef' }] } }
+        it { should include_sexp [:echo, "`sourceline` key missing:", ansi: :yellow] }
+      end
+    end
+
+    context 'when TRAVIS_BUILD_APT_WHITELIST_SKIP env var is set' do
+      let(:paranoid) { true }
+      let(:config) { { sources: ['packagecloud-precise', 'deadsnakes-precise', 'evilbadthings', 'ppa:archivematica/externals', { sourceline: 'foobar', key_url: 'deadbeef' }] } }
+
+      before :all do
+        ENV['TRAVIS_BUILD_APT_WHITELIST_SKIP'] = '1'
+      end
+
+      after :all do
+        ENV.delete 'TRAVIS_BUILD_APT_WHITELIST_SKIP'
+      end
 
       it { should include_sexp [:cmd, apt_sources_append_command(packagecloud['sourceline']), echo: true, assert: true, timing: true] }
       it { should include_sexp [:cmd, apt_add_repository_command(deadsnakes['sourceline']), echo: true, assert: true, timing: true] }


### PR DESCRIPTION
When set, we skip whitelist checking in the `apt` addon