### PR TITLE
Use `#run_stage` on deployment section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,15 @@ matrix:
 script:
   - bundle exec rake
   - e=0; for f in examples/*.sh.txt; do echo "checking bash syntax $f"; bash -n $f || let e=$e+1; done; test $e -eq 0
+  - |
+    e=0
+    mkdir -p $HOME/.travis
+    for f in examples/*-integration-*.sh.txt; do
+      cat > $HOME/.travis/job_stages < /dev/null
+      sed -i '/^source $HOME\/\.travis\/job_stages/,$d' $f
+      bash --norc -c "source $f && source $HOME/.travis/job_stages || exit 1" || let e=$e+1
+    done
+    test $e -eq 0
 
 after_success: bundle exec codeclimate-test-reporter
 

--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -123,10 +123,10 @@ module Travis
 
             def run
               sh.with_errexit_off do
-                script.stages.define_stage(:custom, :before_deploy)
+                script.stages.run_stage(:custom, :before_deploy)
                 sh.fold('dpl.0') { install }
                 cmd(run_command, echo: false, assert: false, timing: true)
-                script.stages.define_stage(:custom, :after_deploy)
+                script.stages.run_stage(:custom, :after_deploy)
               end
             end
 

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -97,14 +97,18 @@ module Travis
       end
 
       def define_stage(type, name)
-        sh.raw "cat <<'EOFUNC' >>$HOME/.travis/job_stages"
+        sh.raw "cat <<'EOFUNC_#{name.upcase}' >>$HOME/.travis/job_stages"
         sh.raw "function travis_run_#{name}() {"
-        type = :builtin if fallback?(type, name)
-        stage = self.class.const_get(type.to_s.camelize).new(script, name)
-        commands = stage.run
+        commands = run_stage(type, name)
         close = (commands.nil? || commands.empty?) ? ":\n}" : "}"
         sh.raw close
-        sh.raw "EOFUNC"
+        sh.raw "\nEOFUNC_#{name.upcase}"
+      end
+
+      def run_stage(type, name)
+        type = :builtin if fallback?(type, name)
+        stage = self.class.const_get(type.to_s.camelize).new(script, name)
+        stage.run
       end
 
       def debug_build?

--- a/spec/build/addons/deploy_spec.rb
+++ b/spec/build/addons/deploy_spec.rb
@@ -22,6 +22,12 @@ describe Travis::Build::Addons::Deploy, :sexp do
     let(:cmds) { ['ruby -S gem install dpl', 'ruby -S dpl'] }
   end
 
+  context "when after_success is also present" do
+    let(:scripts) { { after_success: ["echo hello"], before_deploy: ['./before_deploy_1.sh', './before_deploy_2.sh'], after_deploy: ['./after_deploy_1.sh', './after_deploy_2.sh'] } }
+
+    it { store_example "after_success_and_deploy" }
+  end
+
   describe 'deploys if conditions apply' do
     let(:config) { { provider: 'heroku', password: 'foo', email: 'user@host' } }
     let(:sexp)   { sexp_find(subject, [:if, '($TRAVIS_BRANCH = master)']) }

--- a/spec/build/addons/deploy_spec.rb
+++ b/spec/build/addons/deploy_spec.rb
@@ -25,7 +25,7 @@ describe Travis::Build::Addons::Deploy, :sexp do
   context "when after_success is also present" do
     let(:scripts) { { after_success: ["echo hello"], before_deploy: ['./before_deploy_1.sh', './before_deploy_2.sh'], after_deploy: ['./after_deploy_1.sh', './after_deploy_2.sh'] } }
 
-    it { store_example "after_success_and_deploy" }
+    it { store_example "integration-after_success_and_deploy" }
   end
 
   describe 'deploys if conditions apply' do


### PR DESCRIPTION
This is a followup to #987 and #1006.

This avoids nesting here-docs in the deployment portion in the resulting
bash script.

Previously, these deployment portion was called from the `after_success`
section, which meant that the here-doc end markers in the deployment
portions had leading white spaces, invalidating the otherwise well-formed
marker.

This manifested in errors such as:

```
/home/travis/.travis/job_stages: line 670: warning: here-document at line 628 delimited by end-of-file (wanted `EOFUNC')
/home/travis/.travis/job_stages: line 671: syntax error: unexpected end of file
```

The affected function, and the functions that follow are therefore undefined:

```
/home/travis/build.sh: line 754: travis_run_after_success: command not found
/home/travis/build.sh: line 755: travis_run_after_failure: command not found
/home/travis/build.sh: line 756: travis_run_after_script: command not found
/home/travis/build.sh: line 757: travis_run_finish: command not found
```

This also means that `before_deploy` and `after_deploy` are not defined as Bash functions.