### PR TITLE
Roll JWT functionality to supported addon (sauce_connect)

### DIFF
--- a/lib/travis/build/addons/jwt.rb
+++ b/lib/travis/build/addons/jwt.rb
@@ -8,7 +8,7 @@ module Travis
         SUPER_USER_SAFE = true
 
         def before_before_install
-          sh.echo "The use of \\`jwt\\` as a standalone addon is deprecated, and will be removed on no sooner than 2017-07-01. Please update your configuration", ansi: :yellow
+          sh.deprecate "The use of \\`jwt\\` as a standalone addon is deprecated, and will be removed on no sooner than 2017-07-01. Please update your configuration"
           tokens = {}
           Array(config).each do |secret|
             pull_request = self.data.pull_request ? self.data.pull_request : ""

--- a/lib/travis/build/addons/jwt.rb
+++ b/lib/travis/build/addons/jwt.rb
@@ -8,7 +8,7 @@ module Travis
         SUPER_USER_SAFE = true
 
         def before_before_install
-          sh.echo "The use of \\`jwt\\` as a standalone addon is deprecated, and will be removed on no sooner than YYYY-MM-DD. Please update your configuration", ansi: :red
+          sh.echo "The use of \\`jwt\\` as a standalone addon is deprecated, and will be removed on no sooner than 2017-07-01. Please update your configuration", ansi: :yellow
           tokens = {}
           Array(config).each do |secret|
             pull_request = self.data.pull_request ? self.data.pull_request : ""

--- a/lib/travis/build/addons/jwt.rb
+++ b/lib/travis/build/addons/jwt.rb
@@ -8,6 +8,7 @@ module Travis
         SUPER_USER_SAFE = true
 
         def before_before_install
+          sh.echo "The use of \\`jwt\\` as a standalone addon is deprecated, and will be removed on no sooner than YYYY-MM-DD. Please update your configuration", ansi: :red
           tokens = {}
           Array(config).each do |secret|
             pull_request = self.data.pull_request ? self.data.pull_request : ""


### PR DESCRIPTION
To correspond to https://github.com/travis-ci/travis-scheduler/pull/64.

With this, we will now accommodate the new configuration:

```yaml
addons:
  sauce_connect:
    jwt:
      secure: …
```

to define `SAUCE_ACCESS_KEY`.

If the old configuration is used, a deprecation warning [will be printed](https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/548857#L128). If both the old and the new layouts are used, the new one takes precedence (since it is [executed later](https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/548857#L132)).