### PR TITLE
[R]: Update bioc-devel (addresses #6777)

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -521,7 +521,7 @@ module Travis
           when 'bioc-devel'
             config[:bioc_required] = true
             config[:bioc_use_devel] = true
-            '3.3.1'
+            'devel'
           when 'bioc-release'
             config[:bioc_required] = true
             config[:bioc_use_devel] = false

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -10,7 +10,7 @@ describe Travis::Build::Script::R, :sexp do
 
   it 'normalizes bioc-devel correctly' do
     data[:config][:r] = 'bioc-devel'
-    should include_sexp [:export, ['TRAVIS_R_VERSION', '3.3.1']]
+    should include_sexp [:export, ['TRAVIS_R_VERSION', 'devel']]
     should include_sexp [:cmd, %r{source\(\"https://bioconductor.org/biocLite.R\"\)},
                          assert: true, echo: true, timing: true, retry: true]
     should include_sexp [:cmd, %r{useDevel\(TRUE\)},


### PR DESCRIPTION
@jimhester I think this addresses https://github.com/travis-ci/travis-ci/issues/6777. Is this really all that needs to be done? I ran `bundle exec rspec spec` - all failures are 'expected' and unrelated to my changes, I believe (output below)

I couldn't figure out a way to test whether this actually works with one of my Bioc packages.

```
Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Travis::Build::Addons::CoverityScan needs specs!
     # Temporarily skipped with xit
     # ./spec/build/addons/coverity_scan_spec.rb:16

  2) Travis::Build::Script::Elixir when elixir version is 1.2.0 when OTP release is 18.0 wanted OTP release 18.0 is installed
     # Temporarily skipped with xit
     # ./spec/build/script/elixir_spec.rb:60

  3) Travis::Build::Script::Elixir when elixir version is 1.1.0 when OTP release is 17.4 wanted OTP release 17.4 is installed
     # Temporarily skipped with xit
     # ./spec/build/script/elixir_spec.rb:60

  4) Travis::Build::Script::Elixir when elixir version is 1.1.0 when OTP release is 18.0 wanted OTP release 18.0 is installed
     # Temporarily skipped with xit
     # ./spec/build/script/elixir_spec.rb:60

  5) Travis::Build::Script::Elixir when elixir version is 1.0.5 when OTP release is 17.3 wanted OTP release 17.3 is installed
     # Temporarily skipped with xit
     # ./spec/build/script/elixir_spec.rb:60

  6) Travis::Build::Script::Elixir when elixir version is 1.2.0 when OTP release is 17.3 required OTP release 18.0 is installed
     # Temporarily skipped with xit
     # ./spec/build/script/elixir_spec.rb:68

  7) Travis::Build::Script::Elixir when elixir version is 1.2.0-dev when OTP release is 17.4 required OTP release 18.0 is installed
     # Temporarily skipped with xit
     # ./spec/build/script/elixir_spec.rb:68

  8) Travis::Build::Script::Elixir when elixir version is 1.0.5 when OTP release is 18.0 required OTP release 17.4 is installed
     # Temporarily skipped with xit
     # ./spec/build/script/elixir_spec.rb:68

  9) Travis::Build::Script::Erlang setup downloads OTP archive on demand when the desired release is not pre-installed
     # Temporarily skipped with xit
     # ./spec/build/script/erlang_spec.rb:25

  10) Travis::Build::Script::Php installs php nightly
     # Temporarily skipped with xit
     # ./spec/build/script/php_spec.rb:40

  11) Travis::Build::Script::Php when desired PHP version is not found installs PHP version on demand
     # Temporarily skipped with xit
     # ./spec/build/script/php_spec.rb:76


Finished in 10.99 seconds (files took 1.25 seconds to load)
3462 examples, 0 failures, 11 pending
```
