### PR TITLE
Recover SC startup error gracefully

### DIFF
--- a/lib/travis/build/addons/sauce_connect.rb
+++ b/lib/travis/build/addons/sauce_connect.rb
@@ -29,7 +29,7 @@ module Travis
 
           sh.fold 'sauce_connect.start' do
             sh.echo 'Starting Sauce Connect', echo: false, ansi: :yellow
-            sh.cmd 'travis_start_sauce_connect', assert: false, echo: true, timing: true
+            sh.cmd 'travis_start_sauce_connect', assert: false, echo: true, timing: true, retry: true
             sh.export 'TRAVIS_SAUCE_CONNECT', 'true', echo: false
           end
         end

--- a/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh
+++ b/lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh
@@ -60,11 +60,18 @@ function travis_start_sauce_connect() {
   _SC_PID="$!"
 
   echo "Waiting for Sauce Connect readyfile"
-  while [ ! -f ${sc_readyfile} ]; do
+  while test ! -f ${sc_readyfile} && ps -f $_SC_PID >&/dev/null; do
     sleep .5
   done
 
+  if test ! -f ${sc_readyfile}; then
+    echo "readyfile not created"
+  fi
+
   popd
+
+  test -f ${sc_readyfile}
+  return $?
 }
 
 function travis_stop_sauce_connect() {

--- a/spec/build/addons/sauce_connect_spec.rb
+++ b/spec/build/addons/sauce_connect_spec.rb
@@ -14,7 +14,7 @@ describe Travis::Build::Addons::SauceConnect, :sexp do
   end
 
   shared_examples_for 'starts sauce connect' do
-    it { should include_sexp [:cmd, 'travis_start_sauce_connect', echo: true, timing: true] }
+    it { should include_sexp [:cmd, 'travis_start_sauce_connect', echo: true, timing: true, retry: true] }
     it { should include_sexp [:export, ['TRAVIS_SAUCE_CONNECT', 'true']] }
   end
 


### PR DESCRIPTION
While waiting for Sauce Connect to start, sleep only when the `sc`
command is running.
When `sc` stops running, get out of the sleep loop immediately, so
that we do not waste time waiting for the readyfile that will never
come.

At the same time, we retry opening Sauce Connect tunnel up to 3 times
just in case the failure is temporary.

See https://github.com/travis-ci/travis-ci/issues/3091 for more
context.