### PR TITLE
Install REE from source, if it is not pre-installed

### DIFF
--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -99,6 +99,11 @@ module Travis
           def use_ruby_version
             skip_deps_install if rbx?
             sh.fold('rvm') do
+              if ruby_version.start_with? 'ree'
+                sh.if "! $(rvm list | grep ree)" do
+                  sh.cmd "sed -i 's|^\\(ree_1.8.7_url\\)=.*$|\\1=https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/rubyenterpriseedition|' $HOME/.rvm/config/db"
+                end
+              end
               sh.cmd "rvm use #{ruby_version} --install --binary --fuzzy"
             end
           end

--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -101,6 +101,7 @@ module Travis
             sh.fold('rvm') do
               if ruby_version.start_with? 'ree'
                 sh.if "! $(rvm list | grep ree)" do
+                  sh.echo "Installing REE from source. This may take a few minutes.", ansi: :yellow
                   sh.cmd "sed -i 's|^\\(ree_1.8.7_url\\)=.*$|\\1=https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/rubyenterpriseedition|' $HOME/.rvm/config/db"
                   sh.cmd "rvm use #{ruby_version} --install --fuzzy"
                 end

--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -102,9 +102,14 @@ module Travis
               if ruby_version.start_with? 'ree'
                 sh.if "! $(rvm list | grep ree)" do
                   sh.cmd "sed -i 's|^\\(ree_1.8.7_url\\)=.*$|\\1=https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/rubyenterpriseedition|' $HOME/.rvm/config/db"
+                  sh.cmd "rvm use #{ruby_version} --install --fuzzy"
                 end
+                sh.else do
+                  sh.cmd "rvm use #{ruby_version} --install --binary --fuzzy"
+                end
+              else
+                sh.cmd "rvm use #{ruby_version} --install --binary --fuzzy"
               end
-              sh.cmd "rvm use #{ruby_version} --install --binary --fuzzy"
             end
           end
 


### PR DESCRIPTION
We've removed REE from the build images recently.

Some builds do depend on REE, so we'll install them from source if it's not pre-installed.

Tests:

1. EC2 Precise https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/529282
1. GCE Precise https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/529284 (the image still has REE pre-installed)
1. EC2 Trusty https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/529293

Appears to add about 4 minutes to the build time.