### PR TITLE
Sonarqube addon

### DIFF
--- a/lib/travis/build/addons/sonarqube.rb
+++ b/lib/travis/build/addons/sonarqube.rb
@@ -1,3 +1,4 @@
+require 'digest/md5'
 require 'shellwords'
 require 'travis/build/addons/base'
 
@@ -21,18 +22,26 @@ module Travis
         }
           
         def before_before_script
+          sh.fold 'sonarqube.addon' do
+            folded
+          end
+        end
+        
+        def folded
+          sh.echo "SonarQube addon", echo: false, ansi: :yellow
+          sh.echo "addon hash: #{addon_hash}", echo: false
           @sonarqube_scanner_params = {}
           install_sonar_scanner
           install_build_wrapper
-          
+        
           if !data.secure_env?
-              skip :no_secure_env
-              return
+            skip :no_secure_env
+            return
           elsif !branch_valid?
-              skip :branch_disabled
-              return
+            skip :branch_disabled
+            return
           end
-          
+        
           export_tokens
 
           if data.pull_request
@@ -44,7 +53,7 @@ module Travis
             end
             return
           end
-          
+        
           run
         end
         
@@ -58,38 +67,33 @@ module Travis
         end
           
         def skip(reason)
-          sh.fold 'sonarqube.skip' do
-            sh.echo "Skipping SonarQube Scan because " + SKIP_MSGS[reason], echo: false, ansi: :yellow
-            sh.export 'SONARQUBE_SKIPPED', "true", echo: true
-            export_scanner_params({'sonar.scanner.skip'=> 'true'})
-          end
+          sh.echo "Skipping SonarQube Scan because " + SKIP_MSGS[reason], echo: false, ansi: :yellow
+          sh.export 'SONARQUBE_SKIPPED', "true", echo: true
+          export_scanner_params({'sonar.scanner.skip'=> 'true'})
         end
         
         def install_sonar_scanner
-          sh.fold 'sonarqube.install' do
-            sh.echo "Preparing SonarQube Scanner CLI", echo: false, ansi: :yellow
-            scr = <<SH
+          sh.echo "Preparing SonarQube Scanner CLI", echo: false, ansi: :yellow
+          scr = <<SH
   rm -rf #{SCANNER_HOME}
   mkdir -p #{SCANNER_HOME}
   curl -sSLo #{SCANNER_HOME}/sonar-scanner.zip #{SCANNER_CLI_REPO}/org/sonarsource/scanner/cli/sonar-scanner-cli/#{SCANNER_CLI_VERSION}/sonar-scanner-cli-#{SCANNER_CLI_VERSION}.zip
   unzip #{SCANNER_HOME}/sonar-scanner.zip -d #{SCANNER_HOME}
 SH
-            sh.raw(scr, echo: false)
-            sh.export 'SONAR_SCANNER_HOME', "#{SCANNER_HOME}/sonar-scanner-#{SCANNER_CLI_VERSION}", echo: true
-            sh.export 'PATH', "\"$PATH:#{SCANNER_HOME}/sonar-scanner-#{SCANNER_CLI_VERSION}/bin\"", echo: false
-          end
+          sh.raw(scr, echo: false)
+          sh.export 'SONAR_SCANNER_HOME', "#{SCANNER_HOME}/sonar-scanner-#{SCANNER_CLI_VERSION}", echo: true
+          sh.export 'PATH', "\"$PATH:#{SCANNER_HOME}/sonar-scanner-#{SCANNER_CLI_VERSION}/bin\"", echo: false
         end
         
         def install_build_wrapper
-          if data.language == "java" || data.language == "node_js"
+          if language == "java" || language == "node_js"
             sh.echo "Not installing SonarSource build-wrapper because it's a Java or Javascript project", echo: false, ansi: :yellow
             return
           end
           
-          sh.fold 'sonarsource.build-wrapper.install' do
-            sh.echo "Preparing build wrapper for SonarSource C/C++ plugin", echo: false, ansi: :yellow
+          sh.echo "Preparing build wrapper for SonarSource C/C++ plugin", echo: false, ansi: :yellow
             
-            case data.config[:os]
+          case os
             when 'linux'
               build_wrapper=BUILD_WRAPPER_LINUX
             when 'osx'
@@ -97,37 +101,34 @@ SH
             else
               sh.echo "Can't install SonarSource build wrapper for platform: $TRAVIS_OS_NAME.", ansi: :yellow
               return
-            end
-            
-            sh.cmd "CPPHASH=`curl -s #{DEFAULT_SQ_HOST_URL}/deploy/plugins/index.txt | grep \"^cpp\" | sed \"s/.*|\\(.*\\)/\\1/\"`"
-            sh.cmd "HASH_DIR=#{CACHE_DIR}/$CPPHASH"
-            
-            sh.if "-d $HASH_DIR/#{build_wrapper}" do
-              sh.echo "Using cached build wrapper"
-            end
-            sh.else do
-              sh.mkdir "$HASH_DIR", echo: false, recursive: true
-              sh.cmd "curl -sSLo $HASH_DIR/#{build_wrapper}.zip #{DEFAULT_SQ_HOST_URL}/static/cpp/#{build_wrapper}.zip", echo: false, retry: true
-              sh.cmd "unzip -o $HASH_DIR/#{build_wrapper}.zip -d $HASH_DIR", echo: false
-            end
-            
-            sh.export 'PATH', "\"$PATH:$HASH_DIR/#{build_wrapper}\"", echo: false
           end
+            
+          sh.cmd "sq_cpp_hash=`curl -s #{DEFAULT_SQ_HOST_URL}/deploy/plugins/index.txt | grep \"^cpp\" | sed \"s/.*|\\(.*\\)/\\1/\"`"
+          sh.cmd "sq_build_wrapper_dir=#{CACHE_DIR}/$sq_cpp_hash"
+            
+          sh.if "-d $sq_build_wrapper_dir/#{build_wrapper}" do
+            sh.echo "Using cached build wrapper"
+          end
+          sh.else do
+            sh.mkdir "$sq_build_wrapper_dir", echo: false, recursive: true
+            sh.cmd "curl -sSLo $sq_build_wrapper_dir/#{build_wrapper}.zip #{DEFAULT_SQ_HOST_URL}/static/cpp/#{build_wrapper}.zip", echo: false, retry: true
+            sh.cmd "unzip -o $sq_build_wrapper_dir/#{build_wrapper}.zip -d $sq_build_wrapper_dir", echo: false
+          end
+            
+          sh.export 'PATH', "\"$PATH:$sq_build_wrapper_dir/#{build_wrapper}\"", echo: false
         end
         
         def run
-          sh.fold 'sonarqube.run' do
-            sh.echo "Preparing SonarQube Scanner parameters", echo: false, ansi: :yellow
-            if data.pull_request
-              add_scanner_param("sonar.analysis.mode", "preview")
-              add_scanner_param("sonar.github.repository", data.repository[:slug])
-              add_scanner_param("sonar.github.pullRequest", data.pull_request)
-              add_scanner_param("sonar.github.oauth", "$SONAR_GITHUB_TOKEN")
-            end
+          sh.echo "Preparing SonarQube Scanner parameters", echo: false, ansi: :yellow
+          if data.pull_request
+            add_scanner_param("sonar.analysis.mode", "preview")
+            add_scanner_param("sonar.github.repository", data.repository[:slug])
+            add_scanner_param("sonar.github.pullRequest", data.pull_request)
+            add_scanner_param("sonar.github.oauth", "$SONAR_GITHUB_TOKEN")
+          end
             
-            if data.branch != 'master'
-              add_scanner_param("sonar.branch", data.branch)
-            end
+          if data.branch != 'master'
+            add_scanner_param("sonar.branch", data.branch)
           end
           
           add_scanner_param("sonar.host.url", DEFAULT_SQ_HOST_URL)
@@ -168,6 +169,18 @@ SH
               json << " }\""
               sh.export 'SONARQUBE_SCANNER_PARAMS', json, echo: false
             end
+          end
+          
+          def addon_hash
+            Digest::MD5.hexdigest(File.read(__FILE__).gsub(/\s+/, ""))
+          end
+          
+          def language
+            data.language
+          end
+          
+          def os
+            data.config[:os]
           end
         
           def token

--- a/spec/build/addons/sonarqube_spec.rb
+++ b/spec/build/addons/sonarqube_spec.rb
@@ -19,8 +19,8 @@ describe Travis::Build::Addons::Sonarqube, :sexp do
     
     it { should include_sexp [:export, ['SONAR_SCANNER_HOME', '$HOME/.sonarscanner/sonar-scanner-2.8'], {:echo=>true}] }
     it { should include_sexp [:export, ['PATH', "\"$PATH:$HOME/.sonarscanner/sonar-scanner-2.8/bin\""]] }
-    it { should include_sexp [:mkdir, '$HOME/.sonar/cache', {:recursive=>true}] }
-    it { should include_sexp [:export, ['PATH', "\"$PATH:$HOME/.sonar/cache/build-wrapper-linux-x86\""]] }
+    it { should include_sexp [:mkdir, "$HASH_DIR", {:recursive=>true}] }
+    it { should include_sexp [:export, ['PATH', "\"$PATH:$HASH_DIR/build-wrapper-linux-x86\""]] }
   end
   
   describe 'skip build wrapper installation with java' do
@@ -28,8 +28,8 @@ describe Travis::Build::Addons::Sonarqube, :sexp do
     
     it { should include_sexp [:export, ['SONAR_SCANNER_HOME', '$HOME/.sonarscanner/sonar-scanner-2.8'], {:echo=>true}] }
     it { should include_sexp [:export, ['PATH', "\"$PATH:$HOME/.sonarscanner/sonar-scanner-2.8/bin\""]] }
-    it { should_not include_sexp [:mkdir, '$HOME/.sonar/cache', {:recursive=>true}] }
-    it { should_not include_sexp [:export, ['PATH', "\"$PATH:$HOME/.sonar/cache/build-wrapper-linux-x86\""]] }
+    it { should_not include_sexp [:mkdir, "$HASH_DIR", {:recursive=>true}] }
+    it { should_not include_sexp [:export, ['PATH', "\"$PATH:$HASH_DIR/build-wrapper-linux-x86\""]] }
   end
   
   describe 'skip pull request analysis' do

--- a/spec/build/addons/sonarqube_spec.rb
+++ b/spec/build/addons/sonarqube_spec.rb
@@ -15,12 +15,10 @@ describe Travis::Build::Addons::Sonarqube, :sexp do
   end
 
   describe 'scanner and build wrapper installation' do
-    let(:job)    { { :os => 'linux' } }
-    
     it { should include_sexp [:export, ['SONAR_SCANNER_HOME', '$HOME/.sonarscanner/sonar-scanner-2.8'], {:echo=>true}] }
     it { should include_sexp [:export, ['PATH', "\"$PATH:$HOME/.sonarscanner/sonar-scanner-2.8/bin\""]] }
-    it { should include_sexp [:mkdir, "$HASH_DIR", {:recursive=>true}] }
-    it { should include_sexp [:export, ['PATH', "\"$PATH:$HASH_DIR/build-wrapper-linux-x86\""]] }
+    it { should include_sexp [:mkdir, "$sq_build_wrapper_dir", {:recursive=>true}] }
+    it { should include_sexp [:export, ['PATH', "\"$PATH:$sq_build_wrapper_dir/build-wrapper-linux-x86\""]] }
   end
   
   describe 'skip build wrapper installation with java' do
@@ -28,8 +26,17 @@ describe Travis::Build::Addons::Sonarqube, :sexp do
     
     it { should include_sexp [:export, ['SONAR_SCANNER_HOME', '$HOME/.sonarscanner/sonar-scanner-2.8'], {:echo=>true}] }
     it { should include_sexp [:export, ['PATH', "\"$PATH:$HOME/.sonarscanner/sonar-scanner-2.8/bin\""]] }
-    it { should_not include_sexp [:mkdir, "$HASH_DIR", {:recursive=>true}] }
-    it { should_not include_sexp [:export, ['PATH', "\"$PATH:$HASH_DIR/build-wrapper-linux-x86\""]] }
+    it { should_not include_sexp [:mkdir, "$sq_build_wrapper_dir", {:recursive=>true}] }
+    it { should_not include_sexp [:export, ['PATH', "\"$PATH:$sq_build_wrapper_dir/build-wrapper-linux-x86\""]] }
+  end
+  
+  describe 'skip build wrapper with invalid os' do
+    let(:data) { super().merge(config: { :language => 'unkown' })}
+    
+    it { should include_sexp [:export, ['SONAR_SCANNER_HOME', '$HOME/.sonarscanner/sonar-scanner-2.8'], {:echo=>true}] }
+    it { should include_sexp [:export, ['PATH', "\"$PATH:$HOME/.sonarscanner/sonar-scanner-2.8/bin\""]] }
+    it { should include_sexp [:echo, "Can't install SonarSource build wrapper for platform: $TRAVIS_OS_NAME.", {:ansi=>:yellow}] }
+    it { should_not include_sexp [:export, ['PATH', "\"$PATH:$sq_build_wrapper_dir/build-wrapper-linux-x86\""]] }
   end
   
   describe 'skip pull request analysis' do

--- a/spec/build/addons/sonarqube_spec.rb
+++ b/spec/build/addons/sonarqube_spec.rb
@@ -14,9 +14,22 @@ describe Travis::Build::Addons::Sonarqube, :sexp do
     let(:code) { ['curl -sSLo $HOME/.sonarscanner/sonar-scanner.zip http://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/2.8/sonar-scanner-cli-2.8.zip'] }
   end
 
-  describe 'scanner installation' do
+  describe 'scanner and build wrapper installation' do
+    let(:job)    { { :os => 'linux' } }
+    
     it { should include_sexp [:export, ['SONAR_SCANNER_HOME', '$HOME/.sonarscanner/sonar-scanner-2.8'], {:echo=>true}] }
     it { should include_sexp [:export, ['PATH', "\"$PATH:$HOME/.sonarscanner/sonar-scanner-2.8/bin\""]] }
+    it { should include_sexp [:mkdir, '$HOME/.sonar/cache', {:recursive=>true}] }
+    it { should include_sexp [:export, ['PATH', "\"$PATH:$HOME/.sonar/cache/build-wrapper-linux-x86\""]] }
+  end
+  
+  describe 'skip build wrapper installation with java' do
+    let(:data) { super().merge(config: { :language => 'java' })}
+    
+    it { should include_sexp [:export, ['SONAR_SCANNER_HOME', '$HOME/.sonarscanner/sonar-scanner-2.8'], {:echo=>true}] }
+    it { should include_sexp [:export, ['PATH', "\"$PATH:$HOME/.sonarscanner/sonar-scanner-2.8/bin\""]] }
+    it { should_not include_sexp [:mkdir, '$HOME/.sonar/cache', {:recursive=>true}] }
+    it { should_not include_sexp [:export, ['PATH', "\"$PATH:$HOME/.sonar/cache/build-wrapper-linux-x86\""]] }
   end
   
   describe 'skip pull request analysis' do


### PR DESCRIPTION
The goal of this P/R is to improve the sonarqube addon by installing automatically, for the target platform (linux/macos), the SonarSource build-wrapper. The build-wrapper is needed to configure the analysis of C/C++ projects. This installation is skipped if it's a Java or Javascript project.

Full details: [MMF-611](https://jira.sonarsource.com/browse/MMF-611)