### PR TITLE
Introduce TRAVIS_BUILD_AUTH_DISABLED env var for Enterprise

### DIFF
--- a/lib/travis/api/build/app.rb
+++ b/lib/travis/api/build/app.rb
@@ -20,8 +20,11 @@ module Travis
         end
 
         configure do
-          use Sentry unless Travis::Build.config.sentry_dsn.empty?
-          use Metriks if librato_disabled? 
+          use Sentry unless Travis::Build.config.sentry_dsn.nil?
+          use Metriks unless Travis::Build.config.librato.email.nil? ||
+                             Travis::Build.config.librato.token.nil? ||
+                             Travis::Build.config.librato.source.nil?
+
           use Rack::Deflater
         end
 
@@ -39,9 +42,7 @@ module Travis
           end
 
           def librato_disabled? 
-            (Travis::Build.config.librato.email.nil? || Travis::Build.config.librato.email.empty?) ||
-            (Travis::Build.config.librato.token.nil? || Travis::Build.config.librato.token.empty?) ||
-            (Travis::Build.config.librato.source.nil? || Travis::Build.config.librato.source.empty?)
+
           end
         end
 

--- a/lib/travis/api/build/app.rb
+++ b/lib/travis/api/build/app.rb
@@ -30,6 +30,7 @@ module Travis
 
         helpers do
           def auth_disabled?
+            Travis::Build.config.auth_disabled? ||
             api_tokens.empty? && (
               settings.development? || settings.test?
             )

--- a/lib/travis/api/build/app.rb
+++ b/lib/travis/api/build/app.rb
@@ -40,10 +40,6 @@ module Travis
             @api_tokens ||=
               Travis::Build.config.api_token.to_s.split(',').map(&:strip)
           end
-
-          def librato_disabled? 
-
-          end
         end
 
         before '/script' do

--- a/lib/travis/api/build/app.rb
+++ b/lib/travis/api/build/app.rb
@@ -20,10 +20,10 @@ module Travis
         end
 
         configure do
-          use Sentry unless Travis::Build.config.sentry_dsn.nil?
-          use Metriks unless Travis::Build.config.librato.email.nil? ||
-                             Travis::Build.config.librato.token.nil? ||
-                             Travis::Build.config.librato.source.nil?
+          use Sentry unless Travis::Build.config.sentry_dsn.to_s.empty?
+          use Metriks unless Travis::Build.config.librato.email.to_s.empty? ||
+                             Travis::Build.config.librato.token.to_s.empty? ||
+                             Travis::Build.config.librato.source.to_s.empty?
 
           use Rack::Deflater
         end

--- a/lib/travis/api/build/app.rb
+++ b/lib/travis/api/build/app.rb
@@ -20,10 +20,10 @@ module Travis
         end
 
         configure do
-          use Sentry unless Travis::Build.config.sentry_dsn.empty?
-          use Metriks unless Travis::Build.config.librato.email.empty? ||
-                             Travis::Build.config.librato.token.empty? ||
-                             Travis::Build.config.librato.source.empty?
+          use Sentry unless Travis::Build.config.sentry_dsn.blank?
+          use Metriks unless Travis::Build.config.librato.email.blank? ||
+                             Travis::Build.config.librato.token.blank? ||
+                             Travis::Build.config.librato.source.blank?
 
           use Rack::Deflater
         end

--- a/lib/travis/api/build/app.rb
+++ b/lib/travis/api/build/app.rb
@@ -30,9 +30,8 @@ module Travis
 
         helpers do
           def auth_disabled?
-            Travis::Build.config.auth_disabled? ||
             api_tokens.empty? && (
-              settings.development? || settings.test?
+              Travis::Build.config.auth_disabled? || settings.development? || settings.test?
             )
           end
 

--- a/lib/travis/api/build/app.rb
+++ b/lib/travis/api/build/app.rb
@@ -20,11 +20,8 @@ module Travis
         end
 
         configure do
-          use Sentry unless Travis::Build.config.sentry_dsn.blank?
-          use Metriks unless Travis::Build.config.librato.email.blank? ||
-                             Travis::Build.config.librato.token.blank? ||
-                             Travis::Build.config.librato.source.blank?
-
+          use Sentry unless Travis::Build.config.sentry_dsn.empty?
+          use Metriks if librato_disabled? 
           use Rack::Deflater
         end
 
@@ -39,6 +36,12 @@ module Travis
           def api_tokens
             @api_tokens ||=
               Travis::Build.config.api_token.to_s.split(',').map(&:strip)
+          end
+
+          def librato_disabled? 
+            (Travis::Build.config.librato.email.nil? || Travis::Build.config.librato.email.empty?) ||
+            (Travis::Build.config.librato.token.nil? || Travis::Build.config.librato.token.empty?) ||
+            (Travis::Build.config.librato.source.nil? || Travis::Build.config.librato.source.empty?)
           end
         end
 

--- a/lib/travis/api/build/app.rb
+++ b/lib/travis/api/build/app.rb
@@ -30,8 +30,9 @@ module Travis
 
         helpers do
           def auth_disabled?
+            Travis::Build.config.auth_disabled? ||
             api_tokens.empty? && (
-              Travis::Build.config.auth_disabled? || settings.development? || settings.test?
+              settings.development? || settings.test?
             )
           end
 

--- a/lib/travis/build/config.rb
+++ b/lib/travis/build/config.rb
@@ -33,6 +33,7 @@ module Travis
           trusty: ENV.fetch('TRAVIS_BUILD_APT_SOURCE_WHITELIST_TRUSTY', '')
         },
         apt_whitelist_skip: ENV.fetch('TRAVIS_BUILD_APT_WHITELIST_SKIP', ''),
+        auth_disabled: ENV.fetch('TRAVIS_BUILD_AUTH_DISABLED', false),
         enable_debug_tools: ENV.fetch(
           'TRAVIS_BUILD_ENABLE_DEBUG_TOOLS',
           ENV.fetch('TRAVIS_ENABLE_DEBUG_TOOLS', '')

--- a/lib/travis/build/config.rb
+++ b/lib/travis/build/config.rb
@@ -33,7 +33,7 @@ module Travis
           trusty: ENV.fetch('TRAVIS_BUILD_APT_SOURCE_WHITELIST_TRUSTY', '')
         },
         apt_whitelist_skip: ENV.fetch('TRAVIS_BUILD_APT_WHITELIST_SKIP', ''),
-        auth_disabled: ENV.fetch('TRAVIS_BUILD_AUTH_DISABLED', false),
+        auth_disabled: ENV.fetch('TRAVIS_BUILD_AUTH_DISABLED', ''),
         enable_debug_tools: ENV.fetch(
           'TRAVIS_BUILD_ENABLE_DEBUG_TOOLS',
           ENV.fetch('TRAVIS_ENABLE_DEBUG_TOOLS', '')

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -65,6 +65,17 @@ describe Travis::Api::Build::App, :include_sinatra_helpers do
       end
     end
 
+    context 'without an Authorization header and authorization is disabled' do
+      before do 
+        Travis::Api::Build::App.any_instance
+          .stubs(:auth_disabled?).returns(true)
+      end 
+      it 'returns 200' do
+        response = post '/script', {}, input: PAYLOADS[:push].to_json
+        expect(response.status).to be == 200
+      end
+    end
+
     context 'with an incorrect token' do
       it 'returns 403' do
         header('Authorization', 'token not-the-token')

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -11,6 +11,8 @@ describe Travis::Api::Build::App, :include_sinatra_helpers do
 
     Travis::Api::Build::App.any_instance
       .stubs(:api_tokens).returns(%w(the-token the-other-token))
+    Travis::Api::Build::App.any_instance
+      .stubs(:auth_disabled?).returns(false)
     set_app(app)
   end
 


### PR DESCRIPTION
In Enterprise 2.0 we rely on the behavior where if there is no API token, then authorization is disabled. After a refactor in `travis-build` this non-explicit behavior no longer functioned, breaking the way that workers currently get their build scripts. 

This PR introduces an env var to toggle this behavior back on. ~~At the moment you still also need to not set an API_KEY. If you do set one, this var will be ignored.~~

~~I'm mixed on this, it's truer to the old way but I like to think that when you say "auth disabled" it means it. Getting this out there for discussion but I think I may rework this so that the tests can still pass and we don't have fiddly side effects.~~

[Edit: I did dis] 

Additionally, I think it's worth having a discussion on if having auth disabled is the best thing for Enterprise and if not what the migration for existing workers will be. 