### PR TITLE
TRAVIS-13 Support specifying the organization

### DIFF
--- a/lib/travis/build/addons/sonarqube.rb
+++ b/lib/travis/build/addons/sonarqube.rb
@@ -126,6 +126,10 @@ SH
             add_scanner_param("sonar.github.pullRequest", data.pull_request)
             add_scanner_param("sonar.github.oauth", "$SONAR_GITHUB_TOKEN")
           end
+          
+          if organization
+            add_scanner_param("sonar.organization", organization)
+          end
             
           if data.branch != 'master'
             add_scanner_param("sonar.branch", data.branch)
@@ -181,6 +185,10 @@ SH
           
           def os
             data.config[:os]
+          end
+          
+          def organization
+            config[:organization]
           end
         
           def token

--- a/spec/build/addons/sonarqube_spec.rb
+++ b/spec/build/addons/sonarqube_spec.rb
@@ -44,17 +44,22 @@ describe Travis::Build::Addons::Sonarqube, :sexp do
     
     it { should include_sexp [:export, ['SONARQUBE_SCANNER_PARAMS', "\"{ \\\"sonar.scanner.skip\\\" : \\\"true\\\" }\""]] }
     it { should include_sexp [:export, ['SONARQUBE_SKIPPED', "true"], {:echo=>true}] }
-    
   end
   
-    describe 'pull request analysis' do
+  describe 'pull request analysis' do
     let(:config) { { :github_token => 'mytoken' } }
     let(:job) { super().merge(:pull_request => '123')}
     
     it { should include_sexp [:export, ['SONAR_GITHUB_TOKEN', 'mytoken' ]] }
     it { should include_sexp [:export, ['SONARQUBE_SCANNER_PARAMS', 
-      "\"{ \\\"sonar.analysis.mode\\\" : \\\"preview\\\", \\\"sonar.github.repository\\\" : \\\"travis-ci/travis-ci\\\", \\\"sonar.github.pullRequest\\\" : \\\"123\\\", \\\"sonar.github.oauth\\\" : \\\"$SONAR_GITHUB_TOKEN\\\", \\\"sonar.host.url\\\" : \\\"https://sonarqube.com\\\" }\""]] }
+      "\"{ \\\"sonar.analysis.mode\\\" : \\\"preview\\\", \\\"sonar.github.repository\\\" : \\\"travis-ci/travis-ci\\\", \\\"sonar.github.pullRequest\\\" : \\\"123\\\", \\\"sonar.github.oauth\\\" : \\\"$SONAR_GITHUB_TOKEN\\\", \\\"sonar.host.url\\\" : \\\"https://sonarqube.com\\\" }\""]] }  
+  end
+  
+  describe 'add organization' do
+    let(:config) { { :organization => 'myorg' } }
     
+    it { should include_sexp [:export, ['SONARQUBE_SCANNER_PARAMS', 
+      "\"{ \\\"sonar.organization\\\" : \\\"myorg\\\", \\\"sonar.host.url\\\" : \\\"https://sonarqube.com\\\" }\""]] }  
   end
   
   describe 'branch analysis' do


### PR DESCRIPTION
This is a very simple change that will make the SonarQube travis addon support configuration of organizations in SonarQube.
Example:
```yml
addons:
  sonarqube:
    organization: myorg
```

More information can be found here: https://jira.sonarsource.com/browse/MMF-737