### PR TITLE
Revamp Dart support.

### DIFF
--- a/lib/travis/build/script/dart.rb
+++ b/lib/travis/build/script/dart.rb
@@ -147,10 +147,8 @@ MESSAGE
         end
 
         def install
-          sh.fold 'pub_get' do
-            sh.echo 'pub get'
-
-            sh.if '-f pubspec.yaml' do
+          sh.if '-f pubspec.yaml' do
+            sh.fold 'pub_get' do
               sh.cmd "pub get"
             end
           end
@@ -174,7 +172,7 @@ MESSAGE
             sh.fold "deprecated.unittest" do
               sh.deprecate <<MESSAGE
 DEPRECATED: The unittest package is deprecated. Please upgrade to the test
-package. See https://github.com/dart-lang/test.
+package. See https://github.com/dart-lang/test#readme.
 MESSAGE
             end
 
@@ -242,10 +240,10 @@ MESSAGE
             urlEnd = ''
             # support of "dev" or "stable"
             if ["stable", "dev"].include?(task[:dart])
-              urlEnd = "#{config[:dart]}/release/latest"
+              urlEnd = "#{task[:dart]}/release/latest"
             # support of "stable/release/1.15.0" or "be/raw/110749"
             elsif task[:dart].include?("/")
-              urlEnd = config[:dart]
+              urlEnd = task[:dart]
             # support of dev versions like "1.16.0-dev.2.0" or "1.16.0-dev.2.0"
             elsif task[:dart].include?("-dev")
               urlEnd = "dev/release/#{task[:dart]}"

--- a/lib/travis/build/script/dart.rb
+++ b/lib/travis/build/script/dart.rb
@@ -86,6 +86,8 @@ MESSAGE
           sh.echo 'and mention `@nex3` and \`@a14n\`' \
             ' in the issue', ansi: :green
 
+          sh.export 'PUB_ENVIRONMENT', 'travis'
+
           sh.fold 'dart_install' do
             sh.echo 'Installing Dart', ansi: :yellow
             sh.cmd "curl #{archive_url}/sdk/dartsdk-#{os}-x64-release.zip > $HOME/dartsdk.zip"

--- a/lib/travis/build/script/dart.rb
+++ b/lib/travis/build/script/dart.rb
@@ -4,13 +4,53 @@ module Travis
       class Dart < Script
         DEFAULTS = {
           dart: 'stable',
-          with_content_shell: 'false'
+          with_content_shell: false,
+          install_dartium: false,
+          xvfb: true
         }
+
+        attr_reader :task
+
+        def initialize(*args)
+          super
+
+          @task = config[:dart_tasks] || {}
+          @task = {task.to_sym => true} if task.is_a?(String)
+          @task[:install_dartium] = config[:install_dartium] unless task.include?(:install_dartium)
+          @task[:xvfb] = config[:xvfb] unless task.include?(:xvfb)
+          @task[:dart] ||= config[:dart]
+
+          # Run "pub run test" by default if no other tasks are specified.
+          @task[:test] ||= true if !@task[:dartanalyzer] && !@task[:dartfmt]
+        end
 
         def configure
           super
 
-          if with_content_shell
+          if config[:with_content_shell]
+            if config.include?(:dart_tasks)
+              sh.failure "with_content_shell can't be used with dart_tasks."
+              return
+            elsif config[:install_dartium]
+              sh.failure "with_content_shell can't be used with install_dartium."
+              return
+            elsif !config[:xvfb]
+              sh.failure "with_content_shell can't be used with xvfb."
+              return
+            end
+
+            sh.fold "deprecated.with_content_shell" do
+              sh.deprecate <<MESSAGE
+DEPRECATED: with_content_shell is deprecated. Instead use:
+
+    dart_tasks:
+    - test: --platform vm
+    - test: --platform firefox
+    - test: --platform dartium
+      install_dartium: true
+MESSAGE
+            end
+
             sh.fold 'content_shell_dependencies_install' do
               sh.echo 'Installing Content Shell dependencies', ansi: :yellow
 
@@ -31,7 +71,7 @@ module Travis
         def export
           super
 
-          sh.export 'TRAVIS_DART_VERSION', config[:dart], echo: false
+          sh.export 'TRAVIS_DART_VERSION', task[:dart], echo: false
         end
 
         def setup
@@ -43,16 +83,12 @@ module Travis
             ansi: :green
           sh.echo '  https://github.com/travis-ci/travis-ci/issues' \
             '/new?labels=community:dart', ansi: :green
-          sh.echo 'and mention \`@a14n\`, \`@devoncarew\` and \`@sethladd\`' \
+          sh.echo 'and mention `@nex3` and \`@a14n\`' \
             ' in the issue', ansi: :green
 
           sh.fold 'dart_install' do
             sh.echo 'Installing Dart', ansi: :yellow
-            os = case config[:os]
-            when 'linux' then 'linux-x64'
-            when 'osx' then 'macos-x64'
-            end
-            sh.cmd "curl #{archive_url}/sdk/dartsdk-#{os}-release.zip > $HOME/dartsdk.zip"
+            sh.cmd "curl #{archive_url}/sdk/dartsdk-#{os}-x64-release.zip > $HOME/dartsdk.zip"
             sh.cmd "unzip $HOME/dartsdk.zip -d $HOME > /dev/null"
             sh.cmd "rm $HOME/dartsdk.zip"
             sh.cmd 'export DART_SDK="$HOME/dart-sdk"'
@@ -60,7 +96,31 @@ module Travis
             sh.cmd 'export PATH="$HOME/.pub-cache/bin:$PATH"'
           end
 
-          if with_content_shell
+          if task[:install_dartium]
+            sh.fold 'dartium_install' do
+              sh.echo 'Installing Dartium', anis: :yellow
+
+              sh.cmd "mkdir $HOME/dartium"
+              sh.cmd "cd $HOME/dartium"
+              sh.cmd "curl #{archive_url}/dartium/dartium-#{os}-x64-release.zip > dartium.zip"
+              sh.cmd "unzip dartium.zip > /dev/null"
+              sh.cmd "rm dartium.zip"
+              sh.cmd 'dartium_dir="${PWD%/}/$(ls)"'
+
+              # The executable has to be named "dartium" in order for the test
+              # runner to find it.
+              if os == 'macos'
+                sh.cmd 'ln -s "$dartium_dir/Chromium.app/Contents/MacOS/Chromium" dartium'
+              else
+                sh.cmd 'ln -s "$dartium_dir/chrome" dartium'
+              end
+
+              sh.cmd 'export PATH="$PWD:$PATH"'
+              sh.cmd "cd -"
+            end
+          end
+
+          if config[:with_content_shell]
             if config[:os] != 'linux'
               sh.failure 'Content shell only supported on Linux'
             end
@@ -87,61 +147,113 @@ module Travis
         end
 
         def install
-          sh.if '-f pubspec.yaml' do
-            sh.cmd "pub get"
+          sh.fold 'pub_get' do
+            sh.echo 'pub get'
+
+            sh.if '-f pubspec.yaml' do
+              sh.cmd "pub get"
+            end
           end
         end
 
         def script
           # tests with test package
-          sh.if '[[ -d packages/test ]] || grep -q ^test: .packages 2> /dev/null', raw: true do
-            if with_content_shell
+          sh.if package_installed?('test'), raw: true do
+            if config[:with_content_shell]
               sh.export 'DISPLAY', ':99.0'
               sh.cmd 'sh -e /etc/init.d/xvfb start'
               # give xvfb some time to start
               sh.cmd 't=0; until (xdpyinfo -display :99 &> /dev/null || test $t -gt 10); do sleep 1; let t=$t+1; done'
               sh.cmd 'pub run test -p vm -p content-shell -p firefox'
             else
-              sh.cmd 'pub run test'
+              pub_run_test
             end
           end
           # tests with test_runner for old tests written with unittest package
-          sh.elif '[[ -d packages/unittest ]] || grep -q ^unittest: .packages 2> /dev/null', raw: true do
+          sh.elif package_installed?('unittest'), raw: true do
+            sh.fold "deprecated.unittest" do
+              sh.deprecate <<MESSAGE
+DEPRECATED: The unittest package is deprecated. Please upgrade to the test
+package. See https://github.com/dart-lang/test.
+MESSAGE
+            end
+
             sh.fold 'test_runner_install' do
               sh.echo 'Installing Test Runner', ansi: :yellow
               sh.cmd 'pub global activate test_runner'
             end
 
-            if with_content_shell
+            if config[:with_content_shell]
               sh.cmd 'xvfb-run -s "-screen 0 1024x768x24" pub global run test_runner --disable-ansi'
             else
               sh.cmd 'pub global run test_runner --disable-ansi --skip-browser-tests'
             end
           end
+
+          dartanalyzer
+          dartfmt
         end
 
         private
 
+          def pub_run_test
+            return unless (args = task[:test])
+            args = args.is_a?(String) ? " #{args}" : ""
+
+            # Mac OS doesn't need or support xvfb-run.
+            xvfb_run = 'xvfb-run -s "-screen 0 1024x768x24" '
+            xvfb_run = '' if task[:xvfb] == false || os == "macos"
+            sh.cmd "#{xvfb_run}pub run test#{args}"
+          end
+
+          def dartanalyzer
+            return unless (args = task[:dartanalyzer])
+            args = '.' unless args.is_a?(String)
+            sh.cmd "dartanalyzer #{args}"
+          end
+
+          def dartfmt
+            return unless (args = task[:dartfmt])
+            if args.is_a?(String)
+              sh.echo "dartfmt arguments aren't supported.", ansi: :red
+            end
+
+            sh.if package_installed?('dart_style'), raw: true do
+              sh.raw 'function dartfmt() { pub run dart_style:format "$@"; }'
+            end
+
+            sh.cmd 'unformatted=`dartfmt -n .`'
+            sh.if '! -z "$unformatted"' do
+              sh.echo "Files are unformatted:", ansi: :red
+              sh.echo "$unformatted"
+              sh.failure ""
+            end
+          end
+
+          def package_installed?(package)
+            "[[ -d packages/#{package} ]] || grep -q ^#{package}: .packages 2> /dev/null"
+          end
+
+          def os
+            config[:os] == 'osx' ? 'macos' : 'linux'
+          end
+
           def archive_url
             urlEnd = ''
             # support of "dev" or "stable"
-            if ["stable", "dev"].include?(config[:dart])
+            if ["stable", "dev"].include?(task[:dart])
               urlEnd = "#{config[:dart]}/release/latest"
             # support of "stable/release/1.15.0" or "be/raw/110749"
-            elsif config[:dart].include?("/")
+            elsif task[:dart].include?("/")
               urlEnd = config[:dart]
             # support of dev versions like "1.16.0-dev.2.0" or "1.16.0-dev.2.0"
-            elsif config[:dart].include?("-dev")
-              urlEnd = "dev/release/#{config[:dart]}"
+            elsif task[:dart].include?("-dev")
+              urlEnd = "dev/release/#{task[:dart]}"
             # support of stable versions like "1.14.0" or "1.14.1"
             else
-              urlEnd = "stable/release/#{config[:dart]}"
+              urlEnd = "stable/release/#{task[:dart]}"
             end
             "https://storage.googleapis.com/dart-archive/channels/#{urlEnd}"
-          end
-
-          def with_content_shell
-            ["true", "yes"].include?(config[:with_content_shell].to_s.downcase)
           end
       end
     end

--- a/lib/travis/build/script/dart.rb
+++ b/lib/travis/build/script/dart.rb
@@ -166,7 +166,7 @@ MESSAGE
               sh.cmd 't=0; until (xdpyinfo -display :99 &> /dev/null || test $t -gt 10); do sleep 1; let t=$t+1; done'
               sh.cmd 'pub run test -p vm -p content-shell -p firefox'
             else
-              pub_run_test
+              pub_run_test if run_pub_run_test?
             end
           end
           # tests with test_runner for old tests written with unittest package
@@ -190,18 +190,25 @@ MESSAGE
             end
           end
 
-          dartanalyzer
-          dartfmt
+          dartanalyzer if run_dartanalyzer?
+          dartfmt      if run_dartfmt?
         end
 
         private
+          def run_pub_run_test?
+            !!task[:test]
+          end
+
+          def run_dartanalyzer?
+            !!task[:dartanalyzer]
+          end
+
+          def run_dartfmt?
+            !!task[:dartfmt]
+          end
 
           def pub_run_test
             args = task[:test]
-            unless args
-              sh.raw ':'
-              return
-            end
 
             args = args.is_a?(String) ? " #{args}" : ""
             # Mac OS doesn't need or support xvfb-run.
@@ -212,10 +219,6 @@ MESSAGE
 
           def dartanalyzer
             args = task[:dartanalyzer]
-            unless args
-              sh.raw ':'
-              return
-            end
 
             args = '.' unless args.is_a?(String)
             sh.cmd "dartanalyzer #{args}"
@@ -223,10 +226,6 @@ MESSAGE
 
           def dartfmt
             args = task[:dartfmt]
-            unless args
-              sh.raw ':'
-              return
-            end
 
             if args.is_a?(String)
               sh.echo "dartfmt arguments aren't supported.", ansi: :red

--- a/spec/build/script/dart_spec.rb
+++ b/spec/build/script/dart_spec.rb
@@ -37,7 +37,7 @@ describe Travis::Build::Script::Dart, :sexp do
 
   describe 'installs content_shell if config has a :with_content_shell key set with true' do
     before do
-      data[:config][:with_content_shell] = 'true'
+      data[:config][:with_content_shell] = true
     end
 
     it "installs content_shell" do
@@ -85,6 +85,63 @@ describe Travis::Build::Script::Dart, :sexp do
   end
 
   describe 'script' do
+    describe 'with with_content_shell' do
+      before { data[:config][:with_content_shell] = true }
+
+      it 'should have a deprecation message' do
+        should include_deprecation_sexp(/with_content_shell is deprecated/)
+      end
+
+      describe 'with dart_tasks being set' do
+        before { data[:config][:dart_tasks] = {test: true} }
+        it 'should fail' do
+          should include_sexp [:echo, "with_content_shell can't be used with dart_tasks."]
+        end
+      end
+
+      describe 'with install_dartium being true' do
+        before { data[:config][:install_dartium] = true }
+        it 'should fail' do
+          should include_sexp [:echo, "with_content_shell can't be used with install_dartium."]
+        end
+      end
+
+      describe 'with xvfb being false' do
+        before { data[:config][:xvfb] = false }
+        it 'should fail' do
+          should include_sexp [:echo, "with_content_shell can't be used with xvfb."]
+        end
+      end
+    end
+
+    describe 'with install_dartium' do
+      before { data[:config][:install_dartium] = true }
+
+      describe 'on Linux' do
+        before { data[:config][:os] = 'linux' }
+
+        it 'downloads the Linux archive' do
+          should match_sexp [:cmd, %r{dartium/dartium-linux-x64-release.zip}]
+        end
+
+        it 'links to the chrome executable' do
+          should match_sexp [:cmd, %r{ln -s ".*/chrome" dartium}]
+        end
+      end
+
+      describe 'on OS X' do
+        before { data[:config][:os] = 'osx' }
+
+        it 'downloads the OS X archive' do
+          should match_sexp [:cmd, %r{dartium/dartium-macos-x64-release.zip}]
+        end
+
+        it 'links to the Chromium executable' do
+          should match_sexp [:cmd, %r{ln -s ".*/Chromium\.app/Contents/MacOS/Chromium" dartium}]
+        end
+      end
+    end
+
     describe 'if a directory packages/test exists or the file .packages defines a test [something ... target?]' do
       let(:sexp) { sexp_find(subject, [:if, "[[ -d packages/test ]] || grep -q ^test: .packages 2> /dev/null"]) }
 
@@ -95,7 +152,7 @@ describe Travis::Build::Script::Dart, :sexp do
 
       describe 'with with_content_shell being true' do
         let(:sexp) { sexp_filter(super(), [:then]) }
-        before     { data[:config][:with_content_shell] = 'true' }
+        before     { data[:config][:with_content_shell] = true }
 
         it 'exports DISPLAY=:99:0' do
           expect(sexp).to include_sexp [:export, ['DISPLAY', ':99.0'], echo: true]
@@ -113,8 +170,29 @@ describe Travis::Build::Script::Dart, :sexp do
       describe 'with with_content_shell being nil' do
         let(:sexp) { sexp_filter(super(), [:then]) }
 
-        it 'runs pub run test' do
-          expect(sexp).to include_sexp [:cmd, 'pub run test', echo: true, timing: true]
+        it 'runs pub run test with XVFB' do
+          expect(sexp).to include_sexp [:cmd, 'xvfb-run -s "-screen 0 1024x768x24" pub run test', echo: true, timing: true]
+        end
+
+        describe 'with test args' do
+          before { data[:config][:dart_tasks] = {test: '--platform chrome'} }
+          it "runs pub run test with those arguments" do
+            expect(sexp).to match_sexp [:cmd, /pub run test --platform chrome/]
+          end
+        end
+
+        describe 'with xvfb being false' do
+          before { data[:config][:xvfb] = false }
+          it "runs pub run test without XVFB" do
+            expect(sexp).to include_sexp [:cmd, 'pub run test', echo: true, timing: true]
+          end
+        end
+
+        describe 'with a different task specified' do
+          before { data[:config][:dart_tasks] = 'dartanalyzer' }
+          it "doesn't run pub run test" do
+            expect(sexp).not_to match_sexp [:cmd, /pub run test/]
+          end
         end
       end
     end
@@ -132,7 +210,7 @@ describe Travis::Build::Script::Dart, :sexp do
       end
 
       describe 'with with_content_shell being true' do
-        before { data[:config][:with_content_shell] = 'true' }
+        before { data[:config][:with_content_shell] = true }
 
         it 'runs pub global run test_runner via xvfb-run' do
           expect(sexp).to include_sexp [:cmd, 'xvfb-run -s "-screen 0 1024x768x24" pub global run test_runner --disable-ansi', echo: true, timing: true]
@@ -143,6 +221,37 @@ describe Travis::Build::Script::Dart, :sexp do
         it 'runs pub run test' do
           expect(sexp).to include_sexp [:cmd, 'pub global run test_runner --disable-ansi --skip-browser-tests', echo: true, timing: true]
         end
+      end
+    end
+
+    describe 'with dartanalyzer' do
+      before { data[:config][:dart_tasks] = 'dartanalyzer' }
+
+      it "runs dartanalyzer on the whole package" do
+        should include_sexp [:cmd, 'dartanalyzer .', echo: true, timing: true]
+      end
+
+      describe 'with arguments' do
+        before { data[:config][:dart_tasks] = {dartanalyzer: '--fatal-warnings lib'} }
+
+        it "runs dartanalyzer with those arguments" do
+          should include_sexp [:cmd, 'dartanalyzer --fatal-warnings lib', echo: true, timing: true]
+        end
+      end
+    end
+
+    describe 'with dartfmt' do
+      before { data[:config][:dart_tasks] = 'dartfmt' }
+
+      describe 'when dart_style is installed' do
+        let(:sexp) { sexp_find(subject, [:elif, "[[ -d packages/dart_style ]] || grep -q ^dart_style: .packages 2> /dev/null"]) }
+        it "runs the installed version of dartfmt" do
+          should include_sexp [:raw, 'function dartfmt() { pub run dart_style:format "$@"; }']
+        end
+      end
+
+      it 'runs dartfmt -n on the whole package' do
+        should match_sexp [:cmd, /dartfmt -n \./]
       end
     end
   end


### PR DESCRIPTION
This adds:

* Support for running different test commands in different builds.
* Support for running any browser in XVFB on Linux.
* Support for the Dart static analyzer.
* Support for the Dart code formatter.