### PR TITLE
Add newline after host file to fix log fold

### DIFF
--- a/lib/travis/build/addons/hosts.rb
+++ b/lib/travis/build/addons/hosts.rb
@@ -13,6 +13,7 @@ module Travis
           sh.fold 'hosts.before' do
             sh.echo ""
             sh.cmd "cat #{HOSTS_FILE}"
+            sh.echo ""
           end
           sh.fold 'hosts' do
             sh.cmd "sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 #{hosts}/' #{HOSTS_FILE} > #{TEMP_HOSTS_FILE}"
@@ -21,6 +22,7 @@ module Travis
           sh.fold 'hosts.after' do
             sh.echo ""
             sh.cmd "cat #{HOSTS_FILE}"
+            sh.echo ""
           end
         end
 


### PR DESCRIPTION
This PR adds a newline after each `cat #{HOSTS_FILE}`.

While playing with `addons: hosts`, I noticed that the hostname that I was adding (`testingdb`) wasn't being shown in the UI log:

![image](https://cloud.githubusercontent.com/assets/1730320/24306834/450e4ab0-10c2-11e7-90f4-23d7cbc6591a.png)

Also, the `127.0.0.1 localhost` line was missing there.

However, while looking at the raw log, I can see that this line does definitely exist in `etc/hosts`:

```
[0Ktravis_fold:start:hosts.before
[0K
::1	localhost ip6-localhost ip6-loopback
fe00::0	ip6-localnet
ff00::0	ip6-mcastprefix
ff02::1	ip6-allnodes
ff02::2	ip6-allrouters
172.17.0.9	testing-docker-c391426c-e688-4eed-a828-d68dac8c85b7
127.0.0.1 localhost 127.0.0.1	localhost travis_fold:end:hosts.before
[0Ktravis_fold:start:hosts
[0Ktravis_fold:end:hosts
[0Ktravis_fold:start:hosts.after
[0K
::1	localhost ip6-localhost ip6-loopback
fe00::0	ip6-localnet
ff00::0	ip6-mcastprefix
ff02::1	ip6-allnodes
ff02::2	ip6-allrouters
172.17.0.9	testing-docker-c391426c-e688-4eed-a828-d68dac8c85b7
127.0.0.1 localhost 127.0.0.1	localhost  testingdbtravis_fold:end:hosts.after
```

We're not taking into account that the `etc/hosts` file may not have a line end and therefore the `travis_fold:end:hosts.after` is being injected right after the hosts information. This PR always introduces an extra newline after `cat`ing the hosts file.

