### PR TITLE
Don't fail build if curling of casher fails.

### DIFF
--- a/lib/travis/build/script/shared/directory_cache/base.rb
+++ b/lib/travis/build/script/shared/directory_cache/base.rb
@@ -279,8 +279,10 @@ module Travis
               flags = "-sf #{debug_flags}"
               cmd_opts = {retry: true, assert: false, echo: 'Installing caching utilities'}
               if casher_branch == 'production'
-                sh.cmd curl_cmd(flags, location, "https://#{app_host}/files/#{name}".untaint), cmd_opts
+                static_file_location = "https://#{app_host}/files/#{name}".untaint
+                sh.cmd curl_cmd(flags, location, static_file_location), cmd_opts
                 sh.if "$? -ne 0" do
+                  cmd_opts[:echo] = "Installing caching utilities from the Travis CI server (#{static_file_location}) failed, failing over to using GitHub (#{remote_location})"}
                   sh.cmd curl_cmd(flags, location, remote_location), cmd_opts
                 end
               else

--- a/lib/travis/build/script/shared/directory_cache/base.rb
+++ b/lib/travis/build/script/shared/directory_cache/base.rb
@@ -277,7 +277,7 @@ module Travis
 
             def update_static_file(name, location, remote_location, assert = false)
               flags = "-sf #{debug_flags}"
-              cmd_opts = {retry: true, echo: 'Installing caching utilities'}
+              cmd_opts = {retry: true, assert: false, echo: 'Installing caching utilities'}
               if casher_branch == 'production'
                 sh.cmd curl_cmd(flags, location, "https://#{app_host}/files/#{name}".untaint), cmd_opts
                 sh.if "$? -ne 0" do

--- a/lib/travis/build/script/shared/directory_cache/base.rb
+++ b/lib/travis/build/script/shared/directory_cache/base.rb
@@ -282,7 +282,7 @@ module Travis
                 static_file_location = "https://#{app_host}/files/#{name}".untaint
                 sh.cmd curl_cmd(flags, location, static_file_location), cmd_opts
                 sh.if "$? -ne 0" do
-                  cmd_opts[:echo] = "Installing caching utilities from the Travis CI server (#{static_file_location}) failed, failing over to using GitHub (#{remote_location})"}
+                  cmd_opts[:echo] = "Installing caching utilities from the Travis CI server (#{static_file_location}) failed, failing over to using GitHub (#{remote_location})"
                   sh.cmd curl_cmd(flags, location, remote_location), cmd_opts
                 end
               else

--- a/spec/build/script/directory_cache/gcs_spec.rb
+++ b/spec/build/script/directory_cache/gcs_spec.rb
@@ -40,6 +40,8 @@ describe Travis::Build::Script::DirectoryCache::Gcs, :sexp do
   before do
     # Assume time is at Epoch, which is expected by the V2 signature's Expires header
     Time.stubs(:now).returns 0
+    # Set an app_host so casher messages are right
+    Travis::Build.config.app_host = 'build.travis-ci.org'
   end
 
   describe 'validate' do
@@ -63,7 +65,7 @@ describe Travis::Build::Script::DirectoryCache::Gcs, :sexp do
 
     describe 'uses casher production in default mode' do
       let(:branch) { 'production' }
-      let(:cmd) { [:cmd,  "curl -sf  -o $CASHER_DIR/bin/casher #{url}",retry: true, echo: "Installing caching utilities from the Travis CI server (https:///files/casher) failed, failing over to using GitHub (#{url})"] }
+      let(:cmd) { [:cmd,  "curl -sf  -o $CASHER_DIR/bin/casher #{url}",retry: true, echo: "Installing caching utilities from the Travis CI server (https://#{Travis::Build.config.app_host}/files/casher) failed, failing over to using GitHub (#{url})"] }
       it { should include_sexp [:export, ['CASHER_DIR', '$HOME/.casher'], echo: true] }
       it { should include_sexp [:mkdir, '$CASHER_DIR/bin', recursive: true] }
       it { should include_sexp cmd }

--- a/spec/build/script/directory_cache/gcs_spec.rb
+++ b/spec/build/script/directory_cache/gcs_spec.rb
@@ -63,6 +63,7 @@ describe Travis::Build::Script::DirectoryCache::Gcs, :sexp do
 
     describe 'uses casher production in default mode' do
       let(:branch) { 'production' }
+      let(:cmd) { [:cmd,  "curl -sf  -o $CASHER_DIR/bin/casher #{url}",retry: true, echo: "Installing caching utilities from the Travis CI server (https:///files/casher) failed, failing over to using GitHub (#{url})"] }
       it { should include_sexp [:export, ['CASHER_DIR', '$HOME/.casher'], echo: true] }
       it { should include_sexp [:mkdir, '$CASHER_DIR/bin', recursive: true] }
       it { should include_sexp cmd }

--- a/spec/build/script/directory_cache/s3_spec.rb
+++ b/spec/build/script/directory_cache/s3_spec.rb
@@ -34,6 +34,11 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
   let(:cache)         { described_class.new(sh, Travis::Build::Data.new(data), 'ex a/mple', Time.at(10)) }
   let(:subject)       { sh.to_sexp }
 
+  before do
+    # Set an app_host so casher messages are right
+    Travis::Build.config.app_host = 'build.travis-ci.org'
+  end
+
   describe 'validate' do
     before { cache.valid? }
 
@@ -48,14 +53,15 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
   end
 
   describe 'install' do
-    before { cache.install }
-
-    let(:url) { "https://raw.githubusercontent.com/travis-ci/casher/#{branch}/bin/casher" }
-    let(:cmd) { [:cmd,  "curl -sf  -o $CASHER_DIR/bin/casher #{url}", retry: true, echo: 'Installing caching utilities'] }
+    before do
+      cache.install
+      let(:url) { "https://raw.githubusercontent.com/travis-ci/casher/#{branch}/bin/casher" }
+      let(:cmd) { [:cmd,  "curl -sf  -o $CASHER_DIR/bin/casher #{url}", retry: true, echo: 'Installing caching utilities'] }
+    end
 
     describe 'uses casher production in default mode' do
       let(:branch) { 'production' }
-      let(:cmd) { [:cmd,  "curl -sf  -o $CASHER_DIR/bin/casher #{url}",retry: true, echo: "Installing caching utilities from the Travis CI server (https:///files/casher) failed, failing over to using GitHub (#{url})"] }
+      let(:cmd) { [:cmd,  "curl -sf  -o $CASHER_DIR/bin/casher #{url}",retry: true, echo: "Installing caching utilities from the Travis CI server (https://#{Travis::Build.config.app_host}/files/casher) failed, failing over to using GitHub (#{url})"] }
       it { should include_sexp [:export, ['CASHER_DIR', '$HOME/.casher'], echo: true] }
       it { should include_sexp [:mkdir, '$CASHER_DIR/bin', recursive: true] }
       it { should include_sexp cmd }

--- a/spec/build/script/directory_cache/s3_spec.rb
+++ b/spec/build/script/directory_cache/s3_spec.rb
@@ -51,10 +51,11 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
     before { cache.install }
 
     let(:url) { "https://raw.githubusercontent.com/travis-ci/casher/#{branch}/bin/casher" }
-    let(:cmd) { [:cmd,  "curl -sf  -o $CASHER_DIR/bin/casher #{url}",retry: true, echo: 'Installing caching utilities'] }
+    let(:cmd) { [:cmd,  "curl -sf  -o $CASHER_DIR/bin/casher #{url}", retry: true, echo: 'Installing caching utilities'] }
 
     describe 'uses casher production in default mode' do
       let(:branch) { 'production' }
+      let(:cmd) { [:cmd,  "curl -sf  -o $CASHER_DIR/bin/casher #{url}",retry: true, echo: "Installing caching utilities from the Travis CI server (https:///files/casher) failed, failing over to using GitHub (#{url})"] }
       it { should include_sexp [:export, ['CASHER_DIR', '$HOME/.casher'], echo: true] }
       it { should include_sexp [:mkdir, '$CASHER_DIR/bin', recursive: true] }
       it { should include_sexp cmd }

--- a/spec/build/script/directory_cache/s3_spec.rb
+++ b/spec/build/script/directory_cache/s3_spec.rb
@@ -53,11 +53,10 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
   end
 
   describe 'install' do
-    before do
-      cache.install
-      let(:url) { "https://raw.githubusercontent.com/travis-ci/casher/#{branch}/bin/casher" }
-      let(:cmd) { [:cmd,  "curl -sf  -o $CASHER_DIR/bin/casher #{url}", retry: true, echo: 'Installing caching utilities'] }
-    end
+    before { cache.install }
+
+    let(:url) { "https://raw.githubusercontent.com/travis-ci/casher/#{branch}/bin/casher" }
+    let(:cmd) { [:cmd,  "curl -sf  -o $CASHER_DIR/bin/casher #{url}", retry: true, echo: 'Installing caching utilities'] }
 
     describe 'uses casher production in default mode' do
       let(:branch) { 'production' }

--- a/spec/build/script/directory_cache/s3_spec.rb
+++ b/spec/build/script/directory_cache/s3_spec.rb
@@ -48,10 +48,13 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
   end
 
   describe 'install' do
-    before { cache.install }
+    before do
+      cache.install
+      let(:url) { "https://raw.githubusercontent.com/travis-ci/casher/#{branch}/bin/casher" }
+      let(:cmd) { [:cmd,  "curl -sf  -o $CASHER_DIR/bin/casher #{url}", retry: true, echo: 'Installing caching utilities'] }
+    end
 
-    let(:url) { "https://raw.githubusercontent.com/travis-ci/casher/#{branch}/bin/casher" }
-    let(:cmd) { [:cmd,  "curl -sf  -o $CASHER_DIR/bin/casher #{url}", retry: true, echo: 'Installing caching utilities'] }
+
 
     describe 'uses casher production in default mode' do
       let(:branch) { 'production' }

--- a/spec/build/script/directory_cache/s3_spec.rb
+++ b/spec/build/script/directory_cache/s3_spec.rb
@@ -48,13 +48,10 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
   end
 
   describe 'install' do
-    before do
-      cache.install
-      let(:url) { "https://raw.githubusercontent.com/travis-ci/casher/#{branch}/bin/casher" }
-      let(:cmd) { [:cmd,  "curl -sf  -o $CASHER_DIR/bin/casher #{url}", retry: true, echo: 'Installing caching utilities'] }
-    end
+    before { cache.install }
 
-
+    let(:url) { "https://raw.githubusercontent.com/travis-ci/casher/#{branch}/bin/casher" }
+    let(:cmd) { [:cmd,  "curl -sf  -o $CASHER_DIR/bin/casher #{url}", retry: true, echo: 'Installing caching utilities'] }
 
     describe 'uses casher production in default mode' do
       let(:branch) { 'production' }


### PR DESCRIPTION
Some config issues in Enterprise showed the issue of if we failed to pull down casher it'd fail the build. We'd prefer to failover to githubusercontent. Or just move on, simply not using caching. 

/cc @BanzaiMan - do I understand this issue correct and this fix? 