### PR TITLE
Skip checking `ENV` env var

### DIFF
--- a/lib/travis/api/build/sentry.rb
+++ b/lib/travis/api/build/sentry.rb
@@ -7,12 +7,10 @@ module Travis
     module Build
       class Sentry < Sinatra::Base
         configure do
-          if ENV['ENV'] == 'production'
-            Raven.configure do |config|
-              config.tags = { environment: environment }
-            end
-            use Raven::Rack
+          Raven.configure do |config|
+            config.tags = { environment: environment }
           end
+          use Raven::Rack
         end
       end
     end


### PR DESCRIPTION
And rely on `SENTRY_DSN` exclusively when enabling
Sentry.