### PR TITLE
Do not update packages

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -104,8 +104,6 @@ module Travis
 
                 sh.cmd "sudo mkdir -p /usr/local/lib/R/site-library $R_LIBS_USER"
                 sh.cmd 'sudo chmod 2777 /usr/local/lib/R /usr/local/lib/R/site-library $R_LIBS_USER'
-
-                sh.cmd "Rscript -e 'update.packages(ask = FALSE)'"
               when 'osx'
                 # We want to update, but we don't need the 800+ lines of
                 # output.


### PR DESCRIPTION
This inadvertently caused an error because the repo was not set when it was called.

I originally added it to prevent errors if recommended packages are out of date (https://github.com/travis-ci/travis-ci/issues/6850#issuecomment-266548181), but that is fairly rare so I think it is better to just remove it for now.

This is fairly urgent to merge and deploy as all R builds are currently broken.

Fixes https://github.com/travis-ci/travis-ci/issues/7252