### PR TITLE
Fix .NET Core 1.1 Support

### DIFF
--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -13,7 +13,7 @@ module Travis
         }
 
         MONO_VERSION_REGEXP = /^(\d{1})\.(\d{1,2})\.\d{1,2}$/
-        DOTNET_VERSION_REGEXP = /^\d{1}\.\d{1,2}\.\d{1,2}(-preview\d{1}-\d{6})?$/
+        DOTNET_VERSION_REGEXP = /^\d{1}\.\d{1,2}\.\d{1,2}(?:-preview\d+(\.\d+)?(?:-\d)?-\d{6})?$/
 
         def configure
           super


### PR DESCRIPTION
I believe this will fix https://github.com/travis-ci/travis-ci/issues/6920. The issue is that .NET Core 1.1 has a version of `1.0.0-preview2-1-003177`. Presumably, future 1.1.x releases with the `project.json` build system will have the same version string format.