### PR TITLE
Insulate use of `sw_vers` a bit

### DIFF
--- a/lib/travis/build/appliances/disable_ssh_roaming.rb
+++ b/lib/travis/build/appliances/disable_ssh_roaming.rb
@@ -5,7 +5,7 @@ module Travis
     module Appliances
       class DisableSshRoaming < Base
         def apply
-          sh.if "$(sw_vers -productVersion | cut -d . -f 2) -lt 12" do
+          sh.if %("$(sw_vers -productVersion 2>/dev/null | cut -d . -f 2)" -lt 12) do
             sh.cmd %(mkdir -p $HOME/.ssh)
             sh.cmd %(chmod 0700 $HOME/.ssh)
             sh.cmd %(touch $HOME/.ssh/config)

--- a/spec/build/script/shared/appliances/disable_ssh_roaming.rb
+++ b/spec/build/script/shared/appliances/disable_ssh_roaming.rb
@@ -1,8 +1,8 @@
 shared_examples_for 'disables OpenSSH roaming' do
   let(:disable_ssh_roaming) { %(echo -e "Host *\n  UseRoaming no\n" | cat - $HOME/.ssh/config > $HOME/.ssh/config.tmp && mv $HOME/.ssh/config.tmp $HOME/.ssh/config) }
-  let(:sexp) { sexp_find(subject, [:if, "$(sw_vers -productVersion | cut -d . -f 2) -lt 12"]) }
+  let(:sexp) { sexp_find(subject, [:if, %("$(sw_vers -productVersion 2>/dev/null | cut -d . -f 2)" -lt 12)]) }
 
   it 'disables OpenSSH roaming' do
-    sexp.should include_sexp [:cmd, disable_ssh_roaming]
+    expect(sexp).to include_sexp [:cmd, disable_ssh_roaming]
   end
 end


### PR DESCRIPTION
to prevent errors like `sw_vers: command not found` from showing up in logs on linux builds.