### PR TITLE
[C#] Switch to http for apt-mo.trafficmanager.net to fix .NET Core build

### DIFF
--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -88,10 +88,10 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
             when 'linux'
               sh.cmd 'sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 417A0893', assert: true
               sh.if '$(lsb_release -cs) = trusty' do
-                sh.cmd "sudo sh -c \"echo 'deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main' > /etc/apt/sources.list.d/dotnetdev.list\"", assert: true
+                sh.cmd "sudo sh -c \"echo 'deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main' > /etc/apt/sources.list.d/dotnetdev.list\"", assert: true
               end
               sh.elif '$(lsb_release -cs) = xenial' do
-                sh.cmd "sudo sh -c \"echo 'deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ xenial main' > /etc/apt/sources.list.d/dotnetdev.list\"", assert: true
+                sh.cmd "sudo sh -c \"echo 'deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet-release/ xenial main' > /etc/apt/sources.list.d/dotnetdev.list\"", assert: true
               end
               sh.else do
                 sh.failure "The version of this operating system is not supported by .NET Core. View valid versions at https://docs.travis-ci.com/user/languages/csharp/"

--- a/spec/build/script/csharp_spec.rb
+++ b/spec/build/script/csharp_spec.rb
@@ -23,7 +23,7 @@ describe Travis::Build::Script::Csharp, :sexp do
     it 'sets up package repository for dotnet' do
       data[:config][:dotnet] = '1.0.0-preview2-003121'
       should include_sexp [:cmd, 'sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 417A0893', assert: true]
-      should include_sexp [:cmd, "sudo sh -c \"echo 'deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main' > /etc/apt/sources.list.d/dotnetdev.list\"", assert: true]
+      should include_sexp [:cmd, "sudo sh -c \"echo 'deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main' > /etc/apt/sources.list.d/dotnetdev.list\"", assert: true]
       should include_sexp [:cmd, 'sudo apt-get update -qq', timing: true, assert: true]
     end
 


### PR DESCRIPTION
Fixes https://github.com/travis-ci/travis-ci/issues/7565

Upstream issue: https://github.com/dotnet/core-setup/issues/1947