### PR TITLE
R on OS X: use unsigned R image instead of signed one

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -109,9 +109,9 @@ module Travis
                 # output.
                 sh.cmd 'brew update >/dev/null', retry: true
 
-                # R-devel builds available at research.att.com
+                # (unsigned) R-devel builds available at research.att.com
                 if r_version == 'devel'
-                  r_url = "https://r.research.att.com/mavericks/R-devel/R-devel-mavericks-signed.pkg"
+                  r_url = "https://r.research.att.com/mavericks/R-devel/R-devel-mavericks.pkg"
 
                 # The latest release is the only one available in /bin/macosx
                 elsif r_version == r_latest

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -71,7 +71,7 @@ describe Travis::Build::Script::R, :sexp do
   it 'downloads and installs R devel on OS X' do
     data[:config][:os] = 'osx'
     data[:config][:r] = 'devel'
-    should include_sexp [:cmd, %r{^curl.*r\.research\.att\.com/mavericks/R-devel/R-devel-mavericks-signed\.pkg},
+    should include_sexp [:cmd, %r{^curl.*r\.research\.att\.com/mavericks/R-devel/R-devel-mavericks\.pkg},
                          assert: true, echo: true, retry: true, timing: true]
   end
   it 'downloads and installs gfortran libraries on OS X' do


### PR DESCRIPTION
this should solve https://github.com/travis-ci/travis-ci/issues/7370 by downloading the unsigned image instead of the signed one (which disappeared due to problems with the build process).

/cc @craigcitro @jimhester @s-u @rubak