### PR TITLE
Activate hhvm-nightly correctly

### DIFF
--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -20,7 +20,7 @@ module Travis
         def setup
           super
           if hhvm?
-            sh.cmd "phpenv global hhvm", assert: true
+            sh.cmd "phpenv global #{version} 2>/dev/null", assert: true
           else
             sh.cmd "phpenv global #{version} 2>/dev/null", assert: false
             sh.if "$? -ne 0" do
@@ -123,6 +123,7 @@ module Travis
           sh.echo 'Installing HHVM nightly', ansi: :yellow
           sh.cmd 'sudo apt-get update -qq'
           sh.cmd 'sudo apt-get install hhvm-nightly -y 2>&1 >/dev/null'
+          sh.cmd 'test -d $HOME/.phpenv/versions/hhvm-nightly || cp -r $HOME/.phpenv/versions/hhvm{,-nightly}', echo: false
         end
 
         def fix_hhvm_php_ini

--- a/spec/build/script/php_spec.rb
+++ b/spec/build/script/php_spec.rb
@@ -58,6 +58,7 @@ describe Travis::Build::Script::Php, :sexp do
     before { data[:config][:php] = 'hhvm-nightly' }
     it { should include_sexp [:cmd, 'sudo apt-get update -qq'] }
     it { should include_sexp [:cmd, 'sudo apt-get install hhvm-nightly -y 2>&1 >/dev/null'] }
+    it { store_example "hhvm-nightly" }
   end
 
   describe 'installs specific hhvm version' do


### PR DESCRIPTION
Resolves https://github.com/travis-ci/travis-ci/issues/6616

`hhvm-nightly` (on Trusty, for sure, but probably on Precise) did not
actually work because there was no `hhvm-nightly` directory under
`$HOME/.phpenv/versions`, where `phpenv` looked for PHP installations.

Furthermore, `phpenv global hhvm` is incorrect for `hhvm-nightly`.
This incorrect invocation led to installation of the `hhvm` package
instead, which reverted the HHVM version to whatever stable release
that package refers to.