### PR TITLE
Ensure SHELL, TERM, and USER are defined

### DIFF
--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -12,6 +12,16 @@ ANSI_GREEN="\033[32;1m"
 ANSI_RESET="\033[0m"
 ANSI_CLEAR="\033[0K"
 
+if [ $TERM = dumb ]; then
+  unset TERM
+fi
+: "${SHELL:=/bin/bash}"
+: "${TERM:=xterm}"
+: "${USER:=travis}"
+export SHELL
+export TERM
+export USER
+
 TRAVIS_TEST_RESULT=
 TRAVIS_CMD=
 

--- a/spec/build/templates/header_spec.rb
+++ b/spec/build/templates/header_spec.rb
@@ -26,7 +26,10 @@ describe 'header.sh', integration: true do
 
   let :bash_output do
     IO.popen(
-      ['bash', '-c', header_rendered + bash_body, err: [:child, :out]]
+      [
+        'env', '-i', "HOME=#{build_dir}",
+        'bash', '-c', header_rendered + bash_body, err: %i(child out)
+      ]
     ).read
   end
 
@@ -50,6 +53,16 @@ describe 'header.sh', integration: true do
   ).each do |api_function|
     it "defines #{api_function}" do
       expect(bash_output).to match(/^#{api_function} is a function/)
+    end
+  end
+
+  {
+    SHELL: '/bin/bash',
+    TERM: 'xterm',
+    USER: 'travis'
+  }.each do |env_var, val|
+    it "exports #{env_var}" do
+      expect(bash_output).to match(/^declare -x #{env_var}="#{val}"$/)
     end
   end
 


### PR DESCRIPTION
A recent rollout of refreshed infrastructure for running container-based builds revealed the assumption that `SHELL`, `TERM`, and `USER` env vars were being defined by ... something ... somewhere... and that they would always be around.  As it turns out, when executing a job via the docker remoting API as opposed to SSH, these vars are not defined.  This addition ensures that they are defined, with values that *should* work for the use cases of which we're currently aware.