### PR TITLE
Support git sparseCheckout, close travis-ci/travis-ci#5286

### DIFF
--- a/lib/travis/build/git.rb
+++ b/lib/travis/build/git.rb
@@ -7,7 +7,7 @@ module Travis
   module Build
     class Git
       DEFAULTS = {
-        git: { depth: 50, submodules: true, strategy: 'clone', quiet: false }
+        git: { depth: 50, submodules: true, strategy: 'clone', quiet: false, sparseCheckout: false }
       }
 
       attr_reader :sh, :data


### PR DESCRIPTION
This will add support for git sparseCheckout!

By default, git will checkout all the files from the repository to the filesystem, by sparseCheckout, we can decide to checkout partial of the files, so this will help decrease the number of files git will checkout, which will totally save both disk sapce, cpu time, build time!

There are only few different steps between git clone and git, but would help a lot for a huge repo :smile:

The config will have a `sparseCheckout` under `git` section to point to the **file** contains sparseCheckout config like this:

```yaml
git:
  depth: 10
  sparseCheckout: .travis.sparseCheckoutList
```

Please fell free to test and feedback!

ref:
 - https://git-scm.com/docs/git-read-tree
 - https://github.com/cdnjs/cdnjs/blob/master/documents/sparseCheckout.md
