### PR TITLE
apt: Remove "BETA" apt addon quite mature now

### DIFF
--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -97,7 +97,7 @@ module Travis
           end
 
           def add_apt_sources
-            sh.echo "Adding APT Sources (BETA)", ansi: :yellow
+            sh.echo "Adding APT Sources", ansi: :yellow
 
             whitelisted = []
             disallowed = []
@@ -155,7 +155,7 @@ module Travis
           end
 
           def add_apt_packages
-            sh.echo "Installing APT Packages (BETA)", ansi: :yellow
+            sh.echo "Installing APT Packages", ansi: :yellow
 
             whitelisted, disallowed = config_packages.partition { |pkg| package_whitelisted?(package_whitelists[config_dist] || [], pkg) }
 


### PR DESCRIPTION
Output fix only - Its a lot more mature than BETA now.