### PR TITLE
Allow beta versions in Firefox on-the-fly installation

### DIFF
--- a/lib/travis/build/addons/firefox.rb
+++ b/lib/travis/build/addons/firefox.rb
@@ -46,7 +46,7 @@ module Travis
           end
 
           def sanitize(input)
-            if m = /\A(?<version>[\d\.]+(?:esr)?|(?<latest>latest(?:-(?:beta|esr))?)?)\z/.match(input.chomp)
+            if m = /\A(?<version>[\d\.]+(?:esr|b\d+)?|(?<latest>latest(?:-(?:beta|esr))?)?)\z/.match(input.chomp)
               @version = m[:version]
               @latest  = m[:latest]
             end

--- a/lib/travis/build/addons/firefox.rb
+++ b/lib/travis/build/addons/firefox.rb
@@ -15,7 +15,6 @@ module Travis
 
             unless version
               sh.echo "Invalid version '#{raw_version}' given.", ansi: :red
-              return
             end
 
             export_source_url

--- a/spec/build/addons/firefox_spec.rb
+++ b/spec/build/addons/firefox_spec.rb
@@ -33,6 +33,11 @@ describe Travis::Build::Addons::Firefox, :sexp do
     it { should include_sexp [:cd, :back, stack: true] }
   end
 
+  context 'given a valid version "50.0b6"' do
+    let(:config) { '50.0b6' }
+    it { should include_sexp [:cmd, 'sudo ln -sf $HOME/firefox-50.0b6/firefox/firefox /usr/local/bin/firefox'] }
+  end
+
   context 'given a valid version "latest"' do
     let(:config) { 'latest' }
     it { should include_sexp [:cmd, 'sudo ln -sf $HOME/firefox-latest/firefox/firefox /usr/local/bin/firefox'] }


### PR DESCRIPTION
* Version numbers such as `50.0b6` are now accepted
* When an invalid version is specified, the build script compiles correctly to be executed.