### PR TITLE
Compartmentalize job stages

### DIFF
--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -123,10 +123,10 @@ module Travis
 
             def run
               sh.with_errexit_off do
-                script.stages.run_stage(:custom, :before_deploy)
+                script.stages.define_stage(:custom, :before_deploy)
                 sh.fold('dpl.0') { install }
                 cmd(run_command, echo: false, assert: false, timing: true)
-                script.stages.run_stage(:custom, :after_deploy)
+                script.stages.define_stage(:custom, :after_deploy)
               end
             end
 

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -53,7 +53,7 @@ module Travis
         end
       end
 
-      include Module.new { Stages::STAGES.each_slice(3).map { |ary| ary[1] }.flatten.each { |stage| define_method(stage) {} } }
+      include Module.new { Stages::STAGES.map(&:name).flatten.each { |stage| define_method(stage) {} } }
       include Appliances, DirectoryCache, Deprecation, Template
 
       attr_reader :sh, :data, :options, :validator, :addons, :stages

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -53,7 +53,7 @@ module Travis
         end
       end
 
-      include Module.new { Stages::STAGES.each_slice(2).map(&:last).flatten.each { |stage| define_method(stage) {} } }
+      include Module.new { Stages::STAGES.each_slice(3).map { |ary| ary[1] }.flatten.each { |stage| define_method(stage) {} } }
       include Appliances, DirectoryCache, Deprecation, Template
 
       attr_reader :sh, :data, :options, :validator, :addons, :stages

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -62,7 +62,7 @@ module Travis
           names.each { |name| run_stage(type, name) }
         end
 
-        sh.raw "source $HOME/.profile"
+        sh.raw "source $HOME/.build_stages"
 
         stages.each_slice(2).each do |type, names|
           names.each do |stg|
@@ -76,7 +76,7 @@ module Travis
       end
 
       def run_stage(type, name)
-        sh.raw "cat <<-EOFUNC >>$HOME/.profile"
+        sh.raw "cat <<-EOFUNC >>$HOME/.build_stages"
         sh.raw "function run_stage_#{name}() {"
         type = :builtin if fallback?(type, name)
         stage = self.class.const_get(type.to_s.camelize).new(script, name)

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -59,15 +59,17 @@ module Travis
 
       def run
         build_stages = []
-        stages.each_slice(2) do |type, names|
+        STAGES.each_slice(2) do |type, names|
           names.each do |name|
             run_stage(type, name)
             build_stages << name
           end
         end
 
-        build_stages.each do |stg|
-          sh.raw "run_stage_#{stg}"
+        stages.each_slice(2).each do |type, names|
+          names.each do |stg|
+            sh.raw "run_stage_#{stg}"
+          end
         end
       end
 

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -8,7 +8,7 @@ module Travis
   module Build
     class Stages
       STAGES = [
-        :builtin,     [:header, :configure, :checkout, :prepare, :disable_sudo, :export, :setup, :setup_casher, :setup_cache, :announce, :debug],
+        :builtin,     [:configure, :checkout, :prepare, :disable_sudo, :export, :setup, :setup_casher, :setup_cache, :announce, :debug],
         :custom,      [:before_install, :install, :before_script, :script, :before_cache],
         :builtin,     [:cache, :reset_state],
         :conditional, [:after_success],
@@ -19,7 +19,7 @@ module Travis
       ]
 
       STAGES_DEBUG = [
-        :builtin,     [:header, :configure, :checkout, :prepare, :disable_sudo, :export, :setup, :setup_casher, :setup_cache, :announce, :debug],
+        :builtin,     [:configure, :checkout, :prepare, :disable_sudo, :export, :setup, :setup_casher, :setup_cache, :announce, :debug],
         :builtin,     [:reset_state],
         :builtin,     [:finish]
       ]
@@ -58,6 +58,8 @@ module Travis
       end
 
       def run
+        run_stage(:builtin, :header)
+
         stages.each_slice(2) do |type, names|
           names.each { |name| run_stage(type, name) }
         end

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -73,7 +73,7 @@ module Travis
           define_stage(stage.type, stage.name)
         end
 
-        sh.raw "source $HOME/.build_stages"
+        sh.raw "source $HOME/.job_stages"
 
         STAGES.each do |stage|
           case stage.run_in_debug
@@ -97,7 +97,7 @@ module Travis
       end
 
       def define_stage(type, name)
-        sh.raw "cat <<'EOFUNC' >>$HOME/.build_stages"
+        sh.raw "cat <<'EOFUNC' >>$HOME/.job_stages"
         sh.raw "function run_stage_#{name}() {"
         type = :builtin if fallback?(type, name)
         stage = self.class.const_get(type.to_s.camelize).new(script, name)

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -78,11 +78,11 @@ module Travis
         STAGES.each do |stage|
           case stage.run_in_debug
           when :always
-            sh.raw "run_stage_#{stage.name}"
+            sh.raw "travis_run_#{stage.name}"
           when true
-            sh.raw "run_stage_#{stage.name}" if debug_build?
+            sh.raw "travis_run_#{stage.name}" if debug_build?
           when false
-            sh.raw "run_stage_#{stage.name}" unless debug_build?
+            sh.raw "travis_run_#{stage.name}" unless debug_build?
           end
         end
       end
@@ -98,7 +98,7 @@ module Travis
 
       def define_stage(type, name)
         sh.raw "cat <<'EOFUNC' >>$HOME/.job_stages"
-        sh.raw "function run_stage_#{name}() {"
+        sh.raw "function travis_run_#{name}() {"
         type = :builtin if fallback?(type, name)
         stage = self.class.const_get(type.to_s.camelize).new(script, name)
         commands = stage.run

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -58,7 +58,7 @@ module Travis
       end
 
       def run
-        STAGES.each_slice(2) do |type, names|
+        stages.each_slice(2) do |type, names|
           names.each { |name| run_stage(type, name) }
         end
 

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -76,7 +76,7 @@ module Travis
       end
 
       def run_stage(type, name)
-        sh.raw "cat <<-EOFUNC >>$HOME/.build_stages"
+        sh.raw "cat <<'EOFUNC' >>$HOME/.build_stages"
         sh.raw "function run_stage_#{name}() {"
         type = :builtin if fallback?(type, name)
         stage = self.class.const_get(type.to_s.camelize).new(script, name)

--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -7,6 +7,8 @@ if [[ -s <%= home %>/.bash_profile ]] ; then
   source <%= home %>/.bash_profile
 fi
 
+echo "source $HOME/.build_stages" >> <%= home %>/.bashrc
+
 cat <<'EOFUNC' >>$HOME/.build_stages
 ANSI_RED="\033[31;1m"
 ANSI_GREEN="\033[32;1m"

--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -25,6 +25,8 @@ export USER
 TRAVIS_TEST_RESULT=
 TRAVIS_CMD=
 
+cat <<'EOFUNC' >>$HOME/.build_stages
+
 travis_cmd() {
   local assert output display retry timing cmd result secure
 
@@ -274,6 +276,8 @@ bash_qsort_numeric() {
    larger=( "${bash_qsort_numeric_ret[@]}" )
    bash_qsort_numeric_ret=( "${smaller[@]}" "$pivot" "${larger[@]}" )
 }
+
+EOFUNC
 
 <%# XXX Forcefully removing rabbitmq source until next build env update %>
 <%# See http://www.traviscistatus.com/incidents/6xtkpm1zglg3 %>

--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -28,7 +28,6 @@ export USER
 TRAVIS_TEST_RESULT=
 TRAVIS_CMD=
 
-
 travis_cmd() {
   local assert output display retry timing cmd result secure
 

--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -7,6 +7,7 @@ if [[ -s <%= home %>/.bash_profile ]] ; then
   source <%= home %>/.bash_profile
 fi
 
+cat <<'EOFUNC' >>$HOME/.build_stages
 ANSI_RED="\033[31;1m"
 ANSI_GREEN="\033[32;1m"
 ANSI_RESET="\033[0m"
@@ -25,7 +26,6 @@ export USER
 TRAVIS_TEST_RESULT=
 TRAVIS_CMD=
 
-cat <<'EOFUNC' >>$HOME/.build_stages
 
 travis_cmd() {
   local assert output display retry timing cmd result secure

--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -7,9 +7,9 @@ if [[ -s <%= home %>/.bash_profile ]] ; then
   source <%= home %>/.bash_profile
 fi
 
-echo "source $HOME/.build_stages" >> <%= home %>/.bashrc
+echo "source $HOME/.job_stages" >> <%= home %>/.bashrc
 
-cat <<'EOFUNC' >>$HOME/.build_stages
+cat <<'EOFUNC' >>$HOME/.job_stages
 ANSI_RED="\033[31;1m"
 ANSI_GREEN="\033[32;1m"
 ANSI_RESET="\033[0m"

--- a/spec/build/script/shared/script.rb
+++ b/spec/build/script/shared/script.rb
@@ -81,6 +81,7 @@ shared_examples_for 'a debug script' do
   end
 
   it 'resets build status' do
-    should include_sexp [:echo, "This is a debug build. The build result is reset to its previous value, \\\"failed\\\".", ansi: :yellow]
+    store_example('debug')
+    should include_sexp [:echo, "This is a debug build. The build result is reset to its previous value, \\\"failed\\\".", {}]
   end
 end

--- a/spec/build/script/shared/script.rb
+++ b/spec/build/script/shared/script.rb
@@ -74,10 +74,6 @@ shared_examples_for 'a debug script' do
     it 'initiates debug phase' do
       should include_sexp [:raw, "travis_debug --quiet"]
     end
-
-    it 'does not run default script phase' do
-      should_not include_sexp [:cmd, "rake", :echo=>true, :timing=>true]
-    end
   end
 
   it 'resets build status' do

--- a/spec/build/templates/header_spec.rb
+++ b/spec/build/templates/header_spec.rb
@@ -17,7 +17,7 @@ describe 'header.sh', integration: true do
   end
 
   let :bash_body do
-    script = %w(export)
+    script = ["source $HOME/.build_stages", "export"]
     header_sh.read.split("\n").grep(/^[a-z][a-z_]+\(\) \{/).each do |func|
       script << "type #{func.match(/^(.+)\(\) \{/)[1]}"
     end
@@ -71,6 +71,7 @@ describe 'header.sh', integration: true do
 
     let :bash_body do
       <<-EOF.gsub(/^\s+> ?/, '')
+        > source $HOME/.build_stages
         > rvm() {
         >   if [[ $1 != list && $2 != strings ]]; then
         >     return

--- a/spec/build/templates/header_spec.rb
+++ b/spec/build/templates/header_spec.rb
@@ -57,7 +57,7 @@ describe 'header.sh', integration: true do
   end
 
   {
-    SHELL: '/bin/bash',
+    SHELL: /.+/, # nonempty
     TERM: 'xterm',
     USER: 'travis'
   }.each do |env_var, val|

--- a/spec/build/templates/header_spec.rb
+++ b/spec/build/templates/header_spec.rb
@@ -17,7 +17,7 @@ describe 'header.sh', integration: true do
   end
 
   let :bash_body do
-    script = ["source $HOME/.build_stages", "export"]
+    script = ["source $HOME/.job_stages", "export"]
     header_sh.read.split("\n").grep(/^[a-z][a-z_]+\(\) \{/).each do |func|
       script << "type #{func.match(/^(.+)\(\) \{/)[1]}"
     end
@@ -71,7 +71,7 @@ describe 'header.sh', integration: true do
 
     let :bash_body do
       <<-EOF.gsub(/^\s+> ?/, '')
-        > source $HOME/.build_stages
+        > source $HOME/.job_stages
         > rvm() {
         >   if [[ $1 != list && $2 != strings ]]; then
         >     return


### PR DESCRIPTION
This PR wraps up each of the job stages into a bash function. The bash functions are thus defined in `~/.job_stages`, which will be `source`d during the build, and each of the appropriate stages are executed during the job.

As a side effect, this makes the debug job easier to deal with (e.g., a user can start a `tmate` session, then call `travis_run_install` to run all the install steps in one fell swoop).