### PR TITLE
Update for R 3.3.3

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -506,12 +506,13 @@ module Travis
 
         def normalized_r_version(v=config[:r].to_s)
           case v
-          when 'release' then '3.3.2'
+          when 'release' then '3.3.3'
           when 'oldrel' then '3.2.5'
           when '3.0' then '3.0.3'
           when '3.1' then '3.1.3'
           when '3.2' then '3.2.5'
           when '3.3' then '3.3.2'
+          when '3.3' then '3.3.3'
           when 'bioc-devel'
             config[:bioc_required] = true
             config[:bioc_use_devel] = true

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -25,7 +25,7 @@ describe Travis::Build::Script::R, :sexp do
     data[:config][:r] = 'bioc-release'
     should include_sexp [:cmd, %r{source\(\"https://bioconductor.org/biocLite.R\"\)},
                          assert: true, echo: true, timing: true, retry: true]
-    should include_sexp [:export, ['TRAVIS_R_VERSION', '3.3.2']]
+    should include_sexp [:export, ['TRAVIS_R_VERSION', '3.3.3']]
   end
 
   it 'r_packages works with a single package set' do
@@ -46,7 +46,7 @@ describe Travis::Build::Script::R, :sexp do
   end
 
   it 'downloads and installs latest R' do
-    should include_sexp [:cmd, %r{^curl.*https://s3\.amazonaws\.com/rstudio-travis/R-3\.3\.2-\$\(lsb_release -cs\)\.xz},
+    should include_sexp [:cmd, %r{^curl.*https://s3\.amazonaws\.com/rstudio-travis/R-3\.3\.3-\$\(lsb_release -cs\)\.xz},
                          assert: true, echo: true, retry: true, timing: true]
   end
 
@@ -197,7 +197,7 @@ describe Travis::Build::Script::R, :sexp do
     }
     it {
       data[:config][:r] = 'release'
-      should eq("cache-#{CACHE_SLUG_EXTRAS}--R-3.3.2")
+      should eq("cache-#{CACHE_SLUG_EXTRAS}--R-3.3.3")
     }
     it {
       data[:config][:r] = 'oldrel'


### PR DESCRIPTION
The builds for R 3.3.3 now exists, this updates the current versions to point to them.

Fixes travis-ci/travis-ci#7500