### PR TITLE
Generalize redis PPA fix

### DIFF
--- a/lib/travis/build/appliances/fix_rwky_redis.rb
+++ b/lib/travis/build/appliances/fix_rwky_redis.rb
@@ -6,8 +6,8 @@ module Travis
       class FixRwkyRedis < Base
         def apply
           command = <<-EOF
-            for f in $(grep -l rwky/redis /etc/apt/sources.list.d); do
-              sed 's,rwky/redis,rwky/ppa,g' $f /tmp/${f##**/}
+            for f in $(grep -l rwky/redis /etc/apt/sources.list.d/*); do
+              sed 's,rwky/redis,rwky/ppa,g' $f > /tmp/${f##**/}
               sudo mv /tmp/${f##**/} /etc/apt/sources.list.d
             done
           EOF

--- a/lib/travis/build/appliances/fix_rwky_redis.rb
+++ b/lib/travis/build/appliances/fix_rwky_redis.rb
@@ -5,10 +5,13 @@ module Travis
     module Appliances
       class FixRwkyRedis < Base
         def apply
-          list_file = '/etc/apt/sources.list.d/rwky-redis.list'
-          sh.if "-f #{list_file}" do
-            sh.cmd "sudo sed -i 's,rwky/redis,rwky/ppa,g' #{list_file}", echo: false
-          end
+          command = <<-EOF
+            for f in $(grep -l rwky/redis /etc/apt/sources.list.d); do
+              sed 's,rwky/redis,rwky/ppa,g' $f /tmp/${f##**/}
+              sudo mv /tmp/${f##**/} /etc/apt/sources.list.d
+            done
+          EOF
+          sh.cmd command, echo: false
         end
       end
     end

--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -22,7 +22,6 @@ module Travis
           sh.echo 'C# support for Travis-CI is community maintained.', ansi: :red
           sh.echo 'Please open any issues at https://github.com/travis-ci/travis-ci/issues/new and cc @joshua-anderson @akoeplinger @nterry', ansi: :red
 
-          fix_rwky_redis_ppa # See https://github.com/travis-ci/travis-ci/issues/7332.
           install_mono if is_mono_enabled
           install_dotnet if is_dotnet_enabled
         end
@@ -33,11 +32,6 @@ module Travis
             sh.cmd "sudo sed -e 's,rwky/redis,rwky/ppa,g' #{list_file} > #{temp_list_file}", echo: false
             sh.cmd "cat #{temp_list_file} | sudo tee #{list_file} > /dev/null", echo: false
           end
-        end
-
-        def fix_rwky_redis_ppa
-          fix_ppa_list_file '/etc/apt/sources.list.d/rwky-redis.list'
-          fix_ppa_list_file '/etc/apt/sources.list.d/rwky-redis-source.list'
         end
 
         def install_mono

--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -26,14 +26,6 @@ module Travis
           install_dotnet if is_dotnet_enabled
         end
 
-        def fix_ppa_list_file(list_file)
-          temp_list_file = '/tmp/source.list'
-          sh.if "-f #{list_file}" do
-            sh.cmd "sudo sed -e 's,rwky/redis,rwky/ppa,g' #{list_file} > #{temp_list_file}", echo: false
-            sh.cmd "cat #{temp_list_file} | sudo tee #{list_file} > /dev/null", echo: false
-          end
-        end
-
         def install_mono
           if !is_mono_version_valid?
             sh.failure "\"#{config[:mono]}\" is either an invalid version of \"mono\" or unsupported on this operating system.

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -61,11 +61,6 @@ module Travis
           end
         end
 
-        def fix_rwky_redis_ppa
-          fix_ppa_list_file '/etc/apt/sources.list.d/rwky-redis.list'
-          fix_ppa_list_file '/etc/apt/sources.list.d/rwky-redis-source.list'
-        end
-
         def configure
           super
 
@@ -89,9 +84,6 @@ module Travis
                 # Add marutter's c2d4u repository.
                 sh.cmd 'sudo add-apt-repository -y "ppa:marutter/rrutter"'
                 sh.cmd 'sudo add-apt-repository -y "ppa:marutter/c2d4u"'
-
-                # Fix redis PPA (see https://github.com/travis-ci/travis-ci/issues/7332)
-                fix_rwky_redis_ppa
 
                 # Update after adding all repositories. Retry several
                 # times to work around flaky connection to Launchpad PPAs.

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -53,14 +53,6 @@ module Travis
           sh.export 'R_PROFILE', "~/.Rprofile.site", echo: false
         end
 
-        def fix_ppa_list_file(list_file)
-          temp_list_file = '/tmp/source.list'
-          sh.if "-f #{list_file}" do
-            sh.cmd "sudo sed -e 's,rwky/redis,rwky/ppa,g' #{list_file} > #{temp_list_file}", echo: false
-            sh.cmd "cat #{temp_list_file} | sudo tee #{list_file} > /dev/null", echo: false
-          end
-        end
-
         def configure
           super
 


### PR DESCRIPTION
This commit generalizes the Redis PPA fix introduced previously by
https://github.com/travis-ci/travis-build/pull/958
https://github.com/travis-ci/travis-build/pull/959
https://github.com/travis-ci/travis-build/pull/960
by looking for all APT source having `rwky/redis`.