### PR TITLE
Revert "Hide `export` command's STDERR"

### DIFF
--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -39,7 +39,6 @@ travis_cmd() {
       --display) display=$2;  shift 2;;
       --retry)   retry=true;  shift ;;
       --timing)  timing=true; shift ;;
-      --secure)  secure=" 2>/dev/null"; shift ;;
       *) break ;;
     esac
   done
@@ -53,14 +52,9 @@ travis_cmd() {
   fi
 
   if [[ -n "$retry" ]]; then
-    travis_retry eval "$cmd $secure"
+    travis_retry eval "$cmd"
   else
-    eval "$cmd $secure"
-    if [[ -n $secure && $? -ne 0 ]]; then
-      echo -e "${ANSI_RED}The previous command failed, possibly due to a malformed secure environment variable.${ANSI_CLEAR}
-${ANSI_RED}Please be sure to escape special characters such as ' ' and '$'.${ANSI_CLEAR}
-${ANSI_RED}For more information, see http://www.tldp.org/LDP/abs/html/special-chars.html.${ANSI_CLEAR}"
-    fi
+    eval "$cmd"
   fi
   result=$?
 

--- a/lib/travis/shell/generator/bash.rb
+++ b/lib/travis/shell/generator/bash.rb
@@ -144,7 +144,7 @@ module Travis
         private
 
           def handle_secure_vars(key, value, options)
-            if options[:echo] && options[:secure]
+            if options[:echo] && options.delete(:secure)
               options[:echo] = "export #{key}=[secure]"
               value.untaint
             end

--- a/lib/travis/shell/generator/bash/cmd.rb
+++ b/lib/travis/shell/generator/bash/cmd.rb
@@ -34,7 +34,6 @@ module Travis
               opts << "--display #{escape(options[:echo])}" if options[:echo].is_a?(String)
               opts << '--retry'  if options[:retry]
               opts << '--timing' if options[:timing]
-              opts << '--secure' if options[:secure]
               opts.join(' ')
             end
         end

--- a/spec/shell/generator/bash_spec.rb
+++ b/spec/shell/generator/bash_spec.rb
@@ -139,7 +139,7 @@ describe Travis::Shell::Generator::Bash, :include_node_helpers do
 
     it 'adds --display FOO=[secure] if the given value is tainted' do
       @sexp = [:export, ['FOO', 'foo'], echo: true, secure: true]
-      expect(code).to eql("travis_cmd export\\ FOO\\=foo --echo --display export\\ FOO\\=\\[secure\\] --secure")
+      expect(code).to eql("travis_cmd export\\ FOO\\=foo --echo --display export\\ FOO\\=\\[secure\\]")
     end
   end
 


### PR DESCRIPTION
Reverts travis-ci/travis-build#939

Causing some problems that depend on nonzero exit status.