### PR TITLE
Add URL for dotnet-cli RC builds

### DIFF
--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -188,7 +188,11 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
         end
 
         def dotnet_osx_url
-          return "https://dotnetcli.azureedge.net/dotnet/preview/Installers/#{config[:dotnet]}/dotnet-dev-osx-x64.#{config[:dotnet]}.pkg"
+          if config[:dotnet].include? "-preview"
+            return "https://dotnetcli.azureedge.net/dotnet/preview/Installers/#{config[:dotnet]}/dotnet-dev-osx-x64.#{config[:dotnet]}.pkg"
+          else
+            return "https://dotnetcli.azureedge.net/dotnet/Sdk/#{config[:dotnet]}/dotnet-dev-osx-x64.#{config[:dotnet]}.pkg"
+          end
         end
 
         def is_mono_version_valid?


### PR DESCRIPTION
For example:

https://dotnetcli.azureedge.net/dotnet/Sdk/1.0.0-rc4-004771/dotnet-dev-osx-x64.1.0.0-rc4-004771.pkg
https://dotnetcli.azureedge.net/dotnet/Sdk/1.0.0-rc4-004915/dotnet-dev-osx-x64.1.0.0-rc4-004915.pkg

are valid URLs for RC builds, and for preview the existing format works:

https://dotnetcli.azureedge.net/dotnet/preview/Installers/1.0.0-preview2-1-003177/dotnet-dev-osx-x64.1.0.0-preview2-1-003177.pkg