### PR TITLE
Display `sudo` warning on containers only when `sudo` is invoked

### DIFF
--- a/lib/travis/build/appliances/disable_sudo.rb
+++ b/lib/travis/build/appliances/disable_sudo.rb
@@ -7,7 +7,7 @@ module Travis
         WRITE_SUDO = <<-EOC
 cat <<-'EOF' > _sudo
 if [[ -f \$HOME/.sudo-run ]]; then
-  exit 0
+  exit 1
 fi
 
 echo -e "\\\\033[33;1mThis job is running on container-based infrastructure, which does not allow use of 'sudo', setuid, and setgid executables.\\\\033[0m
@@ -16,6 +16,7 @@ echo -e "\\\\033[33;1mThis job is running on container-based infrastructure, whi
 
 touch \$HOME/.sudo-run
 
+exit 1
 EOF
         EOC
         CLEANUP = 'sudo -n sh -c "chmod 4755 _sudo; chown root:root _sudo; mv _sudo `which sudo`; find / \\( -perm -4000 -o -perm -2000 \\) -a ! -name sudo -exec chmod a-s {} \; 2>/dev/null && sed -e \'s/^%.*//\' -i.bak /etc/sudoers && rm -f /etc/sudoers.d/travis"'

--- a/lib/travis/build/appliances/disable_sudo.rb
+++ b/lib/travis/build/appliances/disable_sudo.rb
@@ -18,7 +18,7 @@ touch \$HOME/.sudo-run
 
 EOF
         EOC
-        DISABLE_SUID = 'sudo -n sh -c "find / -perm -4000 -a ! -name sudo -exec chmod a-s {} \; 2>/dev/null"'
+        DISABLE_SUID = 'sudo -n sh -c "find / \\( -perm -4000 -o -perm -2000 \\) -a ! -name sudo -exec chmod a-s {} \; 2>/dev/null"'
         CLEANUP = 'sudo -n sh -c "chmod 4755 _sudo; chown root:root _sudo; mv _sudo `which sudo`; find / -perm -4000 -a ! -name sudo -exec chmod a-s {} \; 2>/dev/null && sed -e \'s/^%.*//\' -i.bak /etc/sudoers && rm -f /etc/sudoers.d/travis"'
 
         def apply

--- a/lib/travis/build/appliances/disable_sudo.rb
+++ b/lib/travis/build/appliances/disable_sudo.rb
@@ -10,7 +10,7 @@ if [[ -f \$HOME/.sudo-run ]]; then
   exit 0
 fi
 
-echo -e "\\\\033[33;1mThis job is running on container-based infrastructure, which does not allow use of 'sudo', setuid and setguid executables.\\\\033[0m
+echo -e "\\\\033[33;1mThis job is running on container-based infrastructure, which does not allow use of 'sudo', setuid, and setgid executables.\\\\033[0m
 \\\\033[33;1mIf you require sudo, add 'sudo: required' to your .travis.yml\\\\033[0m
 "
 

--- a/lib/travis/build/appliances/disable_sudo.rb
+++ b/lib/travis/build/appliances/disable_sudo.rb
@@ -4,16 +4,26 @@ module Travis
   module Build
     module Appliances
       class DisableSudo < Base
-        MSG1 = "\nThis job is running on container-based infrastructure, which does not allow use of 'sudo', setuid and setguid executables.\n"
-        MSG2 = "If you require sudo, add 'sudo: required' to your .travis.yml\n"
-        MSG3 = "See https://docs.travis-ci.com/user/workers/container-based-infrastructure/ for details.\n"
-        CMD = 'sudo -n sh -c "sed -e \'s/^%.*//\' -i.bak /etc/sudoers && rm -f /etc/sudoers.d/travis && find / -perm -4000 -exec chmod a-s {} \; 2>/dev/null"'
+        WRITE_SUDO = <<-EOC
+cat <<-'EOF' > _sudo
+if [[ -f \$HOME/.sudo-run ]]; then
+  exit 0
+fi
+
+echo -e "\\\\033[33;1mThis job is running on container-based infrastructure, which does not allow use of 'sudo', setuid and setguid executables.\\\\033[0m
+\\\\033[33;1mIf you require sudo, add 'sudo: required' to your .travis.yml\\\\033[0m
+"
+
+touch \$HOME/.sudo-run
+
+EOF
+        EOC
+        DISABLE_SUID = 'sudo -n sh -c "find / -perm -4000 -a ! -name sudo -exec chmod a-s {} \; 2>/dev/null"'
+        CLEANUP = 'sudo -n sh -c "chmod 4755 _sudo; chown root:root _sudo; mv _sudo `which sudo`; find / -perm -4000 -a ! -name sudo -exec chmod a-s {} \; 2>/dev/null && sed -e \'s/^%.*//\' -i.bak /etc/sudoers && rm -f /etc/sudoers.d/travis"'
 
         def apply
-          sh.echo MSG1, ansi: :yellow
-          sh.echo MSG2, ansi: :yellow
-          sh.echo MSG3, ansi: :yellow
-          sh.cmd CMD
+          sh.raw WRITE_SUDO
+          sh.cmd CLEANUP
         end
 
         def apply?

--- a/lib/travis/build/appliances/disable_sudo.rb
+++ b/lib/travis/build/appliances/disable_sudo.rb
@@ -18,8 +18,7 @@ touch \$HOME/.sudo-run
 
 EOF
         EOC
-        DISABLE_SUID = 'sudo -n sh -c "find / \\( -perm -4000 -o -perm -2000 \\) -a ! -name sudo -exec chmod a-s {} \; 2>/dev/null"'
-        CLEANUP = 'sudo -n sh -c "chmod 4755 _sudo; chown root:root _sudo; mv _sudo `which sudo`; find / -perm -4000 -a ! -name sudo -exec chmod a-s {} \; 2>/dev/null && sed -e \'s/^%.*//\' -i.bak /etc/sudoers && rm -f /etc/sudoers.d/travis"'
+        CLEANUP = 'sudo -n sh -c "chmod 4755 _sudo; chown root:root _sudo; mv _sudo `which sudo`; find / \\( -perm -4000 -o -perm -2000 \\) -a ! -name sudo -exec chmod a-s {} \; 2>/dev/null && sed -e \'s/^%.*//\' -i.bak /etc/sudoers && rm -f /etc/sudoers.d/travis"'
 
         def apply
           sh.raw WRITE_SUDO

--- a/spec/build/script/shared/appliances/disable_sudo.rb
+++ b/spec/build/script/shared/appliances/disable_sudo.rb
@@ -1,13 +1,13 @@
 shared_examples_for 'paranoid mode on/off' do
-  let(:remove_sudo) { %(sudo -n sh -c "sed -e 's/^%.*//' -i.bak /etc/sudoers && rm -f /etc/sudoers.d/travis && find / -perm -4000 -exec chmod a-s {} \\; 2>/dev/null") }
+  let(:remove_suid) { %r(find / -perm -4000 -a ! -name sudo -exec chmod a-s \{\} \\;) }
 
   it 'does not remove access to sudo by default' do
-    should_not include_sexp [:cmd, remove_sudo]
+    should_not include_sexp [:cmd, remove_suid]
   end
 
   it 'removes access to sudo if enabled in the config' do
     data[:paranoid] = true
-    should include_sexp [:cmd, remove_sudo]
+    should include_sexp [:cmd, remove_suid]
     store_example 'disable sudo' if data[:config][:language] == :ruby
   end
 end

--- a/spec/build/script/shared/appliances/disable_sudo.rb
+++ b/spec/build/script/shared/appliances/disable_sudo.rb
@@ -1,5 +1,5 @@
 shared_examples_for 'paranoid mode on/off' do
-  let(:remove_suid) { %r(find / -perm -4000 -a ! -name sudo -exec chmod a-s \{\} \\;) }
+  let(:remove_suid) { %r(find / \\\( -perm -4000 -o -perm -2000 \\\) -a ! -name sudo -exec chmod a-s \{\} \\;) }
 
   it 'does not remove access to sudo by default' do
     should_not include_sexp [:cmd, remove_suid]


### PR DESCRIPTION
This PR replaces `/usr/bin/sudo` with a short bash script that displays a warning and quits. This reduces the noise when the user opts in with `sudo: false` **and** knows that `sudo` is unavailable.