### PR TITLE
Skip yarn archive GPG signature verification if gpg is unavailable

### DIFF
--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -204,6 +204,9 @@ module Travis
           end
 
           def install_yarn
+            sh.if "-z \"$(command -v gpg)\"" do
+              sh.export "YARN_GPG", "no"
+            end
             sh.echo   "Installing yarn", ansi: :green
             sh.cmd    "curl -o- -L https://yarnpkg.com/install.sh | bash", echo: true
             sh.echo   "Setting up \\$PATH", ansi: :green


### PR DESCRIPTION
Some Mac images lack `gpg`, and Yarn installation fails.
https://github.com/travis-ci/travis-ci/issues/6916

We skip it for now, since installation (via Homebrew) will add
nontrivial amount of time to the build.