### PR TITLE
node_js: Cache the correct yarn cache directory

### DIFF
--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -80,7 +80,7 @@ module Travis
           if data.cache?(:yarn)
             sh.fold 'cache.yarn' do
               sh.echo ''
-              directory_cache.add '$HOME/.yarn-cache'
+              directory_cache.add '$HOME/.cache/yarn'
             end
           end
         end


### PR DESCRIPTION
See the [yarn repo](https://github.com/yarnpkg/yarn/blob/a1192e596b85acb2f63daa1cbf30e662c2125310/src/constants.js#L41) for where it stores its cache directory.