### PR TITLE
Skip customizable stage if `skip` or `ignore`

### DIFF
--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -74,15 +74,15 @@ module Travis
       def run
         define_header_stage
 
-        STAGES.delete_if { |st| skip?(st) }
-
         STAGES.each do |stage|
-          define_stage(stage.type, stage.name)
+          define_stage(stage.type, stage.name) unless skip?(stage)
         end
 
         sh.raw "source $HOME/.travis/job_stages"
 
         STAGES.each do |stage|
+          next if skip?(stage)
+
           case stage.run_in_debug
           when :always
             sh.raw "travis_run_#{stage.name}"

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -58,6 +58,11 @@ module Travis
         finish:         { assert: true,  echo: true,  timing: true  },
       }
 
+      SKIP_KEYWORDS = %w(
+        skip
+        ignore
+      )
+
       attr_reader :script, :sh, :config
 
       def initialize(script, sh, config)
@@ -68,6 +73,8 @@ module Travis
 
       def run
         define_header_stage
+
+        STAGES.delete_if { |st| skip?(st) }
 
         STAGES.each do |stage|
           define_stage(stage.type, stage.name)
@@ -113,6 +120,10 @@ module Travis
 
       def debug_build?
         script.debug_build_via_api?
+      end
+
+      def skip?(stage)
+        stage.type == :custom && SKIP_KEYWORDS.any? { |kw| config[stage.name] == kw }
       end
     end
   end

--- a/spec/build/script_spec.rb
+++ b/spec/build/script_spec.rb
@@ -62,7 +62,7 @@ describe Travis::Build::Script, :sexp do
   end
 
   context 'when before_install phase is `["skip"]`' do
-    it 'does executes `travis_run_before_install` function' do
+    it 'executes `travis_run_before_install` function' do
       payload[:config][:before_install] = ['skip']
 
       should include_sexp [:raw, 'travis_run_install']

--- a/spec/build/script_spec.rb
+++ b/spec/build/script_spec.rb
@@ -53,6 +53,22 @@ describe Travis::Build::Script, :sexp do
     end
   end
 
+  context 'when install phase is `"skip"`' do
+    it 'does not execute `travis_run_install` function' do
+      payload[:config][:install] = 'skip'
+
+      should_not include_sexp [:raw, 'travis_run_install']
+    end
+  end
+
+  context 'when before_install phase is `["skip"]`' do
+    it 'does executes `travis_run_before_install` function' do
+      payload[:config][:before_install] = ['skip']
+
+      should include_sexp [:raw, 'travis_run_install']
+    end
+  end
+
   context 'when running a debug build' do
     let(:payload) { payload_for(:push_debug, :ruby, config: { cache: ['apt', 'bundler'] }).merge(config) }
     it_behaves_like 'a debug script'


### PR DESCRIPTION
This PR adds special tokens `skip` and `ignore`, which instructs the job to completely skip the customizable stage when they are used as the single token; e.g.,

```yaml
before_install: skip
```

Any other configuration (such as being in a sequence) is simply passed through:

```yaml
script:
  - skip # will execute the command `skip` (which may not succeed)
```