### PR TITLE
Backport 832 for 2.0: Introduce TRAVIS_BUILD_APT_WHITELIST_SKIP env var

### DIFF
--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -79,63 +79,27 @@ module Travis
 
             whitelisted = []
             disallowed = []
-<<<<<<< HEAD
 
             config_sources.each do |source_alias|
               source = source_whitelist[source_alias]
-              whitelisted << source.clone if source && source['sourceline']
-              disallowed << source_alias if source.nil?
-||||||| parent of eb5e562... Merge pull request #832 from travis-ci/ha-apt-bypass-whitelist
-            disallowed_while_sudo = []
 
-            config_sources.each do |src|
-              source = source_whitelist[src]
-
-              if source.respond_to?(:[]) && source['sourceline']
+              if source && source['sourceline']
                 whitelisted << source.clone
-              elsif ! data.disable_sudo?
-                if src.respond_to?(:has_key?)
-                  if src.has_key?(:sourceline)
+              elsif skip_whitelist?
+                if source.respond_to?(:has_key?)
+                  if source.has_key?(:sourceline)
                     whitelisted << {
-                      'sourceline' => src[:sourceline],
-                      'key_url' => src[:key_url]
+                      'sourceline' => source[:sourceline],
+                      'key_url' => source[:key_url]
                     }
                   else
                     sh.echo "`sourceline` key missing:", ansi: :yellow
-                    sh.echo Shellwords.escape(src.inspect)
+                    sh.echo Shellwords.escape(source.inspect)
                   end
                 else
-                  disallowed_while_sudo << src
+                  disallowed << source_alias if source.nil?
                 end
-              elsif source.nil?
-                disallowed << src
               end
-=======
-            disallowed_while_sudo = []
-
-            config_sources.each do |src|
-              source = source_whitelist[src]
-
-              if source.respond_to?(:[]) && source['sourceline']
-                whitelisted << source.clone
-              elsif !(data.disable_sudo?) || skip_whitelist?
-                if src.respond_to?(:has_key?)
-                  if src.has_key?(:sourceline)
-                    whitelisted << {
-                      'sourceline' => src[:sourceline],
-                      'key_url' => src[:key_url]
-                    }
-                  else
-                    sh.echo "`sourceline` key missing:", ansi: :yellow
-                    sh.echo Shellwords.escape(src.inspect)
-                  end
-                else
-                  disallowed_while_sudo << src
-                end
-              elsif source.nil?
-                disallowed << src
-              end
->>>>>>> eb5e562... Merge pull request #832 from travis-ci/ha-apt-bypass-whitelist
             end
 
             unless disallowed.empty?
@@ -167,6 +131,8 @@ module Travis
 
             config_packages.each do |package|
               if package_whitelist.include?(package)
+                whitelisted << package
+              elsif skip_whitelist?
                 whitelisted << package
               else
                 disallowed << package
@@ -214,18 +180,6 @@ module Travis
             @config_packages ||= Array(config[:packages]).flatten.compact
           end
 
-<<<<<<< HEAD
-||||||| parent of eb5e562... Merge pull request #832 from travis-ci/ha-apt-bypass-whitelist
-          def package_whitelisted?(list, pkg)
-            list.include?(pkg) || !data.disable_sudo?
-          end
-
-=======
-          def package_whitelisted?(list, pkg)
-            list.include?(pkg) || !data.disable_sudo? || skip_whitelist?
-          end
-
->>>>>>> eb5e562... Merge pull request #832 from travis-ci/ha-apt-bypass-whitelist
           def package_whitelist
             ::Travis::Build::Addons::Apt.package_whitelist
           end

--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -79,26 +79,29 @@ module Travis
 
             whitelisted = []
             disallowed = []
+            disallowed_while_sudo = []
 
-            config_sources.each do |source_alias|
-              source = source_whitelist[source_alias]
+            config_sources.each do |src|
+              source = source_whitelist[src]
 
-              if source && source['sourceline']
+              if source.respond_to?(:[]) && source['sourceline']
                 whitelisted << source.clone
-              elsif skip_whitelist?
-                if source.respond_to?(:has_key?)
-                  if source.has_key?(:sourceline)
+              elsif !(data.disable_sudo?) || skip_whitelist?
+                if src.respond_to?(:has_key?)
+                  if src.has_key?(:sourceline)
                     whitelisted << {
-                      'sourceline' => source[:sourceline],
-                      'key_url' => source[:key_url]
+                      'sourceline' => src[:sourceline],
+                      'key_url' => src[:key_url]
                     }
                   else
                     sh.echo "`sourceline` key missing:", ansi: :yellow
-                    sh.echo Shellwords.escape(source.inspect)
+                    sh.echo Shellwords.escape(src.inspect)
                   end
                 else
-                  disallowed << source_alias if source.nil?
+                  disallowed_while_sudo << src
                 end
+              elsif source.nil?
+                disallowed << src
               end
             end
 
@@ -107,6 +110,12 @@ module Travis
               sh.echo 'If you require these sources, please review the source ' \
                 'approval process at: ' \
                 'https://github.com/travis-ci/apt-source-whitelist#source-approval-process'
+            end
+
+            unless disallowed_while_sudo.empty?
+              sh.echo "Disallowing sources: #{disallowed_while_sudo.map { |source| Shellwords.escape(source) }.join(', ')}", ansi: :red
+              sh.echo "To add unlisted APT sources, follow instructions in " \
+                "https://docs.travis-ci.com/user/installing-dependencies#Installing-Packages-with-the-APT-Addon"
             end
 
             unless whitelisted.empty?
@@ -126,18 +135,7 @@ module Travis
           def add_apt_packages
             sh.echo "Installing APT Packages (BETA)", ansi: :yellow
 
-            whitelisted = []
-            disallowed = []
-
-            config_packages.each do |package|
-              if package_whitelist.include?(package)
-                whitelisted << package
-              elsif skip_whitelist?
-                whitelisted << package
-              else
-                disallowed << package
-              end
-            end
+            whitelisted, disallowed = config_packages.partition { |pkg| package_whitelisted?(package_whitelist, pkg) }
 
             unless disallowed.empty?
               sh.echo "Disallowing packages: #{disallowed.map { |package| Shellwords.escape(package) }.join(', ')}", ansi: :red
@@ -178,6 +176,10 @@ module Travis
 
           def config_packages
             @config_packages ||= Array(config[:packages]).flatten.compact
+          end
+
+          def package_whitelisted?(list, pkg)
+            list.include?(pkg) || !data.disable_sudo? || skip_whitelist?
           end
 
           def package_whitelist

--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -68,6 +68,10 @@ module Travis
           end
         end
 
+        def skip_whitelist?
+          ENV['TRAVIS_BUILD_APT_WHITELIST_SKIP']
+        end
+
         private
 
           def add_apt_sources
@@ -75,11 +79,63 @@ module Travis
 
             whitelisted = []
             disallowed = []
+<<<<<<< HEAD
 
             config_sources.each do |source_alias|
               source = source_whitelist[source_alias]
               whitelisted << source.clone if source && source['sourceline']
               disallowed << source_alias if source.nil?
+||||||| parent of eb5e562... Merge pull request #832 from travis-ci/ha-apt-bypass-whitelist
+            disallowed_while_sudo = []
+
+            config_sources.each do |src|
+              source = source_whitelist[src]
+
+              if source.respond_to?(:[]) && source['sourceline']
+                whitelisted << source.clone
+              elsif ! data.disable_sudo?
+                if src.respond_to?(:has_key?)
+                  if src.has_key?(:sourceline)
+                    whitelisted << {
+                      'sourceline' => src[:sourceline],
+                      'key_url' => src[:key_url]
+                    }
+                  else
+                    sh.echo "`sourceline` key missing:", ansi: :yellow
+                    sh.echo Shellwords.escape(src.inspect)
+                  end
+                else
+                  disallowed_while_sudo << src
+                end
+              elsif source.nil?
+                disallowed << src
+              end
+=======
+            disallowed_while_sudo = []
+
+            config_sources.each do |src|
+              source = source_whitelist[src]
+
+              if source.respond_to?(:[]) && source['sourceline']
+                whitelisted << source.clone
+              elsif !(data.disable_sudo?) || skip_whitelist?
+                if src.respond_to?(:has_key?)
+                  if src.has_key?(:sourceline)
+                    whitelisted << {
+                      'sourceline' => src[:sourceline],
+                      'key_url' => src[:key_url]
+                    }
+                  else
+                    sh.echo "`sourceline` key missing:", ansi: :yellow
+                    sh.echo Shellwords.escape(src.inspect)
+                  end
+                else
+                  disallowed_while_sudo << src
+                end
+              elsif source.nil?
+                disallowed << src
+              end
+>>>>>>> eb5e562... Merge pull request #832 from travis-ci/ha-apt-bypass-whitelist
             end
 
             unless disallowed.empty?
@@ -158,6 +214,18 @@ module Travis
             @config_packages ||= Array(config[:packages]).flatten.compact
           end
 
+<<<<<<< HEAD
+||||||| parent of eb5e562... Merge pull request #832 from travis-ci/ha-apt-bypass-whitelist
+          def package_whitelisted?(list, pkg)
+            list.include?(pkg) || !data.disable_sudo?
+          end
+
+=======
+          def package_whitelisted?(list, pkg)
+            list.include?(pkg) || !data.disable_sudo? || skip_whitelist?
+          end
+
+>>>>>>> eb5e562... Merge pull request #832 from travis-ci/ha-apt-bypass-whitelist
           def package_whitelist
             ::Travis::Build::Addons::Apt.package_whitelist
           end

--- a/spec/build/addons/apt_packages_spec.rb
+++ b/spec/build/addons/apt_packages_spec.rb
@@ -2,10 +2,11 @@ require 'ostruct'
 
 describe Travis::Build::Addons::AptPackages, :sexp do
   let(:script)    { stub('script') }
-  let(:data)      { payload_for(:push, :ruby, config: { addons: { apt_packages: config } }) }
+  let(:data)      { payload_for(:push, :ruby, config: { addons: { apt_packages: config } }, paranoid: paranoid) }
   let(:sh)        { Travis::Shell::Builder.new }
   let(:addon)     { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
   let(:package_whitelist) { ['curl', 'git'] }
+  let(:paranoid)  { true }
   subject         { sh.to_sexp }
 
   before do
@@ -27,6 +28,13 @@ describe Travis::Build::Addons::AptPackages, :sexp do
     let(:config) { ['git', 'curl', 'darkcoin'] }
 
     it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true] }
+  end
+
+  context 'with multiple packages, some whitelisted' do
+    let(:config) { ['git', 'curl', 'darkcoin'] }
+    let(:paranoid) { false }
+
+    it { should include_sexp [:cmd, apt_get_install_command('git', 'curl', 'darkcoin'), echo: true, timing: true] }
   end
 
   context 'with singular whitelisted package' do

--- a/spec/build/addons/apt_spec.rb
+++ b/spec/build/addons/apt_spec.rb
@@ -108,6 +108,35 @@ describe Travis::Build::Addons::Apt, :sexp do
       let(:config) { { packages: ['git', 'curl', 'darkcoin'] } }
 
       it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true] }
+<<<<<<< HEAD
+||||||| parent of eb5e562... Merge pull request #832 from travis-ci/ha-apt-bypass-whitelist
+
+      context 'when sudo is enabled' do
+        let(:paranoid) { false }
+
+        it { should include_sexp [:cmd, apt_get_install_command('git', 'curl', 'darkcoin'), echo: true, timing: true] }
+      end
+=======
+
+      context 'when sudo is enabled' do
+        let(:paranoid) { false }
+
+        it { should include_sexp [:cmd, apt_get_install_command('git', 'curl', 'darkcoin'), echo: true, timing: true] }
+      end
+
+      context 'when TRAVIS_BUILD_APT_WHITELIST_SKIP is set' do
+        let(:paranoid) { true }
+        before :all do
+          ENV['TRAVIS_BUILD_APT_WHITELIST_SKIP'] = '1'
+        end
+
+        after :all do
+          ENV.delete 'TRAVIS_BUILD_APT_WHITELIST_SKIP'
+        end
+
+        it { should include_sexp [:cmd, apt_get_install_command('git', 'curl', 'darkcoin'), echo: true, timing: true] }
+      end
+>>>>>>> eb5e562... Merge pull request #832 from travis-ci/ha-apt-bypass-whitelist
     end
 
     context 'with singular whitelisted package' do
@@ -197,5 +226,71 @@ describe Travis::Build::Addons::Apt, :sexp do
 
       it { should_not include_sexp [:cmd, apt_add_repository_command(packagecloud['sourceline']), echo: true, assert: true, timing: true] }
     end
+<<<<<<< HEAD
+||||||| parent of eb5e562... Merge pull request #832 from travis-ci/ha-apt-bypass-whitelist
+
+    context 'when sudo is enabled' do
+      let(:paranoid) { false }
+      let(:config) { { sources: ['packagecloud-precise', 'deadsnakes-precise', 'evilbadthings', 'ppa:archivematica/externals', { sourceline: 'foobar', key_url: 'deadbeef' }] } }
+
+      it { should include_sexp [:cmd, apt_sources_append_command(packagecloud['sourceline']), echo: true, assert: true, timing: true] }
+      it { should include_sexp [:cmd, apt_add_repository_command(deadsnakes['sourceline']), echo: true, assert: true, timing: true] }
+      it { should include_sexp [:cmd, apt_key_add_command(packagecloud['key_url']), echo: true, assert: true, timing: true] }
+      it { should include_sexp [:cmd, apt_sources_append_command('foobar'), echo: true, assert: true, timing: true] }
+      it { should include_sexp [:cmd, apt_key_add_command('deadbeef'), echo: true, assert: true, timing: true] }
+      it { should_not include_sexp [:cmd, apt_sources_append_command(evilbadthings['sourceline']), echo: true, assert: true, timing: true] }
+      it { should_not include_sexp [:cmd, apt_add_repository_command('ppa:evilbadppa'), echo: true, assert: true, timing: true] }
+
+      context 'when a malformed source is given' do
+        let(:config) { { sources: [{ key_url: 'deadbeef' }] } }
+        it { should include_sexp [:echo, "`sourceline` key missing:", ansi: :yellow] }
+      end
+    end
+=======
+
+    context 'when sudo is enabled' do
+      let(:paranoid) { false }
+      let(:config) { { sources: ['packagecloud-precise', 'deadsnakes-precise', 'evilbadthings', 'ppa:archivematica/externals', { sourceline: 'foobar', key_url: 'deadbeef' }] } }
+
+      it { should include_sexp [:cmd, apt_sources_append_command(packagecloud['sourceline']), echo: true, assert: true, timing: true] }
+      it { should include_sexp [:cmd, apt_add_repository_command(deadsnakes['sourceline']), echo: true, assert: true, timing: true] }
+      it { should include_sexp [:cmd, apt_key_add_command(packagecloud['key_url']), echo: true, assert: true, timing: true] }
+      it { should include_sexp [:cmd, apt_sources_append_command('foobar'), echo: true, assert: true, timing: true] }
+      it { should include_sexp [:cmd, apt_key_add_command('deadbeef'), echo: true, assert: true, timing: true] }
+      it { should_not include_sexp [:cmd, apt_sources_append_command(evilbadthings['sourceline']), echo: true, assert: true, timing: true] }
+      it { should_not include_sexp [:cmd, apt_add_repository_command('ppa:evilbadppa'), echo: true, assert: true, timing: true] }
+
+      context 'when a malformed source is given' do
+        let(:config) { { sources: [{ key_url: 'deadbeef' }] } }
+        it { should include_sexp [:echo, "`sourceline` key missing:", ansi: :yellow] }
+      end
+    end
+
+    context 'when TRAVIS_BUILD_APT_WHITELIST_SKIP env var is set' do
+      let(:paranoid) { true }
+      let(:config) { { sources: ['packagecloud-precise', 'deadsnakes-precise', 'evilbadthings', 'ppa:archivematica/externals', { sourceline: 'foobar', key_url: 'deadbeef' }] } }
+
+      before :all do
+        ENV['TRAVIS_BUILD_APT_WHITELIST_SKIP'] = '1'
+      end
+
+      after :all do
+        ENV.delete 'TRAVIS_BUILD_APT_WHITELIST_SKIP'
+      end
+
+      it { should include_sexp [:cmd, apt_sources_append_command(packagecloud['sourceline']), echo: true, assert: true, timing: true] }
+      it { should include_sexp [:cmd, apt_add_repository_command(deadsnakes['sourceline']), echo: true, assert: true, timing: true] }
+      it { should include_sexp [:cmd, apt_key_add_command(packagecloud['key_url']), echo: true, assert: true, timing: true] }
+      it { should include_sexp [:cmd, apt_sources_append_command('foobar'), echo: true, assert: true, timing: true] }
+      it { should include_sexp [:cmd, apt_key_add_command('deadbeef'), echo: true, assert: true, timing: true] }
+      it { should_not include_sexp [:cmd, apt_sources_append_command(evilbadthings['sourceline']), echo: true, assert: true, timing: true] }
+      it { should_not include_sexp [:cmd, apt_add_repository_command('ppa:evilbadppa'), echo: true, assert: true, timing: true] }
+
+      context 'when a malformed source is given' do
+        let(:config) { { sources: [{ key_url: 'deadbeef' }] } }
+        it { should include_sexp [:echo, "`sourceline` key missing:", ansi: :yellow] }
+      end
+    end
+>>>>>>> eb5e562... Merge pull request #832 from travis-ci/ha-apt-bypass-whitelist
   end
 end

--- a/spec/build/addons/apt_spec.rb
+++ b/spec/build/addons/apt_spec.rb
@@ -108,21 +108,6 @@ describe Travis::Build::Addons::Apt, :sexp do
       let(:config) { { packages: ['git', 'curl', 'darkcoin'] } }
 
       it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true] }
-<<<<<<< HEAD
-||||||| parent of eb5e562... Merge pull request #832 from travis-ci/ha-apt-bypass-whitelist
-
-      context 'when sudo is enabled' do
-        let(:paranoid) { false }
-
-        it { should include_sexp [:cmd, apt_get_install_command('git', 'curl', 'darkcoin'), echo: true, timing: true] }
-      end
-=======
-
-      context 'when sudo is enabled' do
-        let(:paranoid) { false }
-
-        it { should include_sexp [:cmd, apt_get_install_command('git', 'curl', 'darkcoin'), echo: true, timing: true] }
-      end
 
       context 'when TRAVIS_BUILD_APT_WHITELIST_SKIP is set' do
         let(:paranoid) { true }
@@ -136,7 +121,6 @@ describe Travis::Build::Addons::Apt, :sexp do
 
         it { should include_sexp [:cmd, apt_get_install_command('git', 'curl', 'darkcoin'), echo: true, timing: true] }
       end
->>>>>>> eb5e562... Merge pull request #832 from travis-ci/ha-apt-bypass-whitelist
     end
 
     context 'with singular whitelisted package' do
@@ -226,45 +210,6 @@ describe Travis::Build::Addons::Apt, :sexp do
 
       it { should_not include_sexp [:cmd, apt_add_repository_command(packagecloud['sourceline']), echo: true, assert: true, timing: true] }
     end
-<<<<<<< HEAD
-||||||| parent of eb5e562... Merge pull request #832 from travis-ci/ha-apt-bypass-whitelist
-
-    context 'when sudo is enabled' do
-      let(:paranoid) { false }
-      let(:config) { { sources: ['packagecloud-precise', 'deadsnakes-precise', 'evilbadthings', 'ppa:archivematica/externals', { sourceline: 'foobar', key_url: 'deadbeef' }] } }
-
-      it { should include_sexp [:cmd, apt_sources_append_command(packagecloud['sourceline']), echo: true, assert: true, timing: true] }
-      it { should include_sexp [:cmd, apt_add_repository_command(deadsnakes['sourceline']), echo: true, assert: true, timing: true] }
-      it { should include_sexp [:cmd, apt_key_add_command(packagecloud['key_url']), echo: true, assert: true, timing: true] }
-      it { should include_sexp [:cmd, apt_sources_append_command('foobar'), echo: true, assert: true, timing: true] }
-      it { should include_sexp [:cmd, apt_key_add_command('deadbeef'), echo: true, assert: true, timing: true] }
-      it { should_not include_sexp [:cmd, apt_sources_append_command(evilbadthings['sourceline']), echo: true, assert: true, timing: true] }
-      it { should_not include_sexp [:cmd, apt_add_repository_command('ppa:evilbadppa'), echo: true, assert: true, timing: true] }
-
-      context 'when a malformed source is given' do
-        let(:config) { { sources: [{ key_url: 'deadbeef' }] } }
-        it { should include_sexp [:echo, "`sourceline` key missing:", ansi: :yellow] }
-      end
-    end
-=======
-
-    context 'when sudo is enabled' do
-      let(:paranoid) { false }
-      let(:config) { { sources: ['packagecloud-precise', 'deadsnakes-precise', 'evilbadthings', 'ppa:archivematica/externals', { sourceline: 'foobar', key_url: 'deadbeef' }] } }
-
-      it { should include_sexp [:cmd, apt_sources_append_command(packagecloud['sourceline']), echo: true, assert: true, timing: true] }
-      it { should include_sexp [:cmd, apt_add_repository_command(deadsnakes['sourceline']), echo: true, assert: true, timing: true] }
-      it { should include_sexp [:cmd, apt_key_add_command(packagecloud['key_url']), echo: true, assert: true, timing: true] }
-      it { should include_sexp [:cmd, apt_sources_append_command('foobar'), echo: true, assert: true, timing: true] }
-      it { should include_sexp [:cmd, apt_key_add_command('deadbeef'), echo: true, assert: true, timing: true] }
-      it { should_not include_sexp [:cmd, apt_sources_append_command(evilbadthings['sourceline']), echo: true, assert: true, timing: true] }
-      it { should_not include_sexp [:cmd, apt_add_repository_command('ppa:evilbadppa'), echo: true, assert: true, timing: true] }
-
-      context 'when a malformed source is given' do
-        let(:config) { { sources: [{ key_url: 'deadbeef' }] } }
-        it { should include_sexp [:echo, "`sourceline` key missing:", ansi: :yellow] }
-      end
-    end
 
     context 'when TRAVIS_BUILD_APT_WHITELIST_SKIP env var is set' do
       let(:paranoid) { true }
@@ -291,6 +236,5 @@ describe Travis::Build::Addons::Apt, :sexp do
         it { should include_sexp [:echo, "`sourceline` key missing:", ansi: :yellow] }
       end
     end
->>>>>>> eb5e562... Merge pull request #832 from travis-ci/ha-apt-bypass-whitelist
   end
 end

--- a/spec/build/addons/apt_spec.rb
+++ b/spec/build/addons/apt_spec.rb
@@ -9,6 +9,12 @@ describe Travis::Build::Addons::Apt, :sexp do
   let(:config)            { {} }
   let(:source_whitelist)  { [{ alias: 'testing', sourceline: 'deb http://example.com/deb repo main' }] }
   let(:package_whitelist) { %w(git curl) }
+  let(:evilbadthings) do
+  {
+    'alias' => 'evilbadthings',
+    'sourceline' => 'deb https://evilbadthings.com/chef/stable/ubuntu/ precise main'
+  }
+end
   subject                 { sh.to_sexp }
 
   before :all do


### PR DESCRIPTION
This backports #832.

Conflicting files:
- lib/travis/build/addons/apt.rb
- spec/build/addons/apt_spec.rb

cc @BanzaiMan