### PR TITLE
Remove apt source for apt.dockerproject.org

### DIFF
--- a/lib/travis/build/appliances.rb
+++ b/lib/travis/build/appliances.rb
@@ -22,6 +22,7 @@ require 'travis/build/appliances/services'
 require 'travis/build/appliances/show_system_info'
 require 'travis/build/appliances/validate'
 require 'travis/build/appliances/npm_registry'
+require 'travis/build/appliances/rm_dockerproject_apt_source'
 
 module Travis
   module Build

--- a/lib/travis/build/appliances/rm_dockerproject_apt_source.rb
+++ b/lib/travis/build/appliances/rm_dockerproject_apt_source.rb
@@ -1,0 +1,25 @@
+require 'travis/build/appliances/base'
+
+module Travis
+  module Build
+    module Appliances
+      class RmDockerprojectAptSource < Base
+        MSG = "Due to infrastructure issues with apt.dockerproject.org we're disabling the apt repository for now. " \
+              "If you're relying on being able to change your Docker version via \\`apt-get\\`, that will not work right now. " \
+              "We're sorry for the trouble, please follow https://github.com/travis-ci/travis-ci/issues/6881 for updates on when the apt repository infrastructure is fixed"
+        CMD = 'sudo rm -f /etc/apt/sources.list.d/docker.list'
+
+        def apply
+          sh.if "\"$(lsb_release -cs)\" = trusty" do
+            sh.echo MSG, ansi: :yellow
+            sh.cmd CMD
+          end
+        end
+
+        def apply?
+          ! data.disable_sudo?
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -171,6 +171,7 @@ module Travis
           apply :npm_registry
           apply :rvm_use
           apply :rm_oraclejdk8_symlink
+          apply :rm_dockerproject_apt_source
         end
 
         def checkout


### PR DESCRIPTION
There is an issue with this APT source preventing use of `apt`.

See
https://github.com/travis-ci/travis-ci/issues/6881 for more details.