### PR TITLE
When `eval`ing secure commands, send STDERR to /dev/null

### DIFF
--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -56,7 +56,11 @@ travis_cmd() {
     travis_retry eval "$cmd $secure"
     result=$?
   else
-    eval "$cmd $secure"
+    if [[ -n "$secure" ]]; then
+      eval "$cmd $secure" 2>/dev/null
+    else
+      eval "$cmd $secure"
+    fi
     result=$?
     if [[ -n $secure && $result -ne 0 ]]; then
       echo -e "${ANSI_RED}The previous command failed, possibly due to a malformed secure environment variable.${ANSI_CLEAR}


### PR DESCRIPTION
In cases where `eval` is passed an invalid statement, it will
dump the entire string to STDERR, causing leak.

These messages should be suppressed if `$secure` is set

Resolves https://github.com/travis-ci/travis-ci/issues/7359.