### PR TITLE
Update composer to 1.0.0 once

### DIFF
--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -160,6 +160,7 @@ hhvm.libxml.ext_entity_whitelist=file,http,https
         end
 
         def composer_self_update
+          sh.cmd "composer self-update 1.0.0", assert: false unless version =~ /^5\.2/
           sh.cmd "composer self-update", assert: false unless version =~ /^5\.2/
         end
       end


### PR DESCRIPTION
Composer 1.0.0 beta 2 introduced the concept of channels in
`composer self-update`:
https://github.com/composer/composer/blob/master/CHANGELOG.md#100-beta2---2016-03-27
Before this feature, it always updated to the latest commit, which
could be buggy.

By stepping at 1.0.0, we ensure that `composer self-update` updates
to the stable release, avoiding a buggy commit.