### PR TITLE
Look for phpunit in order defined by composer

### DIFF
--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -57,7 +57,7 @@ module Travis
         end
 
         def script
-          sh.raw "_phpunit_bin=$(jq -r .config[\"bin-dir\"] $TRAVIS_BUILD_DIR/composer.json 2>/dev/null)"
+          sh.raw '_phpunit_bin=$(jq -r .config[\"bin-dir\"] $TRAVIS_BUILD_DIR/composer.json 2>/dev/null)'
           sh.if "-n $COMPOSER_BIN_DIR && -x $COMPOSER_BIN_DIR/phpunit" do
             sh.cmd '$COMPOSER_BIN_DIR/phpunit'
           end


### PR DESCRIPTION
When composer is used, preferred phpunit may not be the one that
is provided by the PHP runtime we offer.

As described in https://getcomposer.org/doc/articles/vendor-binaries.md#can-vendor-binaries-be-installed-somewhere-other-than-vendor-bin-
(and as discovered by an additional experiment), the order is:
1. $COMPOSER_BIN_DIR/phpunit
2. `config: "bin-dir"` in composer.json
3. vendor/bin/phpunit

If none of these applies, we invoke `phpunit`, which is the one
provided by our PHP runtime.

This resolves https://github.com/travis-ci/travis-ci/issues/7226.