### PR TITLE
Remove APT list cache

### DIFF
--- a/lib/travis/build/appliances.rb
+++ b/lib/travis/build/appliances.rb
@@ -1,5 +1,6 @@
 require 'travis/build/appliances/checkout'
 require 'travis/build/appliances/clean_up_path'
+require 'travis/build/appliances/clear_apt_cache'
 require 'travis/build/appliances/debug_tools'
 require 'travis/build/appliances/deprecations'
 require 'travis/build/appliances/disable_sudo'

--- a/lib/travis/build/appliances/clear_apt_cache.rb
+++ b/lib/travis/build/appliances/clear_apt_cache.rb
@@ -1,0 +1,13 @@
+require 'travis/build/appliances/base'
+
+module Travis
+  module Build
+    module Appliances
+      class ClearAptCache < Base
+        def apply
+          sh.cmd "sudo rm -rf /var/lib/apt/lists/*", echo: false
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -168,6 +168,7 @@ module Travis
           apply :rvm_use
           apply :rm_oraclejdk8_symlink
           apply :fix_rwky_redis
+          apply :clear_apt_cache
         end
 
         def checkout


### PR DESCRIPTION
Stale files cause hash sum errors:

```
W: Size of file /var/lib/apt/lists/packagecloud.io_rabbitmq_rabbitmq-server_ubuntu_dists_trusty_main_binary-amd64_Packages.gz is not what the server reported 353 2072
W: Failed to fetch https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu/dists/trusty/main/source/Sources  Hash Sum mismatch

W: Failed to fetch https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu/dists/trusty/main/binary-amd64/Packages  Hash Sum mismatch

E: Some index files failed to download. They have been ignored, or old ones used instead.
```

We sidestep this issue by clearing stale files.

See http://askubuntu.com/a/41618