### PR TITLE
Embed GHC-finding func for haskell jobs

### DIFF
--- a/lib/travis/build/script/haskell.rb
+++ b/lib/travis/build/script/haskell.rb
@@ -3,7 +3,7 @@ module Travis
     class Script
       class Haskell < Script
         DEFAULTS = {
-          ghc: (ENV['TRAVIS_DEFAULT_GHC'] || '7.6.3').untaint
+          ghc: (ENV['TRAVIS_BUILD_GHC_DEFAULT'] || '7.6.3').untaint
         }
 
         def setup

--- a/lib/travis/build/script/haskell.rb
+++ b/lib/travis/build/script/haskell.rb
@@ -3,7 +3,7 @@ module Travis
     class Script
       class Haskell < Script
         DEFAULTS = {
-          ghc: (ENV['TRAVIS_BUILD_GHC_DEFAULT'] || '7.6.3').untaint
+          ghc: (ENV['TRAVIS_BUILD_GHC_DEFAULT'] || '7.8.4').untaint
         }
 
         def setup

--- a/lib/travis/build/script/haskell.rb
+++ b/lib/travis/build/script/haskell.rb
@@ -2,10 +2,19 @@ module Travis
   module Build
     class Script
       class Haskell < Script
-        DEFAULTS = {}
+        DEFAULTS = {
+          ghc: (ENV['TRAVIS_DEFAULT_GHC'] || '7.6.3').untaint
+        }
 
         def setup
           super
+          sh.raw(
+            template(
+              'haskell.sh',
+              default_ghc: DEFAULTS[:ghc],
+              root: '/'
+            )
+          )
           sh.export 'PATH', "#{path}:$PATH", assert: true
           sh.cmd 'cabal update', fold: 'cabal', retry: true
         end
@@ -25,7 +34,7 @@ module Travis
         end
 
         def path
-          "/usr/local/ghc/$(ghc_find #{version})/bin/"
+          "/usr/local/ghc/$(travis_ghc_find #{version})/bin/"
         end
 
         def version

--- a/lib/travis/build/script/haskell.rb
+++ b/lib/travis/build/script/haskell.rb
@@ -34,7 +34,7 @@ module Travis
         end
 
         def path
-          "/usr/local/ghc/$(travis_ghc_find #{version})/bin/"
+          "${TRAVIS_GHC_ROOT}/$(travis_ghc_find #{version})/bin"
         end
 
         def version

--- a/lib/travis/build/templates/haskell.sh
+++ b/lib/travis/build/templates/haskell.sh
@@ -4,6 +4,9 @@ if [[ ! -d "${TRAVIS_GHC_ROOT}" && -d '<%= root %>/opt/ghc' ]]; then
   TRAVIS_GHC_ROOT='<%= root %>/opt/ghc'
 fi
 
+export TRAVIS_GHC_DEFAULT
+export TRAVIS_GHC_ROOT
+
 function travis_ghc_find() {
   local search="${1}"
   local v

--- a/lib/travis/build/templates/haskell.sh
+++ b/lib/travis/build/templates/haskell.sh
@@ -1,0 +1,26 @@
+: "${TRAVIS_GHC_DEFAULT:=<%= default_ghc %>}"
+: "${TRAVIS_GHC_ROOT:=<%= root %>/usr/local/ghc}"
+
+function travis_ghc_find() {
+  local search="${1}"
+  local v
+  if [[ ! "${search}"  ]]; then
+    echo "${TRAVIS_GHC_DEFAULT}"
+  else
+    for v in "${TRAVIS_GHC_ROOT}"/*/; do
+      v=${v%%/}
+      v=${v##*/}
+      if [[ ! -d "${TRAVIS_GHC_ROOT}/${v}" ]]; then
+        continue
+      fi
+      if [[ "${v}" == ${search}* ]]; then
+        echo "${v}"
+        return 0
+      fi
+    done
+    echo "travis_ghc_find: error, no such version ${search}" >&2
+    echo "travis_ghc_find: using default version ${TRAVIS_GHC_VERSIONS}" >&2
+    echo "${TRAVIS_GHC_DEFAULT}"
+    return 1
+  fi
+}

--- a/lib/travis/build/templates/haskell.sh
+++ b/lib/travis/build/templates/haskell.sh
@@ -1,5 +1,8 @@
 : "${TRAVIS_GHC_DEFAULT:=<%= default_ghc %>}"
 : "${TRAVIS_GHC_ROOT:=<%= root %>/usr/local/ghc}"
+if [[ ! -d "${TRAVIS_GHC_ROOT}" && -d '<%= root %>/opt/ghc' ]]; then
+  TRAVIS_GHC_ROOT='<%= root %>/opt/ghc'
+fi
 
 function travis_ghc_find() {
   local search="${1}"

--- a/lib/travis/build/templates/haskell.sh
+++ b/lib/travis/build/templates/haskell.sh
@@ -4,7 +4,7 @@
 function travis_ghc_find() {
   local search="${1}"
   local v
-  if [[ ! "${search}"  ]]; then
+  if [[ ! "${search}" ]]; then
     echo "${TRAVIS_GHC_DEFAULT}"
   else
     for v in "${TRAVIS_GHC_ROOT}"/*/; do

--- a/spec/build/script/haskell_spec.rb
+++ b/spec/build/script/haskell_spec.rb
@@ -16,7 +16,7 @@ describe Travis::Build::Script::Haskell, :sexp do
   it "exports PATH variable" do
     version = "version"
     data[:config][:ghc] = version
-    should include_sexp [:export, ['PATH', "/usr/local/ghc/$(ghc_find #{version})/bin/:$PATH"], echo: true, assert: true]
+    should include_sexp [:export, ['PATH', "/usr/local/ghc/$(travis_ghc_find #{version})/bin/:$PATH"], echo: true, assert: true]
   end
 
   it 'runs cabal update' do

--- a/spec/build/script/haskell_spec.rb
+++ b/spec/build/script/haskell_spec.rb
@@ -16,7 +16,7 @@ describe Travis::Build::Script::Haskell, :sexp do
   it "exports PATH variable" do
     version = "version"
     data[:config][:ghc] = version
-    should include_sexp [:export, ['PATH', "/usr/local/ghc/$(travis_ghc_find #{version})/bin/:$PATH"], echo: true, assert: true]
+    should include_sexp [:export, ['PATH', "${TRAVIS_GHC_ROOT}/$(travis_ghc_find #{version})/bin:$PATH"], echo: true, assert: true]
   end
 
   it 'runs cabal update' do


### PR DESCRIPTION
so that there is no dependency on the underlying VM having such a tool
available.  Also, modified the func a bit to accept only a default version and
otherwise use the versions available on the system for matching.