### PR TITLE
Choose a valid branch with "travis compile".

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -5,7 +5,8 @@ module Travis
 
       on('--branch NAME', 'the branch to check out when cloning the repo') {|c, name| c.branch = name}
 
-      attr_accessor :slug, :source_url, :branch
+      attr_accessor :slug, :source_url
+      attr_writer :branch
 
       def setup
         error "run command is not available on #{RUBY_VERSION}" if RUBY_VERSION < '1.9.3'
@@ -69,13 +70,13 @@ module Travis
               :push_timeout => 60
             },
             :job => {
-              :branch => choose_branch
+              :branch => branch
             }
           }
         end
 
-        def choose_branch
-          return branch if branch
+        def branch
+          return @branch if @branch
           name = `git name-rev --name-only HEAD 2>#{IO::NULL}`.chomp
           name =~ /~\d+$/ ? nil : name
         end

--- a/lib/travis/build/git/clone.rb
+++ b/lib/travis/build/git/clone.rb
@@ -47,7 +47,7 @@ module Travis
 
           def clone_args
             args = "--depth=#{depth}"
-            args << " --branch=#{branch}" unless data.ref
+            args << " --branch=#{branch}" unless branch.empty? || data.ref
             args << " --quiet" if quiet?
             args
           end


### PR DESCRIPTION
This defaults to the current branch, and falls back to not specifying
--branch at all and using whatever the repository default it.

Closes travis-ci/travis-ci#7286