### PR TITLE
Fix an error where Sierra builds can't use git

### DIFF
--- a/lib/travis/build/appliances/disable_ssh_roaming.rb
+++ b/lib/travis/build/appliances/disable_ssh_roaming.rb
@@ -5,10 +5,14 @@ module Travis
     module Appliances
       class DisableSshRoaming < Base
         def apply
-          sh.cmd %(mkdir -p $HOME/.ssh)
-          sh.cmd %(chmod 0700 $HOME/.ssh)
-          sh.cmd %(touch $HOME/.ssh/config)
-          sh.cmd %(echo -e "Host *\n  UseRoaming no\n" | cat - $HOME/.ssh/config > $HOME/.ssh/config.tmp && mv $HOME/.ssh/config.tmp $HOME/.ssh/config)
+          sh.cmd <<-EOF
+if [ $(sw_vers -productVersion | cut -d . -f 2) -lt 12 ]; do
+  mkdir -p $HOME/.ssh
+  chmod 0700 $HOME/.ssh
+  touch $HOME/.ssh/config
+  echo -e "Host *\n  UseRoaming no\n" | cat - $HOME/.ssh/config > $HOME/.ssh/config.tmp && mv $HOME/.ssh/config.tmp $HOME/.ssh/config
+fi
+          EOF
         end
       end
     end

--- a/lib/travis/build/appliances/disable_ssh_roaming.rb
+++ b/lib/travis/build/appliances/disable_ssh_roaming.rb
@@ -5,14 +5,12 @@ module Travis
     module Appliances
       class DisableSshRoaming < Base
         def apply
-          sh.cmd <<-EOF
-if [ $(sw_vers -productVersion | cut -d . -f 2) -lt 12 ]; do
-  mkdir -p $HOME/.ssh
-  chmod 0700 $HOME/.ssh
-  touch $HOME/.ssh/config
-  echo -e "Host *\n  UseRoaming no\n" | cat - $HOME/.ssh/config > $HOME/.ssh/config.tmp && mv $HOME/.ssh/config.tmp $HOME/.ssh/config
-fi
-          EOF
+          sh.if "$(sw_vers -productVersion | cut -d . -f 2) -lt 12" do
+            sh.cmd %(mkdir -p $HOME/.ssh)
+            sh.cmd %(chmod 0700 $HOME/.ssh)
+            sh.cmd %(touch $HOME/.ssh/config)
+            sh.cmd %(echo -e "Host *\n  UseRoaming no\n" | cat - $HOME/.ssh/config > $HOME/.ssh/config.tmp && mv $HOME/.ssh/config.tmp $HOME/.ssh/config)
+          end
         end
       end
     end

--- a/spec/build/script/shared/appliances/disable_ssh_roaming.rb
+++ b/spec/build/script/shared/appliances/disable_ssh_roaming.rb
@@ -1,7 +1,8 @@
 shared_examples_for 'disables OpenSSH roaming' do
   let(:disable_ssh_roaming) { %(echo -e "Host *\n  UseRoaming no\n" | cat - $HOME/.ssh/config > $HOME/.ssh/config.tmp && mv $HOME/.ssh/config.tmp $HOME/.ssh/config) }
+  let(:sexp) { sexp_find(subject, [:if, "$(sw_vers -productVersion | cut -d . -f 2) -lt 12"]) }
 
   it 'disables OpenSSH roaming' do
-    should include_sexp [:cmd, disable_ssh_roaming]
+    sexp.should include_sexp [:cmd, disable_ssh_roaming]
   end
 end


### PR DESCRIPTION
Due to the CVE earlier this year regarding "Roaming" mode in SSH, Apple
has decided it's a good idea to just completely take out SSH roaming
entirely, starting in macOS 10.12. Defining an invalid directive in the
SSH configuration breaks Git, so we need to not set that directive.

The "if OS minor version is < 12" syntax is weird, but is used elsewhere
in the repo just the same way.