### PR TITLE
Pull casher file from travis-build web app

### DIFF
--- a/lib/travis/build/script/shared/directory_cache/base.rb
+++ b/lib/travis/build/script/shared/directory_cache/base.rb
@@ -109,8 +109,10 @@ module Travis
             sh.export 'CASHER_DIR', '$HOME/.casher'
 
             sh.mkdir '$CASHER_DIR/bin', echo: false, recursive: true
-            sh.cmd "curl #{casher_url} #{debug_flags} -L -o #{BIN_PATH} -s --fail", retry: true, echo: 'Installing caching utilities'
-            sh.raw "[ $? -ne 0 ] && echo 'Failed to fetch casher from GitHub, disabling cache.' && echo > #{BIN_PATH}"
+            update_static_file('casher', BIN_PATH, casher_url, true)
+            sh.if "$? -ne 0" do
+              sh.echo 'Failed to fetch casher from GitHub, disabling cache.', ansi: :yellow
+            end
 
             sh.if "-f #{BIN_PATH}" do
               sh.chmod '+x', BIN_PATH, assert: false, echo: false
@@ -257,13 +259,39 @@ module Travis
               if branch = data.cache[:branch]
                 branch
               else
-                data.cache?(:edge) ? 'master' : 'production'
+                edge? ? 'master' : 'production'
               end
+            end
+
+            def edge?
+              data.cache?(:edge)
             end
 
             def debug_flags
               "-v -w '#{CURL_FORMAT}'" if data.cache[:debug]
             end
+
+            def app_host
+              @app_host ||= Travis::Build.config.app_host.to_s.strip.untaint
+            end
+
+            def update_static_file(name, location, remote_location, assert = false)
+              flags = "-sf #{debug_flags}"
+              cmd_opts = {retry: true, echo: 'Installing caching utilities'}
+              if casher_branch == 'production'
+                sh.cmd curl_cmd(flags, location, "https://#{app_host}/files/#{name}".untaint), cmd_opts
+                sh.if "$? -ne 0" do
+                  sh.cmd curl_cmd(flags, location, remote_location), cmd_opts
+                end
+              else
+                sh.cmd curl_cmd(flags, location, (CASHER_URL % casher_branch)), cmd_opts
+              end
+            end
+
+            def curl_cmd(flags, location, remote_location)
+              "curl #{flags} -o #{location} #{remote_location}"
+            end
+
         end
       end
     end

--- a/public/files/casher
+++ b/public/files/casher
@@ -1,0 +1,240 @@
+#!/usr/bin/env ruby
+require 'timeout'
+require 'shellwords'
+require 'fileutils'
+require 'yaml'
+require 'uri'
+require 'open3'
+
+class Casher
+  include FileUtils
+
+  CURL_FORMAT = <<-EOF
+     time_namelookup:  %%{time_namelookup} s
+        time_connect:  %%{time_connect} s
+     time_appconnect:  %%{time_appconnect} s
+    time_pretransfer:  %%{time_pretransfer} s
+       time_redirect:  %%{time_redirect} s
+  time_starttransfer:  %%{time_starttransfer} s
+      speed_download:  %%{speed_download} bytes/s
+                     ----------
+          time_total:  %%{time_total} s
+  EOF
+
+  ANSI_RED="\033[31;1m"
+  ANSI_GREEN="\033[32;1m"
+  ANSI_RESET="\033[0m"
+  ANSI_CLEAR="\033[0K"
+
+
+  TAR_DIR_NOT_FOUND_REGEXP = /(\w+): Not found in archive/
+
+  MD5DEEP_CHECK_LOG_LIMIT = 1000
+
+  def initialize
+    @casher_dir = ENV['CASHER_DIR'] || File.expand_path(".casher", ENV["HOME"])
+    @mtime_file = File.expand_path('mtime.yml', @casher_dir)
+    @checksum_file_before = File.expand_path('md5sums_before', @casher_dir)
+    @checksum_file_after  = File.expand_path('md5sums_after', @casher_dir)
+    @fetch_tar  = File.expand_path('fetch.tbz', @casher_dir)
+    @push_tar   = File.expand_path('push.tbz', @casher_dir)
+    @paths_file = File.expand_path('paths', @casher_dir)
+    @mtimes     = File.exist?(@mtime_file) && File.size(@mtime_file) > 0 ? YAML.load_file(@mtime_file) : {}
+    @timeout    = Integer(ENV['CASHER_TIME_OUT'] || 3*60)
+
+    @counter = 0
+
+    mkdir_p @casher_dir
+  end
+
+  def run(command, *arguments)
+    raise "unknown command" unless %w[fetch add push].include? command
+    Timeout.timeout(@timeout) { send(command, *arguments) }
+  rescue TimeoutError
+    line  = "casher #{command}"
+    line += Shellwords.join(arguments) if command == "add"
+    $stderr.puts "running `#{line}` took longer than #{@timeout} seconds and has been aborted"
+  end
+
+  def fetch(*urls)
+    msg "attempting to download cache archive"
+    archive_found = false
+    urls.each do |url|
+      msg "fetching #{%r(([^/]+?/[^/]+?)(\?.*)?$).match(url)[1]}"
+
+      @fetch_tar  = File.expand_path('fetch.tgz', @casher_dir) if path_ext(url) == 'tgz'
+
+      if system "curl --tcp-nodelay -w '#{CURL_FORMAT}' %p -o %p -f -s --retry 3 >#{@casher_dir}/fetch.log 2>#{@casher_dir}/fetch.err.log" % [url, @fetch_tar]
+        msg "found cache"
+        archive_found = true
+        break
+      end
+    end
+    unless archive_found
+      msg "could not download cache", :red
+      if File.exist? @fetch_tar
+        rm @fetch_tar
+      end
+    end
+  end
+
+  def add(*paths)
+    expanded_paths = paths.map { |p| File.expand_path(p) }
+    expanded_paths.map do |p|
+      msg "adding #{p} to cache"
+      unless File.exist?(p)
+        msg "creating directory #{p}"
+        mkdir_p p
+      end
+    end
+
+    File.open(@paths_file, 'a') { |f| f << expanded_paths.compact.join("\n") << "\n" }
+    FileUtils.touch(@checksum_file_before)
+
+    if fetched_archive
+      output, errors = tar(:x, fetched_archive, *expanded_paths) do
+        sleep 1
+      end
+
+      dirs_not_in_archive = errors.scan(TAR_DIR_NOT_FOUND_REGEXP).flatten.uniq
+
+      dirs_not_in_archive.each do |dir|
+        msg "#{dir} is not yet cached", :red
+      end
+
+      expanded_paths.map { |p| @mtimes[p] = Time.now.to_i }
+
+      if md5deep_available?
+        system "md5deep -r #{expanded_paths.compact.map { |p| Shellwords.escape(p) }.join(' ')} | sort >> #{@checksum_file_before}"
+      else
+        mtime_file = File.open(@mtime_file, 'w')
+        mtime_file.write @mtimes.to_yaml
+      end
+    end
+
+  end
+
+  def push(url)
+    cached_directories.map { |p| p = File.dirname(p) if File.file?(p); mkdir_p p }
+
+    unless changed?
+      msg "nothing changed, not updating cache"
+      return
+    end
+
+    msg "changes detected, packing new archive"
+
+    @push_tar  = File.expand_path('push.tgz', @casher_dir) if path_ext(url) == 'tgz'
+
+    tar(:c, @push_tar, *cached_directories) do
+      @counter += 1
+      puts "." if @counter % 5 == 0
+      sleep 1
+    end
+
+    msg "uploading archive"
+    unless system "curl -T %p %p -s -S -f >#{@casher_dir}/push.log 2>#{@casher_dir}/push.err.log" % [@push_tar, url]
+      msg "failed to upload cache", :red
+      puts File.read("#{@casher_dir}/push.err.log"), File.read("#{@casher_dir}/push.log")
+    end
+
+  end
+
+  def changed?
+    return true unless fetched_archive
+
+    if md5deep_available?
+      paths  = File.read(@paths_file).split("\n")
+      diff_file = File.expand_path('checksum_diff', @casher_dir)
+      system("sort #{@checksum_file_before} | uniq > #{@checksum_file_before}.sorted")
+      system(<<-SCRIPT)
+        md5deep -r #{paths.map { |p| Shellwords.escape(p) }.join(" ")} | sort | uniq > #{@checksum_file_after};
+        diff -B #{@checksum_file_before}.sorted #{@checksum_file_after} | \
+        awk '/^[<>]/ {for (i=3; i<=NF; i++) printf(\"%s%s\", $(i), i<NF? OFS : \"\\n\")};' | sort | uniq > #{diff_file}
+      SCRIPT
+      result = File.size(@checksum_file_before) == 0 || File.size(diff_file) > 0
+
+      if File.size(diff_file) > 0
+        first_bytes = File.read(diff_file, MD5DEEP_CHECK_LOG_LIMIT + 1)
+        msg "change detected (content changed, file is created, or file is deleted):\n#{first_bytes}\n"
+        msg "...\n" if first_bytes.size > MD5DEEP_CHECK_LOG_LIMIT
+      end
+
+      return result
+    end
+
+    @mtimes.any? do |path, mtime|
+      Dir.glob("#{path}/**/*").any? do |file|
+        next if File.mtime(file).to_i <= mtime
+        next if File.directory?(file)
+        msg "change detected: #{file}"
+        true
+      end
+    end
+  end
+
+  def tar(flag, file, *args, &block)
+    compression_flag = file.end_with?('.tbz') ? 'j' : 'z'
+
+    cmd = "tar -P#{compression_flag}#{flag}f #{Shellwords.escape(file)} #{Shellwords.join(args)}"
+    stdin, stdout, stderr, wait_thr = Open3.popen3(cmd)
+    while wait_thr.status do
+      yield
+    end
+
+    errors = stderr.read
+    output = stdout.read
+    File.write(File.join(@casher_dir, 'tar.log'), output)
+    File.write(File.join(@casher_dir, 'tar.err.log'), errors)
+    status = wait_thr.value
+
+    if !status.success? && flag.to_s != 'x'
+      msg "FAILED: #{cmd}", :red
+      puts errors, output
+    end
+
+    [stdout, errors]
+  end
+
+  def path_ext(url)
+    path = URI.split(url)[5]
+    path.split('.').last
+  end
+
+  def fetched_archive
+    [ File.expand_path('fetch.tbz', @casher_dir), File.expand_path('fetch.tgz', @casher_dir) ].find do |f|
+      File.exist? f
+    end
+  end
+
+  def md5deep_available?
+    @md5deep_available ||= (system("which md5deep >/dev/null 2>&1") || install_md5deep)
+  end
+
+  def install_md5deep
+    if ENV['TRAVIS_OS_NAME'] == 'osx'
+      system('brew install md5deep')
+    end
+  end
+
+  def cached_directories
+    if File.exist?(@paths_file)
+      File.read(@paths_file).split("\n").compact
+    else
+      @mtimes.keys
+    end
+  end
+
+  def msg(text, color = :green)
+    marker = case color
+    when :green
+      ANSI_GREEN
+    when :red
+      ANSI_RED
+    end
+
+    puts "#{marker}#{text}#{ANSI_RESET}"
+  end
+end
+
+Casher.new.run(*ARGV) if $0 == __FILE__

--- a/spec/build/script/directory_cache/gcs_spec.rb
+++ b/spec/build/script/directory_cache/gcs_spec.rb
@@ -59,32 +59,32 @@ describe Travis::Build::Script::DirectoryCache::Gcs, :sexp do
     before { cache.install }
 
     let(:url) { "https://raw.githubusercontent.com/travis-ci/casher/#{branch}/bin/casher" }
-    let(:cmd) { [:cmd,  "curl #{url}  -L -o $CASHER_DIR/bin/casher -s --fail", retry: true, display: 'Installing caching utilities'] }
+    let(:cmd) { [:cmd,  "curl -sf  -o $CASHER_DIR/bin/casher #{url}", retry: true, echo: 'Installing caching utilities'] }
 
     describe 'uses casher production in default mode' do
       let(:branch) { 'production' }
       it { should include_sexp [:export, ['CASHER_DIR', '$HOME/.casher'], echo: true] }
       it { should include_sexp [:mkdir, '$CASHER_DIR/bin', recursive: true] }
-      it { should include_sexp :cmd }
-      it { should include_sexp [:raw, '[ $? -ne 0 ] && echo \'Failed to fetch casher from GitHub, disabling cache.\' && echo > $CASHER_DIR/bin/casher'] }
+      it { should include_sexp cmd }
+      it { should include_sexp [:echo, 'Failed to fetch casher from GitHub, disabling cache.', ansi: :yellow] }
     end
 
     describe 'uses casher master in edge mode' do
       let(:branch) { 'master' }
       let(:config) { { cache: { edge: true } } }
-      it { should include_sexp :cmd }
+      it { should include_sexp cmd }
     end
 
     describe 'passing a casher branch' do
       let(:branch) { 'foo' }
       let(:config) { { cache: { branch: branch } } }
-      it { should include_sexp :cmd }
+      it { should include_sexp cmd }
     end
 
     describe 'using debug flag' do
-      let(:config) { { cache: { debug: true } } }
-      let(:cmd) { [:cmd,  "curl #{url} -v #{described_class::CURL_FORMAT} -L -o $CASHER_DIR/bin/casher -s --fail", retry: true, display: 'Installing caching utilities'] }
-      it { should include_sexp :cmd }
+      let(:config) { { cache: { debug: true, branch: branch } } }
+      let(:cmd) { [:cmd,  "curl -sf -v -w '#{described_class::CURL_FORMAT}' -o $CASHER_DIR/bin/casher #{url}", retry: true, echo: 'Installing caching utilities'] }
+      it { should include_sexp cmd }
     end
   end
 

--- a/spec/build/script/directory_cache/s3_spec.rb
+++ b/spec/build/script/directory_cache/s3_spec.rb
@@ -51,32 +51,32 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
     before { cache.install }
 
     let(:url) { "https://raw.githubusercontent.com/travis-ci/casher/#{branch}/bin/casher" }
-    let(:cmd) { [:cmd,  "curl #{url}  -L -o $CASHER_DIR/bin/casher -s --fail", retry: true, display: 'Installing caching utilities'] }
+    let(:cmd) { [:cmd,  "curl -sf  -o $CASHER_DIR/bin/casher #{url}",retry: true, echo: 'Installing caching utilities'] }
 
     describe 'uses casher production in default mode' do
       let(:branch) { 'production' }
       it { should include_sexp [:export, ['CASHER_DIR', '$HOME/.casher'], echo: true] }
       it { should include_sexp [:mkdir, '$CASHER_DIR/bin', recursive: true] }
-      it { should include_sexp :cmd }
-      it { should include_sexp [:raw, '[ $? -ne 0 ] && echo \'Failed to fetch casher from GitHub, disabling cache.\' && echo > $CASHER_DIR/bin/casher'] }
+      it { should include_sexp cmd }
+      it { should include_sexp [:echo, 'Failed to fetch casher from GitHub, disabling cache.', ansi: :yellow] }
     end
 
     describe 'uses casher master in edge mode' do
       let(:branch) { 'master' }
       let(:config) { { cache: { edge: true } } }
-      it { should include_sexp :cmd }
+      it { should include_sexp cmd }
     end
 
     describe 'passing a casher branch' do
       let(:branch) { 'foo' }
       let(:config) { { cache: { branch: branch } } }
-      it { should include_sexp :cmd }
+      it { should include_sexp cmd }
     end
 
     describe 'using debug flag' do
-      let(:config) { { cache: { debug: true } } }
-      let(:cmd) { [:cmd,  "curl #{url} -v #{described_class::CURL_FORMAT} -L -o $CASHER_DIR/bin/casher -s --fail", retry: true, display: 'Installing caching utilities'] }
-      it { should include_sexp :cmd }
+      let(:config) { { cache: { debug: true, branch: branch } } }
+      let(:cmd) { [:cmd,  "curl -sf -v -w '#{described_class::CURL_FORMAT}' -o $CASHER_DIR/bin/casher #{url}", retry: true, echo: 'Installing caching utilities'] }
+      it { should include_sexp cmd }
     end
   end
 


### PR DESCRIPTION
This PR adds a recent production version of `casher` to the local file storage, which will be served by the web app and fetched by `build.sh`. This allows the use of `casher` even when GitHub is down.