### PR TITLE
Invoke `yarn` with `--frozen-lockfile`

### DIFF
--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -44,7 +44,7 @@ module Travis
         def install
           sh.if '-f package.json' do
             sh.if "-f yarn.lock" do
-              sh.cmd "yarn", retry: true, fold: 'install'
+              sh.cmd "yarn --frozen-lockfile", retry: true, fold: 'install'
             end
             sh.else do
               npm_install config[:npm_args]


### PR DESCRIPTION
With `--frozen-lockfile`, `yarn` will install packages indicated by
`yarn.lock`, and fail if any update is required.

Resolves https://github.com/travis-ci/travis-ci/issues/7395