### PR TITLE
Reload jdk_switcher_rc after removing symlink

### DIFF
--- a/lib/travis/build/appliances/rm_oraclejdk8_symlink.rb
+++ b/lib/travis/build/appliances/rm_oraclejdk8_symlink.rb
@@ -10,6 +10,8 @@ module Travis
           sh.if "-L #{symlink}" do
             sh.echo "Removing symlink #{symlink}"
             sh.cmd "sudo rm -f #{symlink}", echo: true
+            sh.echo "Reload jdk_switcher"
+            sh.cmd "source $HOME/.jdk_switcher_rc", echo: true
           end
         end
 


### PR DESCRIPTION
So that `$ORACLEJDK8_JAVA_HOME` is set correctly.

This resulted in worse problem than before, where we ended up with:

    update-java-alternatives: directory does not exist: /usr/lib/jvm/java-8-oracle-amd64