### PR TITLE
[D] Use a fallback bootstrap script provider if dlang.org is offline

### DIFF
--- a/lib/travis/build/script/d.rb
+++ b/lib/travis/build/script/d.rb
@@ -26,6 +26,7 @@ module Travis
 
             sh.cmd 'CURL_USER_AGENT="Travis-CI $(curl --version | head -n 1)"'
             sh.cmd 'for i in {0..4}; do curl -fsS -A "$CURL_USER_AGENT" --max-time 5 https://dlang.org/install.sh -O && break || [ $i -ge 4 ] || sleep $((1 << $i)); done'
+            sh.cmd '[[ ! -f install.sh ]] && for i in {0..4}; do curl -fsS -A "$CURL_USER_AGENT" --max-time 5 https://raw.githubusercontent.com/dlang/installer/master/script/install.sh -O && break || [ $i -ge 4 ] || sleep $((1 << $i)); done'
             sh.cmd "source \"$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash install.sh #{config[:d]} --activate)\""
           end
         end


### PR DESCRIPTION
We sometimes see timeouts in D installation that are due to connection issues to `dlang.org`, which is queried to receive the newest installation script, e.g. https://travis-ci.org/dlang/dmd/jobs/177747612, https://travis-ci.org/dlang/dmd/jobs/177747323, https://travis-ci.org/dlang/dmd/jobs/169949568

This PR increases the timeout from ~45s to 9.68 min `(2^9-1 +10 * 7) / 60` (similar to the 10 minutes default timeout for stalled builds), which hopefully might help in some cases.

However we should think about mitigating the connection issues in the first place, by e.g. using a CDN or a more stable location for the installation script.

@ Travis CI maintainers: do you maybe have same experience or advise on this problem?

CC @MartinNowak @klickverbot 