### PR TITLE
nix: add back in removed line

### DIFF
--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -44,6 +44,7 @@ module Travis
 
           sh.fold 'nix.install' do
             sh.cmd "curl https://nixos.org/nix/install | sh"
+            sh.cmd "source $HOME/.nix-profile/etc/profile.d/nix.sh"
           end
         end
 


### PR DESCRIPTION
Support for Nix was broken after I accidentally removed this line. Adding it back in should get support working again.