### PR TITLE
Consider repo's default_branch for cache selection

### DIFF
--- a/lib/travis/build/script/shared/directory_cache/base.rb
+++ b/lib/travis/build/script/shared/directory_cache/base.rb
@@ -136,9 +136,9 @@ module Travis
               urls << fetch_url(data.branch, true)
               urls << fetch_url(data.branch)
             end
-            if data.branch != 'master'
-              urls << fetch_url('master', true)
-              urls << fetch_url('master')
+            if data.branch != data.repository[:default_branch]
+              urls << fetch_url(data.repository[:default_branch], true)
+              urls << fetch_url(data.repository[:default_branch])
             end
 
             urls.uniq

--- a/spec/support/payloads.rb
+++ b/spec/support/payloads.rb
@@ -8,7 +8,8 @@ PAYLOADS = {
     'repository' => {
       'github_id' => 42,
       'slug' => 'travis-ci/travis-ci',
-      'source_url' => 'git://github.com/travis-ci/travis-ci.git'
+      'source_url' => 'git://github.com/travis-ci/travis-ci.git',
+      'default_branch' => 'master'
     },
     'build' => {
       'id' => '1',
@@ -34,7 +35,8 @@ PAYLOADS = {
     'repository' => {
       'github_id' => 42,
       'slug' => 'travis-ci/travis-ci',
-      'source_url' => 'git://github.com/travis-ci/travis-ci.git'
+      'source_url' => 'git://github.com/travis-ci/travis-ci.git',
+      'default_branch' => 'master'
     },
     'build' => {
       'id' => '1',


### PR DESCRIPTION
With https://github.com/travis-ci/travis-scheduler/pull/37, we take the repository's default into account when looking for caches.