### PR TITLE
node_js: Allow skipping `npm install` with npm_skip_install

### DIFF
--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -40,9 +40,11 @@ module Travis
         end
 
         def install
-          sh.if '-f package.json' do
-            sh.cmd "npm install #{config[:npm_args]}", retry: true, fold: 'install'
-          end
+            unless npm_skip_install?
+              sh.if '-f package.json' do
+                sh.cmd "npm install #{config[:npm_args]}", retry: true, fold: 'install'
+              end
+            end
         end
 
         def script
@@ -145,6 +147,10 @@ module Travis
 
           def npm_disable_progress
             sh.cmd "npm config set progress false", echo: false, timing: false
+          end
+
+          def npm_skip_install?
+            !!config[:npm_skip_install]
           end
 
           def npm_strict_ssl?

--- a/spec/build/script/node_js_spec.rb
+++ b/spec/build/script/node_js_spec.rb
@@ -84,11 +84,17 @@ describe Travis::Build::Script::NodeJs, :sexp do
   end
 
   describe 'if package.json exists' do
-    let(:sexp) { sexp_find(subject, [:if, '-f package.json'], [:then]) }
+    let(:sexp)             { sexp_find(subject, [:if, '-f package.json'], [:then]) }
+    let(:npm_install)      { [:cmd, 'npm install ', assert: true, echo: true, retry: true, timing: true] }
+    let(:npm_install_args) { [:cmd, 'npm install --npm-args', assert: true, echo: true, retry: true, timing: true] }
+
+    it 'installs with npm install' do
+      expect(sexp).to include_sexp npm_install
+    end
 
     it 'installs with npm install --npm-args' do
       data[:config][:npm_args] = '--npm-args'
-      expect(sexp).to include_sexp [:cmd, 'npm install --npm-args', assert: true, echo: true, retry: true, timing: true]
+      expect(sexp).to include_sexp npm_install_args
     end
   end
 

--- a/spec/build/script/node_js_spec.rb
+++ b/spec/build/script/node_js_spec.rb
@@ -96,6 +96,11 @@ describe Travis::Build::Script::NodeJs, :sexp do
       data[:config][:npm_args] = '--npm-args'
       expect(sexp).to include_sexp npm_install_args
     end
+
+    it "doesn't run npm install if npm_skip_install is true" do
+      data[:config][:npm_skip_install] = true
+      should_not include_sexp npm_install
+    end
   end
 
   describe 'script' do


### PR DESCRIPTION
Currently `npm install` is always run if a package.json is present.

This PR introduces a `npm_skip_install` to flag to disable this behaviour. This is useful, since a lot of alternative package managers are popping up, most recently [Yarn](https://yarnpkg.com/) ([GitHub](https://github.com/yarnpkg/yarn)), which work as full drop-in replacements for npm. To use them you currently would have to `rm -rf node_modules/` which also increases run time by quite some bit.

I therefore propose this flag. The default behaviour is the same - when the flag is omitted, we continue to run `npm install` as usual. I've also slightly cleaned up a related spec and added an additional one.

Issue: travis-ci/travis-ci#6713.