### PR TITLE
git checkout TAG_NAME if given

### DIFF
--- a/lib/travis/build/data.rb
+++ b/lib/travis/build/data.rb
@@ -137,6 +137,10 @@ module Travis
         job[:branch] || ''
       end
 
+      def tag
+        job[:tag]
+      end
+
       def ref
         job[:ref]
       end

--- a/lib/travis/build/git/clone.rb
+++ b/lib/travis/build/git/clone.rb
@@ -57,7 +57,7 @@ module Travis
 
           def clone_args
             args = "--depth=#{depth}"
-            args << " --branch=#{branch}" unless data.ref || data.tag
+            args << " --branch=#{tag || branch}" unless data.ref
             args << " --quiet" if quiet?
             args
           end
@@ -67,7 +67,11 @@ module Travis
           end
 
           def branch
-            data.branch.shellescape
+            data.branch.shellescape if data.branch
+          end
+
+          def tag
+            data.tag.shellescape if data.tag
           end
 
           def quiet?

--- a/lib/travis/build/git/clone.rb
+++ b/lib/travis/build/git/clone.rb
@@ -46,12 +46,18 @@ module Travis
           end
 
           def checkout
-            sh.cmd "git checkout -qf #{data.pull_request ? 'FETCH_HEAD' : data.commit}", timing: false
+            sh.cmd "git checkout -qf #{checkout_ref}", timing: false
+          end
+
+          def checkout_ref
+            return 'FETCH_HEAD' if data.pull_request
+            return data.tag     if data.tag
+            data.commit
           end
 
           def clone_args
             args = "--depth=#{depth}"
-            args << " --branch=#{branch}" unless data.ref
+            args << " --branch=#{branch}" unless data.ref || data.tag
             args << " --quiet" if quiet?
             args
           end

--- a/spec/build/git/clone_spec.rb
+++ b/spec/build/git/clone_spec.rb
@@ -131,6 +131,7 @@ describe Travis::Build::Git::Clone, :sexp do
   let(:cd)            { [:cd,  'travis-ci/travis-ci', echo: true] }
   let(:fetch_ref)     { [:cmd, %r(git fetch origin \+[\w/]+:), assert: true, echo: true, retry: true, timing: true] }
   let(:checkout_push) { [:cmd, 'git checkout -qf 313f61b', assert: true, echo: true] }
+  let(:checkout_tag)  { [:cmd, 'git checkout -qf v1.0.0', assert: true, echo: true] }
   let(:checkout_pull) { [:cmd, 'git checkout -qf FETCH_HEAD', assert: true, echo: true] }
 
   it { should include_sexp cd }
@@ -140,8 +141,14 @@ describe Travis::Build::Git::Clone, :sexp do
     it { should include_sexp fetch_ref }
   end
 
-  describe 'with no ref given' do
+  describe 'with a tag given' do
+    before { payload[:job][:tag] = 'v1.0.0' }
+    it { should include_sexp checkout_tag }
+  end
+
+  describe 'with no ref or tag given' do
     it { should_not include_sexp fetch_ref }
+    it { should_not include_sexp checkout_tag }
   end
 
   describe 'checks out the given commit for a push request' do


### PR DESCRIPTION
This is for: https://github.com/travis-pro/post-its/issues/330

We currently try to fetch the branch even if there's no branch defined:

![image](https://cloud.githubusercontent.com/assets/2208/24797248/ac42c1d8-1b90-11e7-974b-fe1170516e02.png)

I'm not sure if we should `git fetch` some other ref in order for the `depth` to include the given tag.