### PR TITLE
Start debug session as a login shell

### DIFF
--- a/lib/travis/build/appliances/debug_tools/templates/travis_debug.sh
+++ b/lib/travis/build/appliances/debug_tools/templates/travis_debug.sh
@@ -19,7 +19,7 @@ while [[ $# > 0 ]]; do
   esac
 done
 
-$TMATE new-session -d '/bin/bash'
+$TMATE new-session -d '/bin/bash -l'
 $TMATE wait tmate-ready
 
 echo -e "${ANSI_YELLOW}Use the following SSH command to access the interactive debugging environment:${ANSI_RESET}"


### PR DESCRIPTION
This forces the process to read `/etc/profile` (and `/etc/profile.d/*`),
so that many things that the users expect (such as `nvm` and proper
`$JAVA_HOME`) are available.

This resolves https://github.com/travis-ci/travis-ci/issues/7357.