### PR TITLE
Use app_host string without causing RuntimeError

### DIFF
--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -147,14 +147,18 @@ module Travis
           end
 
           def update_nvm
-            return unless Travis::Build.config.app_host
+            return if app_host.empty?
             nvm_sh_location = "$HOME/.nvm/nvm.sh"
             sh.if "$(vers2int `nvm --version`) -lt $(vers2int #{NVM_VERSION})" do
               sh.echo "Updating nvm to v#{NVM_VERSION}", ansi: :yellow, timing: false
               sh.raw "mkdir -p $HOME/.nvm"
-              sh.raw "curl -s -o #{nvm_sh_location} https://#{Travis::Build.config.app_host.untaint}/files/nvm.sh".untaint, assert: false
+              sh.raw "curl -s -o #{nvm_sh_location} https://#{app_host}/files/nvm.sh".untaint, assert: false
               sh.raw "source #{nvm_sh_location}", assert: false
             end
+          end
+
+          def app_host
+            @app_host ||= Travis::Build.config.app_host.to_s.strip.untaint
           end
 
           def npm_disable_prefix


### PR DESCRIPTION
as observed when deploying to production