### PR TITLE
Remove `./node_modules/.bin` from $PATH

### DIFF
--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -18,6 +18,7 @@ module Travis
         def setup
           super
           convert_legacy_nodejs_config
+          remove_node_modules_bin_from_path
           update_nvm
           nvm_install
           npm_disable_prefix
@@ -211,6 +212,12 @@ module Travis
             sh.cmd    "curl -o- -L https://yarnpkg.com/install.sh | bash", echo: true
             sh.echo   "Setting up \\$PATH", ansi: :green
             sh.export "PATH", "$HOME/.yarn/bin:$PATH"
+          end
+
+          def remove_node_modules_bin_from_path
+            sh.echo "Removing `./node_modules/bin` from \\$PATH, because this can cause subtle bugs. " \
+              "See https://github.com/travis-ci/travis-ci/issue/5092 for details."
+            sh.export "PATH", "echo $PATH | tr : \"\\n\" | sed -e \"#{Regexp.new('./node_modules/bin').inspect}d\" | tr \"\\n\" :"
           end
       end
     end

--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -215,9 +215,11 @@ module Travis
           end
 
           def remove_node_modules_bin_from_path
-            sh.echo "Removing \\`./node_modules/.bin\\` from \\$PATH, because this can cause subtle bugs. " \
-              "See https://github.com/travis-ci/travis-ci/issue/5092 for details.", ansi: :red
-            sh.export "PATH", "$(echo $PATH | tr : \"\\n\" | sed -e \"#{Regexp.new('\./node_modules/\.bin').inspect}d\" | tr \"\\n\" :)"
+            sh.if "$(echo $PATH | grep '\./node_modules/.bin')" do
+              sh.echo "Removing \\`./node_modules/.bin\\` from \\$PATH, because this can cause subtle bugs. " \
+                "See https://github.com/travis-ci/travis-ci/issue/5092 for details.", ansi: :red
+              sh.export "PATH", "$(echo $PATH | tr : \"\\n\" | sed -e \"#{Regexp.new('\./node_modules/\.bin').inspect}d\" | tr \"\\n\" :)"
+            end
           end
       end
     end

--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -215,7 +215,7 @@ module Travis
           end
 
           def remove_node_modules_bin_from_path
-            sh.echo "Removing `./node_modules/bin` from \\$PATH, because this can cause subtle bugs. " \
+            sh.echo "Removing \\`./node_modules/.bin\\` from \\$PATH, because this can cause subtle bugs. " \
               "See https://github.com/travis-ci/travis-ci/issue/5092 for details."
             sh.export "PATH", "$(echo $PATH | tr : \"\\n\" | sed -e \"#{Regexp.new('\./node_modules/\.bin').inspect}d\" | tr \"\\n\" :)"
           end

--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -217,7 +217,7 @@ module Travis
           def remove_node_modules_bin_from_path
             sh.echo "Removing `./node_modules/bin` from \\$PATH, because this can cause subtle bugs. " \
               "See https://github.com/travis-ci/travis-ci/issue/5092 for details."
-            sh.export "PATH", "echo $PATH | tr : \"\\n\" | sed -e \"#{Regexp.new('./node_modules/bin').inspect}d\" | tr \"\\n\" :"
+            sh.export "PATH", "$(echo $PATH | tr : \"\\n\" | sed -e \"#{Regexp.new('./node_modules/bin').inspect}d\" | tr \"\\n\" :)"
           end
       end
     end

--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -216,7 +216,7 @@ module Travis
 
           def remove_node_modules_bin_from_path
             sh.echo "Removing \\`./node_modules/.bin\\` from \\$PATH, because this can cause subtle bugs. " \
-              "See https://github.com/travis-ci/travis-ci/issue/5092 for details."
+              "See https://github.com/travis-ci/travis-ci/issue/5092 for details.", ansi: :red
             sh.export "PATH", "$(echo $PATH | tr : \"\\n\" | sed -e \"#{Regexp.new('\./node_modules/\.bin').inspect}d\" | tr \"\\n\" :)"
           end
       end

--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -217,7 +217,7 @@ module Travis
           def remove_node_modules_bin_from_path
             sh.echo "Removing `./node_modules/bin` from \\$PATH, because this can cause subtle bugs. " \
               "See https://github.com/travis-ci/travis-ci/issue/5092 for details."
-            sh.export "PATH", "$(echo $PATH | tr : \"\\n\" | sed -e \"#{Regexp.new('./node_modules/bin').inspect}d\" | tr \"\\n\" :)"
+            sh.export "PATH", "$(echo $PATH | tr : \"\\n\" | sed -e \"#{Regexp.new('\./node_modules/\.bin').inspect}d\" | tr \"\\n\" :)"
           end
       end
     end


### PR DESCRIPTION
Some npm modules define commands with widely used bash functions
(and probably others).
Putting this component in `$PATH` causes subtle issues, such as
https://github.com/travis-ci/travis-ci/issues/5092.
We are removing it, so that this is no longer the case.

This will most likely break some builds, so we add a warning.