### PR TITLE
Fixing the regex for csharp

### DIFF
--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -13,7 +13,7 @@ module Travis
         }
 
         MONO_VERSION_REGEXP = /^(\d{1})\.(\d{1,2})\.\d{1,2}$/
-        DOTNET_VERSION_REGEXP = /^\d{1}\.\d{1,2}\.\d{1,2}(?:-preview\d+(\.\d+)?(?:-\d)?-\d{6})?$/
+        DOTNET_VERSION_REGEXP = /^\d{1}\.\d{1,2}\.\d{1,2}(?:-(?:preview|rc)\d+(\.\d+)?(?:-\d)?-\d{6})?$/
 
         def configure
           super


### PR DESCRIPTION
Fixes the regex for csharp to allow `-rc*` builds to also be available. 

/cc @BanzaiMan @akoeplinger 