### PR TITLE
update haxe default version to 3.4.0

### DIFF
--- a/lib/travis/build/script/haxe.rb
+++ b/lib/travis/build/script/haxe.rb
@@ -17,7 +17,7 @@ module Travis
     class Script
       class Haxe < Script
         DEFAULTS = {
-          haxe: '3.2.1',
+          haxe: '3.4.0',
           neko: '2.1.0'
         }
 


### PR DESCRIPTION
Haxe 3.4.0 is released, so bumping the default version.