### PR TITLE
Fetch version from dyno metadata var

### DIFF
--- a/lib/travis/build.rb
+++ b/lib/travis/build.rb
@@ -12,7 +12,7 @@ module Travis
     class << self
       def version
         @version ||= `git rev-parse HEAD 2>/dev/null || \\
-                        echo "${SOURCE_VERSION:-unknown}"`.strip
+                        echo "${HEROKU_SLUG_COMMIT:-unknown}"`.strip
       end
 
       def self.register(key)


### PR DESCRIPTION
instead of `SOURCE_VERSION`, which is provided by a third party buildpack