### PR TITLE
Add ./node_modules/.bin to $PATH

### DIFF
--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -17,6 +17,7 @@ module Travis
 
         def setup
           super
+          prepend_path './node_modules/.bin'
           convert_legacy_nodejs_config
           update_nvm
           nvm_install
@@ -211,6 +212,12 @@ module Travis
             sh.cmd    "curl -o- -L https://yarnpkg.com/install.sh | bash", echo: true
             sh.echo   "Setting up \\$PATH", ansi: :green
             sh.export "PATH", "$HOME/.yarn/bin:$PATH"
+          end
+
+          def prepend_path(path)
+            sh.if "$(echo :$PATH: | grep -v :#{path}:)" do
+              sh.export "PATH", "#{path}:$PATH", echo: true
+            end
           end
       end
     end


### PR DESCRIPTION
https://github.com/travis-ci/travis-cookbooks/pull/786 removed it, but
this broke many Ember-based repositories, so we will reinstate it.

This is meant to be a hot fix, which would be reverted after a new set
of build images are rolled out.