### PR TITLE
Mark the script failure if coverity_scan fails

### DIFF
--- a/lib/travis/build/addons/coverity_scan.rb
+++ b/lib/travis/build/addons/coverity_scan.rb
@@ -79,7 +79,7 @@ SH
               env << "COVERITY_SCAN_BUILD_COMMAND=\"${COVERITY_SCAN_BUILD_COMMAND:-#{@config[:build_command]}}\""
               env << "COVERITY_SCAN_BUILD_COMMAND_PREPEND=\"${COVERITY_SCAN_BUILD_COMMAND_PREPEND:-#{@config[:build_command_prepend]}}\""
               env << "COVERITY_SCAN_BRANCH_PATTERN=${COVERITY_SCAN_BRANCH_PATTERN:-#{@config[:branch_pattern]}}"
-              sh.cmd "curl -s #{@config[:build_script_url]} | #{env.join(' ')} bash", echo: true
+              sh.cmd "curl -sf #{@config[:build_script_url]} | #{env.join(' ')} bash", echo: true, assert: true
             end
           end
           sh.else echo:true do


### PR DESCRIPTION
By asserting the `curl` command and the `curl | bash` pipe to succeed, we mark the build a failure if the Coverity Scan exits with a nonzero status.

This replaces https://github.com/travis-ci/travis-build/pull/260.