### PR TITLE
Accommodate firefox binaries by fixing $PATH

### DIFF
--- a/lib/travis/build/addons/firefox.rb
+++ b/lib/travis/build/addons/firefox.rb
@@ -25,7 +25,7 @@ module Travis
             sh.if '$(uname) = "Linux"' do
               sh.cmd "wget -O /tmp/#{filename} $FIREFOX_SOURCE_URL", echo: true, timing: true, retry: true
               sh.cmd "tar xf /tmp/#{filename}"
-              sh.cmd "sudo ln -sf #{install_dir}/firefox/firefox /usr/local/bin/firefox", echo: false
+              sh.export 'PATH', "#{install_dir}/firefox:$PATH"
             end
             sh.elif '$(uname) = "Darwin"' do
               sh.cmd "wget -O /tmp/#{filename('dmg')} $FIREFOX_SOURCE_URL", echo: true, timing: true, retry: true

--- a/spec/build/addons/firefox_spec.rb
+++ b/spec/build/addons/firefox_spec.rb
@@ -29,28 +29,28 @@ describe Travis::Build::Addons::Firefox, :sexp do
 
     it { should include_sexp [:cmd, 'wget -O /tmp/firefox-20.0.tar.bz2 $FIREFOX_SOURCE_URL', echo: true, timing: true, retry: true] }
     it { should include_sexp [:cmd, 'tar xf /tmp/firefox-20.0.tar.bz2'] }
-    it { should include_sexp [:cmd, 'sudo ln -sf $HOME/firefox-20.0/firefox/firefox /usr/local/bin/firefox'] }
+    it { should include_sexp [:export, ['PATH', "$HOME/firefox-20.0/firefox:$PATH"], echo: true] }
     it { should include_sexp [:cd, :back, stack: true] }
   end
 
   context 'given a valid version "50.0b6"' do
     let(:config) { '50.0b6' }
-    it { should include_sexp [:cmd, 'sudo ln -sf $HOME/firefox-50.0b6/firefox/firefox /usr/local/bin/firefox'] }
+    it { should include_sexp [:export, ['PATH', "$HOME/firefox-50.0b6/firefox:$PATH"], echo: true] }
   end
 
   context 'given a valid version "latest"' do
     let(:config) { 'latest' }
-    it { should include_sexp [:cmd, 'sudo ln -sf $HOME/firefox-latest/firefox/firefox /usr/local/bin/firefox'] }
+    it { should include_sexp [:export, ['PATH', "$HOME/firefox-latest/firefox:$PATH"], echo: true] }
   end
 
   context 'given a valid version "latest-beta"' do
     let(:config) { 'latest-beta' }
-    it { should include_sexp [:cmd, 'sudo ln -sf $HOME/firefox-latest-beta/firefox/firefox /usr/local/bin/firefox'] }
+    it { should include_sexp [:export, ['PATH', "$HOME/firefox-latest-beta/firefox:$PATH"], echo: true] }
   end
 
   context 'given a valid version "latest-esr"' do
     let(:config) { 'latest-esr' }
-    it { should include_sexp [:cmd, 'sudo ln -sf $HOME/firefox-latest-esr/firefox/firefox /usr/local/bin/firefox'] }
+    it { should include_sexp [:export, ['PATH', "$HOME/firefox-latest-esr/firefox:$PATH"], echo: true] }
   end
 
   context 'given a invalid version string' do
@@ -61,7 +61,7 @@ describe Travis::Build::Addons::Firefox, :sexp do
     end
 
     it { should include_sexp [:echo, "Invalid version '20.0\\;\\ sudo\\ rm\\ -rf\\ /' given.", ansi: :red] }
-    it { should_not include_sexp [:cmd, 'sudo ln -sf $HOME/firefox-20.0/firefox/firefox /usr/local/bin/firefox'] }
+    it { should_not include_sexp [:export, ['PATH', "$HOME/firefox-20.0/firefox:$PATH"], echo: true] }
   end
 end
 


### PR DESCRIPTION
The firefox archive contains more than just `firefox`, so we need to put
the directory into which we expanded the archive to `$PATH`, so that all
associated binaries are found correctly.

This resolves https://github.com/travis-ci/travis-ci/issues/4649.