### PR TITLE
Fix .NET Core support on macOS.

### DIFF
--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -103,7 +103,6 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
                 sh.failure "The version of this operating system is not supported by .NET Core. View valid versions at https://docs.travis-ci.com/user/languages/csharp/"
               end
               sh.cmd 'brew install openssl', timing: true, assert: true
-              sh.cmd 'brew link --force openssl', timing: false, assert: true
               sh.cmd 'mkdir -p /usr/local/lib', timing: false, assert: true
               sh.cmd 'ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/', timing: false, assert: true
               sh.cmd 'ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/', timing: false, assert: true

--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -104,6 +104,9 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
               end
               sh.cmd 'brew install openssl', timing: true, assert: true
               sh.cmd 'brew link --force openssl', timing: false, assert: true
+              sh.cmd 'mkdir -p /usr/local/lib', timing: false, assert: true
+              sh.cmd 'ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/', timing: false, assert: true
+              sh.cmd 'ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/', timing: false, assert: true
               sh.cmd "curl -o \"/tmp/dotnet.pkg\" -fL #{dotnet_osx_url}", timing: true, assert: true, echo: true
               sh.cmd 'sudo installer -package "/tmp/dotnet.pkg" -target "/"', timing: true, assert: true
               sh.cmd 'eval $(/usr/libexec/path_helper -s)', timing: false, assert: true

--- a/spec/build/script/csharp_spec.rb
+++ b/spec/build/script/csharp_spec.rb
@@ -167,7 +167,9 @@ describe Travis::Build::Script::Csharp, :sexp do
       data[:config][:os] = 'osx'
       data[:config][:dotnet] = '1.0.0-preview2-003121'
       should include_sexp [:cmd, "brew install openssl", timing: true, assert: true]
-      should include_sexp [:cmd, "brew link --force openssl", assert: true]
+      should include_sexp [:cmd, "mkdir -p /usr/local/lib", assert: true]
+      should include_sexp [:cmd, "ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/", assert: true]
+      should include_sexp [:cmd, "ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/", assert: true]
       should include_sexp [:cmd, "curl -o \"/tmp/dotnet.pkg\" -fL https://dotnetcli.azureedge.net/dotnet/preview/Installers/1.0.0-preview2-003121/dotnet-dev-osx-x64.1.0.0-preview2-003121.pkg", timing: true, assert: true, echo: true]
       should include_sexp [:cmd, "sudo installer -package \"/tmp/dotnet.pkg\" -target \"/\"", timing: true, assert: true]
       should include_sexp [:cmd, "eval $(/usr/libexec/path_helper -s)", assert: true]


### PR DESCRIPTION
Now if you try to build .NET Core app on macOS you'll get an exception:
```
System.DllNotFoundException: Unable to load DLL 'System.Security.Cryptography.Native': The specified module could not be found.
 (Exception from HRESULT: 0x8007007E)
   at Interop.CryptoInitializer.EnsureOpenSslInitialized()
   at Interop.CryptoInitializer..cctor()
   --- End of inner exception stack trace ---
   at Interop.Crypto..cctor()
   --- End of inner exception stack trace ---
   at Interop.Crypto.GetRandomBytes(Byte* buf, Int32 num)
   at System.IO.Path.GetCryptoRandomBytes(Byte* bytes, Int32 byteCount)
   at System.IO.Path.GetRandomFileName()
   at Microsoft.DotNet.InternalAbstractions.TemporaryDirectory..ctor()
   at Microsoft.Extensions.EnvironmentAbstractions.DirectoryWrapper.CreateTemporaryDirectory()
   at Microsoft.DotNet.Configurer.NuGetPackagesArchiver..ctor()
   at Microsoft.DotNet.Cli.Program.ConfigureDotNetForFirstTimeUse(INuGetCacheSentinel nugetCacheSentinel)
   at Microsoft.DotNet.Cli.Program.ProcessArgs(String[] args, ITelemetry telemetryClient)
   at Microsoft.DotNet.Cli.Program.Main(String[] args)
```
It relates to known [issue](https://github.com/dotnet/corefx/issues/9171).

To solve this problem it's necessary to do the following:
```Fish shell
~$ mkdir -p /usr/local/lib
~$ ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/
~$ ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/
```
Moreover, official [.NET Core installation guide](https://www.microsoft.com/net/core#macos) tells that you should run commands desribed above before using .NET Core on macOS.

So, this PR adds this commands which will be perform on macOS before installing .NET Core.
