### PR TITLE
Hide `export` command's STDERR

### DIFF
--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -26,7 +26,7 @@ TRAVIS_TEST_RESULT=
 TRAVIS_CMD=
 
 travis_cmd() {
-  local assert output display retry timing cmd result
+  local assert output display retry timing cmd result secure
 
   cmd=$1
   TRAVIS_CMD=$cmd
@@ -54,15 +54,16 @@ travis_cmd() {
 
   if [[ -n "$retry" ]]; then
     travis_retry eval "$cmd $secure"
+    result=$?
   else
     eval "$cmd $secure"
-    if [[ -n $secure && $? -ne 0 ]]; then
+    result=$?
+    if [[ -n $secure && $result -ne 0 ]]; then
       echo -e "${ANSI_RED}The previous command failed, possibly due to a malformed secure environment variable.${ANSI_CLEAR}
 ${ANSI_RED}Please be sure to escape special characters such as ' ' and '$'.${ANSI_CLEAR}
 ${ANSI_RED}For more information, see http://www.tldp.org/LDP/abs/html/special-chars.html.${ANSI_CLEAR}"
     fi
   fi
-  result=$?
 
   if [[ -n "$timing" ]]; then
     travis_time_finish

--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -61,7 +61,7 @@ travis_cmd() {
     if [[ -n $secure && $result -ne 0 ]]; then
       echo -e "${ANSI_RED}The previous command failed, possibly due to a malformed secure environment variable.${ANSI_CLEAR}
 ${ANSI_RED}Please be sure to escape special characters such as ' ' and '$'.${ANSI_CLEAR}
-${ANSI_RED}For more information, see http://www.tldp.org/LDP/abs/html/special-chars.html.${ANSI_CLEAR}"
+${ANSI_RED}For more information, see https://docs.travis-ci.com/user/encryption-keys.${ANSI_CLEAR}"
     fi
   fi
 

--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -39,6 +39,7 @@ travis_cmd() {
       --display) display=$2;  shift 2;;
       --retry)   retry=true;  shift ;;
       --timing)  timing=true; shift ;;
+      --secure)  secure=" 2>/dev/null"; shift ;;
       *) break ;;
     esac
   done
@@ -52,9 +53,14 @@ travis_cmd() {
   fi
 
   if [[ -n "$retry" ]]; then
-    travis_retry eval "$cmd"
+    travis_retry eval "$cmd $secure"
   else
-    eval "$cmd"
+    eval "$cmd $secure"
+    if [[ -n $secure && $? -ne 0 ]]; then
+      echo -e "${ANSI_RED}The previous command failed, possibly due to a malformed secure environment variable.${ANSI_CLEAR}
+${ANSI_RED}Please be sure to escape special characters such as ' ' and '$'.${ANSI_CLEAR}
+${ANSI_RED}For more information, see http://www.tldp.org/LDP/abs/html/special-chars.html.${ANSI_CLEAR}"
+    fi
   fi
   result=$?
 

--- a/lib/travis/shell/generator/bash.rb
+++ b/lib/travis/shell/generator/bash.rb
@@ -144,7 +144,7 @@ module Travis
         private
 
           def handle_secure_vars(key, value, options)
-            if options[:echo] && options.delete(:secure)
+            if options[:echo] && options[:secure]
               options[:echo] = "export #{key}=[secure]"
               value.untaint
             end

--- a/lib/travis/shell/generator/bash/cmd.rb
+++ b/lib/travis/shell/generator/bash/cmd.rb
@@ -34,6 +34,7 @@ module Travis
               opts << "--display #{escape(options[:echo])}" if options[:echo].is_a?(String)
               opts << '--retry'  if options[:retry]
               opts << '--timing' if options[:timing]
+              opts << '--secure' if options[:secure]
               opts.join(' ')
             end
         end

--- a/spec/shell/generator/bash_spec.rb
+++ b/spec/shell/generator/bash_spec.rb
@@ -139,7 +139,7 @@ describe Travis::Shell::Generator::Bash, :include_node_helpers do
 
     it 'adds --display FOO=[secure] if the given value is tainted' do
       @sexp = [:export, ['FOO', 'foo'], echo: true, secure: true]
-      expect(code).to eql("travis_cmd export\\ FOO\\=foo --echo --display export\\ FOO\\=\\[secure\\]")
+      expect(code).to eql("travis_cmd export\\ FOO\\=foo --echo --display export\\ FOO\\=\\[secure\\] --secure")
     end
   end
 


### PR DESCRIPTION
This PR redoes what #939 aimed to do.

In addition to reverting the revert of #939, we heed the advice given in https://github.com/travis-ci/travis-build/pull/939#commitcomment-20594568 and saves off the command's actual result before printing the warning.