### PR TITLE
Determine Node.js version at run time

### DIFF
--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -204,6 +204,7 @@ module Travis
           end
 
           def install_yarn
+            sh.echo   "Installing yarn", ansi: :green
             sh.cmd    "curl -o- -L https://yarnpkg.com/install.sh | bash", echo: true
             sh.echo   "Setting up \\$PATH", ansi: :green
             sh.export "PATH", "$HOME/.yarn/bin:$PATH"


### PR DESCRIPTION
nvm supports additional shorthands for Node.js versions, such as
"stable", as well as leading "v" (e.g., "v6"), which evaluates to "0"
when passed to `#to_i`. This is bad news for determining whether
`yarn`'s requirment is met.

Instead, we use `node --version` output at run time to decide.

Note that `node --version` does have a leading "v", so we need to drop
that before passing on to the `vers2int` function.