### PR TITLE
Coerce use of 1.8.7-p371 with `rvm: '1.8.7'`

### DIFF
--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -117,7 +117,7 @@ module Travis
           end
 
           def force_187_p371(version)
-            version.gsub(/^1\.8\.7.*$/,'1.8.7-p371')
+            version.gsub(/^1\.8\.7.*$/, '1.8.7-p371')
           end
       end
     end

--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -45,7 +45,8 @@ module Travis
           end
 
           def ruby_version
-            config[:rvm].to_s.gsub(/-(1[89]|2[01])mode$/, '-d\1')
+            vers = config[:rvm].to_s.gsub(/-(1[89]|2[01])mode$/, '-d\1')
+            force_187_p371 vers
           end
 
           def setup_rvm
@@ -113,6 +114,10 @@ module Travis
           def write_default_gems
             sh.mkdir '$rvm_path/gemsets', recursive: true, echo: false
             sh.cmd 'echo -e "gem-wrappers\nrubygems-bundler\nbundler\nrake\nrvm\n" > $rvm_path/gemsets/global.gems', echo: false, timing: false
+          end
+
+          def force_187_p371(version)
+            version.gsub(/^1\.8\.7.*$/,'1.8.7-p371')
           end
       end
     end

--- a/spec/build/script/ruby_spec.rb
+++ b/spec/build/script/ruby_spec.rb
@@ -131,6 +131,16 @@ describe Travis::Build::Script::Ruby, :sexp do
     end
   end
 
+  context 'when testing with 1.8.7' do
+    before :each do
+      data[:config][:rvm] = '1.8.7'
+    end
+
+    it 'coerces version to 1.8.7-p371' do
+      should include_sexp [:cmd, 'rvm use 1.8.7-p371 --install --binary --fuzzy', assert: true, echo: true, timing: true]
+    end
+  end
+
   context 'when testing with rbx' do
     before :each do
       data[:config][:rvm] = 'rbx'


### PR DESCRIPTION
Recent Precise images do not have 1.8.7 pre-installed, so it needs to be
installed on the fly.
Unfortunately, copying the 1.8.7-p371 archive to 1.8.7 does not do the
trick, so we coerce the version to 1.8.7-p371 instead, so that RVM can
find and install it.