### PR TITLE
Revert "Merge pull request #860 from travis-ci/meat-data-default-ruby"

### DIFF
--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -53,6 +53,10 @@ module Travis
           end
 
           private
+            def use_ruby
+              (data.disable_sudo? || data.config[:os] == 'osx') ? '1.9.3' : '2.2.5'
+            end
+
             def check_conditions_and_run
               sh.if(conditions) do
                 run
@@ -170,7 +174,7 @@ module Travis
 
             def cmd(cmd, *args)
               sh.cmd('type rvm &>/dev/null || source ~/.rvm/scripts/rvm', echo: false, assert: false)
-              sh.cmd("rvm #{data.default_ruby} --fuzzy do ruby -S #{cmd}", *args)
+              sh.cmd("rvm #{use_ruby} --fuzzy do ruby -S #{cmd}", *args)
             end
 
             def options

--- a/lib/travis/build/data.rb
+++ b/lib/travis/build/data.rb
@@ -17,20 +17,12 @@ module Travis
         pip:       false
       }
 
-      DEFAULT_RUBIES = {
-        default: ENV.fetch('TRAVIS_BUILD_DEFAULT_RUBY', '2.2.5'),
-        osx: ENV.fetch('TRAVIS_BUILD_OSX_DEFAULT_RUBY', '1.9.3'),
-        precise: ENV.fetch('TRAVIS_BUILD_PRECISE_DEFAULT_RUBY', '2.2.5'),
-        precise_nosudo: ENV.fetch('TRAVIS_BUILD_PRECISE_SUDO_DEFAULT_RUBY', '1.9.3')
-      }
-
-      attr_reader :data, :default_rubies
+      attr_reader :data
 
       def initialize(data, defaults = {})
         data = data.deep_symbolize_keys
         defaults = defaults.deep_symbolize_keys
         @data = DEFAULTS.deep_merge(defaults.deep_merge(data))
-        @default_rubies = DEFAULT_RUBIES.dup
       end
 
       def [](key)
@@ -111,14 +103,6 @@ module Travis
 
       def disable_sudo?
         !!data[:paranoid]
-      end
-
-      def default_ruby
-        dist_sudo_key = config[:dist].to_s
-        dist_sudo_key = "#{config[:dist]}_nosudo" if config[:sudo] == false
-        default_rubies[config[:os].to_s.to_sym] ||
-          default_rubies[dist_sudo_key.to_sym] ||
-          default_rubies.fetch(:default)
       end
 
       def source_host

--- a/lib/travis/build/script/shared/directory_cache/base.rb
+++ b/lib/travis/build/script/shared/directory_cache/base.rb
@@ -167,6 +167,10 @@ module Travis
           end
 
           private
+            def use_ruby
+              (data.disable_sudo? || data.config[:os] == 'osx') ? '1.9.3' : '2.2.5'
+            end
+
             def host_proc
               raise "#{__method__} must be overridden"
             end
@@ -180,7 +184,7 @@ module Travis
               sh.with_errexit_off do
                 sh.if "-f #{BIN_PATH}" do
                   sh.cmd('type rvm &>/dev/null || source ~/.rvm/scripts/rvm', echo: false, assert: false)
-                  sh.cmd "rvm #{data.default_ruby} --fuzzy do #{BIN_PATH} #{command} #{Array(args).join(' ')}", options.merge(echo: false, assert: false)
+                  sh.cmd "rvm #{use_ruby} --fuzzy do #{BIN_PATH} #{command} #{Array(args).join(' ')}", options.merge(echo: false, assert: false)
                 end
               end
             end

--- a/spec/build/addons/deploy_spec.rb
+++ b/spec/build/addons/deploy_spec.rb
@@ -6,10 +6,9 @@ describe Travis::Build::Addons::Deploy, :sexp do
   let(:script)  { Travis::Build::Script::Ruby.new(data) }
   let(:scripts) { { before_deploy: ['./before_deploy_1.sh', './before_deploy_2.sh'], after_deploy: ['./after_deploy_1.sh', './after_deploy_2.sh'] } }
   let(:config)  { {} }
-  let(:dist) { 'trusty' }
-  let(:sudo) { 'required' }
+  let(:disable_sudo) { false }
   let(:os)      { 'linux' }
-  let(:data)    { payload_for(:push, :ruby, paranoid: false, config: { os: os, dist: dist, sudo: sudo, addons: { deploy: config } }.merge(scripts)) }
+  let(:data)    { payload_for(:push, :ruby, paranoid: disable_sudo, config: { os: os, addons: { deploy: config } }.merge(scripts)) }
   # let(:sh)      { Travis::Shell::Builder.new }
   let(:sh)      { script.sh }
   # let(:addon)   { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
@@ -44,17 +43,10 @@ describe Travis::Build::Addons::Deploy, :sexp do
       end
     end
 
-    context 'on precise builds' do
-      let(:dist) { 'precise' }
-      it "uses Ruby 2.2.5 to deploy" do
-        expect(sexp).to include_sexp [:cmd, "rvm 2.2.5 --fuzzy do ruby -S dpl --provider=\"heroku\" --password=\"foo\" --email=\"user@host\" --fold; if [ $? -ne 0 ]; then echo \"failed to deploy\"; travis_terminate 2; fi", timing: true]
-      end
-
-      context 'without sudo' do
-        let(:sudo) { false }
-        it "uses Ruby 1.9.3 to deploy" do
-          expect(sexp).to include_sexp [:cmd, "rvm 1.9.3 --fuzzy do ruby -S dpl --provider=\"heroku\" --password=\"foo\" --email=\"user@host\" --fold; if [ $? -ne 0 ]; then echo \"failed to deploy\"; travis_terminate 2; fi", timing: true]
-        end
+    context 'when sudo is unavailable' do
+      let(:disable_sudo) { true }
+      it "uses Ruby 1.9.3 to deploy" do
+        expect(sexp).to include_sexp [:cmd, "rvm 1.9.3 --fuzzy do ruby -S dpl --provider=\"heroku\" --password=\"foo\" --email=\"user@host\" --fold; if [ $? -ne 0 ]; then echo \"failed to deploy\"; travis_terminate 2; fi", timing: true]
       end
     end
   end

--- a/spec/build/data_spec.rb
+++ b/spec/build/data_spec.rb
@@ -99,42 +99,4 @@ describe Travis::Build::Data do
       it { expect(data.cache).to eq(bundler: false, cocoapods: false, composer: false, ccache: false, pip: false) }
     end
   end
-
-  describe 'default_ruby' do
-    subject(:data) { Travis::Build::Data.new(config: config) }
-    let(:config) { { os: 'linux' } }
-
-    before do
-      data.default_rubies.merge!(
-        default: 'default',
-        osx: 'osx',
-        precise: 'precise',
-        precise_nosudo: 'precise_nosudo'
-      )
-    end
-
-    context 'on unknown os or dist' do
-      it { expect(data.default_ruby).to eq('default') }
-    end
-
-    context 'on osx' do
-      let(:config) { { os: 'osx' } }
-      it { expect(data.default_ruby).to eq('osx') }
-    end
-
-    context 'on trusty' do
-      let(:config) { { dist: 'trusty' } }
-      it { expect(data.default_ruby).to eq('default') }
-    end
-
-    context 'on precise' do
-      let(:config) { { dist: 'precise' } }
-      it { expect(data.default_ruby).to eq('precise') }
-    end
-
-    context 'on precise with sudo: false' do
-      let(:config) { { dist: 'precise', sudo: false } }
-      it { expect(data.default_ruby).to eq('precise_nosudo') }
-    end
-  end
 end

--- a/spec/build/script/directory_cache/gcs_spec.rb
+++ b/spec/build/script/directory_cache/gcs_spec.rb
@@ -101,8 +101,8 @@ describe Travis::Build::Script::DirectoryCache::Gcs, :sexp do
       end
     end
 
-    context 'on precise builds' do
-      let(:config) { { os: 'linux', dist: 'precise' } }
+    context 'when sudo is unavailable' do
+      let(:disable_sudo) { true }
       before { cache.fetch }
       it 'uses Ruby 2.2.5 to fetch' do
         should include_sexp [:cmd, "rvm 2.2.5 --fuzzy do $CASHER_DIR/bin/casher fetch #{url_tgz}", timing: true]
@@ -150,8 +150,8 @@ describe Travis::Build::Script::DirectoryCache::Gcs, :sexp do
       end
     end
 
-    context 'on precise builds' do
-      let(:config) { { os: 'linux', dist: 'precise' } }
+    context 'when sudo is unavailable' do
+      let(:disable_sudo) { true }
       before { cache.push }
       it 'uses Ruby 2.2.5 to push' do
         should include_sexp [:cmd, "rvm 2.2.5 --fuzzy do $CASHER_DIR/bin/casher push #{push_url}", timing: true]

--- a/spec/build/script/directory_cache/gcs_spec.rb
+++ b/spec/build/script/directory_cache/gcs_spec.rb
@@ -104,15 +104,8 @@ describe Travis::Build::Script::DirectoryCache::Gcs, :sexp do
     context 'when sudo is unavailable' do
       let(:disable_sudo) { true }
       before { cache.fetch }
-      it 'uses Ruby 2.2.5 to fetch' do
-        should include_sexp [:cmd, "rvm 2.2.5 --fuzzy do $CASHER_DIR/bin/casher fetch #{url_tgz}", timing: true]
-      end
-
-      context 'without sudo' do
-        let(:config) { { os: 'linux', dist: 'precise', sudo: false } }
-        it 'uses Ruby 1.9.3 to fetch' do
-          should include_sexp [:cmd, "rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher fetch #{url_tgz}", timing: true]
-        end
+      it "uses Ruby 1.9.3 to fetch" do
+        should include_sexp [:cmd, "rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher fetch #{url_tgz}", timing: true]
       end
     end
   end
@@ -153,15 +146,8 @@ describe Travis::Build::Script::DirectoryCache::Gcs, :sexp do
     context 'when sudo is unavailable' do
       let(:disable_sudo) { true }
       before { cache.push }
-      it 'uses Ruby 2.2.5 to push' do
-        should include_sexp [:cmd, "rvm 2.2.5 --fuzzy do $CASHER_DIR/bin/casher push #{push_url}", timing: true]
-      end
-
-      context 'without sudo' do
-        let(:config) { { os: 'linux', dist: 'precise', sudo: false } }
-        it 'uses Ruby 1.9.3 to push' do
-          should include_sexp [:cmd, "rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher push #{push_url}", timing: true]
-        end
+      it "uses Ruby 1.9.3 to push" do
+        should include_sexp [:cmd, "rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher push #{push_url}", timing: true]
       end
     end
   end

--- a/spec/build/script/directory_cache/s3_spec.rb
+++ b/spec/build/script/directory_cache/s3_spec.rb
@@ -95,15 +95,8 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
     context 'when sudo is unavailable' do
       let(:disable_sudo) { true }
       before { cache.fetch }
-      it 'uses Ruby 2.2.5 to fetch' do
-        should include_sexp [:cmd, "rvm 2.2.5 --fuzzy do $CASHER_DIR/bin/casher fetch #{fetch_url_tgz}", timing: true]
-      end
-
-      context 'without sudo' do
-        let(:config) { { os: 'linux', dist: 'precise', sudo: false } }
-        it 'uses Ruby 1.9.3 to fetch' do
-          should include_sexp [:cmd, "rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher fetch #{fetch_url_tgz}", timing: true]
-        end
+      it "uses Ruby 1.9.3 to fetch" do
+        should include_sexp [:cmd, "rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher fetch #{fetch_url_tgz}", timing: true]
       end
     end
   end
@@ -143,15 +136,8 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
     context 'when sudo is unavailable' do
       let(:disable_sudo) { true }
       before { cache.push }
-      it 'uses Ruby 2.2.5 to push' do
-        should include_sexp [:cmd, "rvm 2.2.5 --fuzzy do $CASHER_DIR/bin/casher push #{push_url}", timing: true]
-      end
-
-      context 'without sudo' do
-        let(:config) { { os: 'linux', dist: 'precise', sudo: false } }
-        it 'uses Ruby 1.9.3 to push' do
-          should include_sexp [:cmd, "rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher push #{push_url}", timing: true]
-        end
+      it "uses Ruby 1.9.3 to push" do
+        should include_sexp [:cmd, "rvm 1.9.3 --fuzzy do $CASHER_DIR/bin/casher push #{push_url}", timing: true]
       end
     end
   end

--- a/spec/build/script/directory_cache/s3_spec.rb
+++ b/spec/build/script/directory_cache/s3_spec.rb
@@ -92,8 +92,8 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
       end
     end
 
-    context 'on precise builds' do
-      let(:config) { { os: 'linux', dist: 'precise' } }
+    context 'when sudo is unavailable' do
+      let(:disable_sudo) { true }
       before { cache.fetch }
       it 'uses Ruby 2.2.5 to fetch' do
         should include_sexp [:cmd, "rvm 2.2.5 --fuzzy do $CASHER_DIR/bin/casher fetch #{fetch_url_tgz}", timing: true]
@@ -140,8 +140,8 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
       end
     end
 
-    context 'on precise builds' do
-      let(:config) { { os: 'linux', dist: 'precise' } }
+    context 'when sudo is unavailable' do
+      let(:disable_sudo) { true }
       before { cache.push }
       it 'uses Ruby 2.2.5 to push' do
         should include_sexp [:cmd, "rvm 2.2.5 --fuzzy do $CASHER_DIR/bin/casher push #{push_url}", timing: true]


### PR DESCRIPTION
This reverts commit 0319bf71049bf9f82730158ec5d3e474e35ab713, reversing
changes made to f2e5e21fed8306d99cbcc899f9c69c4f23d1bf54.

The PR #860 originally introduced these changes.

The changes in this PR caused deploys on container-based infrastructure
to stop working, as they used Ruby 2.2.5 instead of 1.9.3.