### PR TITLE
Display error message when build script is not generated

### DIFF
--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -183,10 +183,18 @@ module Travis
 
           def config_sources
             @config_sources ||= Array(config[:sources]).flatten.compact
+          rescue TypeError => e
+            if e.message =~ /no implicit conversion of Symbol into Integer/
+              raise Travis::Build::AptSourcesConfigError.new
+            end
           end
 
           def config_packages
             @config_packages ||= Array(config[:packages]).flatten.compact
+          rescue TypeError => e
+            if e.message =~ /no implicit conversion of Symbol into Integer/
+              raise Travis::Build::AptPackagesConfigError.new
+            end
           end
 
           def config_dist

--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -37,6 +37,14 @@ module Travis
             @config = config
             @silent = false
             @allow_failure = config.delete(:allow_failure)
+          rescue TypeError => te
+            if te.message =~ /no implicit conversion of Symbol into String/
+              # this probably came from config.delete, because allow_failure was a sequence rather than a map
+              ex = CompilationError.new("`deploy` is a YAML sequence, but a YAML map was expected")
+              ex.doc_path = '/user/customizing-the-build'
+            else
+              raise te
+            end
           end
 
           def deploy

--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -42,8 +42,9 @@ module Travis
 
           rescue TypeError => e
             if e.message =~ /no implicit conversion of Symbol into String/
-              ex = Travis::Build::CompilationError.new("\\`deploy\\` configuration should be a map, or a sequence of maps")
+              ex = Travis::Build::CompilationError.new("The \\`deploy\\` configuration should be a map, or a sequence of maps.")
               ex.doc_path = '/user/deployment/'
+              ex.set_backtrace e.backtrace.dup
               raise ex
             else
               raise e

--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -36,14 +36,17 @@ module Travis
             @data = data
             @config = config
             @silent = false
+
             @allow_failure = config.delete(:allow_failure)
-          rescue TypeError => te
-            if te.message =~ /no implicit conversion of Symbol into String/
-              # this probably came from config.delete, because allow_failure was a sequence rather than a map
-              ex = CompilationError.new("`deploy` is a YAML sequence, but a YAML map was expected")
-              ex.doc_path = '/user/customizing-the-build'
+
+
+          rescue TypeError => e
+            if e.message =~ /no implicit conversion of Symbol into String/
+              ex = Travis::Build::CompilationError.new("\\`deploy\\` configuration should be a map, or a sequence of maps")
+              ex.doc_path = '/user/deployment/'
+              raise ex
             else
-              raise te
+              raise e
             end
           end
 

--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -39,7 +39,6 @@ module Travis
 
             @allow_failure = config.delete(:allow_failure)
 
-
           rescue TypeError => e
             if e.message =~ /no implicit conversion of Symbol into String/
               raise Travis::Build::DeployConfigError.new

--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -42,12 +42,7 @@ module Travis
 
           rescue TypeError => e
             if e.message =~ /no implicit conversion of Symbol into String/
-              ex = Travis::Build::CompilationError.new("The \\`deploy\\` configuration should be a map, or a sequence of maps.")
-              ex.doc_path = '/user/deployment/'
-              ex.set_backtrace e.backtrace.dup
-              raise ex
-            else
-              raise e
+              raise Travis::Build::DeployConfigError.new
             end
           end
 

--- a/lib/travis/build/env/var.rb
+++ b/lib/travis/build/env/var.rb
@@ -10,6 +10,9 @@ module Travis
             vars = line.scan(PATTERN).map { |var| var[0, 2] }
             vars = vars.map { |var| var << { secure: true } } if secure
             vars
+
+          rescue Exception => e
+            raise Travis::Build::EnvVarDefinitionError
           end
 
           def mark_secure(vars)

--- a/lib/travis/build/errors.rb
+++ b/lib/travis/build/errors.rb
@@ -21,5 +21,15 @@ module Travis
         '/user/environment-variables'
       end
     end
+
+    class DeployConfigError < CompilationError
+      def initialize(msg = "The \\`deploy\\` configuration should be a map, or a sequence of maps.")
+        super
+      end
+
+      def doc_path
+        '/user/deployment'
+      end
+    end
   end
 end

--- a/lib/travis/build/errors.rb
+++ b/lib/travis/build/errors.rb
@@ -1,0 +1,7 @@
+module Travis
+  module Build
+    class CompilationError < StandardError
+      attr_accessor :doc_path
+    end
+  end
+end

--- a/lib/travis/build/errors.rb
+++ b/lib/travis/build/errors.rb
@@ -23,7 +23,7 @@ module Travis
     end
 
     class DeployConfigError < CompilationError
-      def initialize(msg = "The \\`deploy\\` configuration should be a map, or a sequence of maps.")
+      def initialize(msg = "The \\`deploy\\` configuration should be a hash (dictionary), or an array of hashes.")
         super
       end
 

--- a/lib/travis/build/errors.rb
+++ b/lib/travis/build/errors.rb
@@ -31,5 +31,25 @@ module Travis
         '/user/deployment'
       end
     end
+
+    class AptSourcesConfigError < CompilationError
+      def initialize(msg = "\\`apt\\` should be a hash with key \\`sources\\` and an array as a value.")
+        super
+      end
+
+      def doc_path
+        '/user/installing-dependencies'
+      end
+    end
+
+    class AptPackagesConfigError < CompilationError
+      def initialize(msg = "\\`apt\\` should be a hash with key \\`packages\\` and an array as a value.")
+        super
+      end
+
+      def doc_path
+        '/user/installing-dependencies'
+      end
+    end
   end
 end

--- a/lib/travis/build/errors.rb
+++ b/lib/travis/build/errors.rb
@@ -2,6 +2,24 @@ module Travis
   module Build
     class CompilationError < StandardError
       attr_accessor :doc_path
+
+      def initialize(msg = '')
+        @msg = msg
+      end
+
+      def to_s
+        @msg
+      end
+    end
+
+    class EnvVarDefinitionError < CompilationError
+      def initialize(msg = "Environment variables definition is incorrect.")
+        super
+      end
+
+      def doc_path
+        '/user/environment-variables'
+      end
     end
   end
 end

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -252,6 +252,7 @@ module Travis
           doc_path = exception.is_a?(Travis::Build::CompilationError) ? exception.doc_path : ''
 
           [
+            "",
             "There was an error in the .travis.yml file from which we could not recover.\n",
             msg,
             "",

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -262,11 +262,13 @@ module Travis
           @sh = Shell::Builder.new
           sh.raw 'echo "Unfortunately, we do not know much about this error."' unless exception.is_a?(Travis::Build::CompilationError)
           error_message_ary(exception).each { |line| sh.raw "echo -e \"\033[31;1m#{line}\033[0m\"" }
+          sh.raw "echo -en \"travis_fold:start:backtrace\r\033[0m\""
           sh.raw "echo -e \"\nException backtrace is shown for troubleshooting purposes:\n\""
           sh.raw "echo #{exception.class}: #{exception.message}" unless exception.is_a?(Travis::Build::CompilationError)
           exception.backtrace.map do |line|
             sh.raw "echo #{line.shellescape}"
           end
+          sh.raw "echo -en \"travis_fold:end:backtrace\r\033[0m\""
           sh.raw "exit 2"
           Shell.generate(sh.to_sexp)
         end

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -75,6 +75,7 @@ module Travis
       rescue Travis::Shell::Generator::TaintedOutput => to
         raise to
       rescue Exception => e
+        Raven.capture_exception(e)
         show_compile_error_msg(e)
       end
 
@@ -262,13 +263,7 @@ module Travis
           @sh = Shell::Builder.new
           sh.raw 'echo "Unfortunately, we do not know much about this error."' unless exception.is_a?(Travis::Build::CompilationError)
           error_message_ary(exception).each { |line| sh.raw "echo -e \"\033[31;1m#{line}\033[0m\"" }
-          sh.raw "echo -en \"travis_fold:start:backtrace\r\033[0m\""
-          sh.raw "echo -e \"\nException backtrace is shown for troubleshooting purposes:\n\""
           sh.raw "echo #{exception.class}: #{exception.message}" unless exception.is_a?(Travis::Build::CompilationError)
-          exception.backtrace.map do |line|
-            sh.raw "echo #{line.shellescape}"
-          end
-          sh.raw "echo -en \"travis_fold:end:backtrace\r\033[0m\""
           sh.raw "exit 2"
           Shell.generate(sh.to_sexp)
         end

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -248,23 +248,32 @@ module Travis
         end
 
         def error_message_ary(exception)
-          msg = exception.message
-          doc_path = exception.is_a?(Travis::Build::CompilationError) ? exception.doc_path : ''
+          if exception.is_a? Travis::Build::CompilationError
+            msg = [
+              exception.message
+            ]
+            doc_path = exception.doc_path
+          else
+            msg = [
+              "Unfortunately, we do not know much about this error.",
+              "",
+              "#{exception.class}: #{exception.message}"
+            ]
+            doc_path = ''
+          end
 
           [
             "",
             "There was an error in the .travis.yml file from which we could not recover.\n",
-            msg,
+            *msg,
             "",
-            "Please review https://docs.travis-ci.com#{doc_path}."
-          ].flatten # this allows msg to be an array
+            "Please review https://docs.travis-ci.com#{doc_path}, or contact us at support@travis-ci.com."
+          ]
         end
 
         def show_compile_error_msg(exception)
           @sh = Shell::Builder.new
-          sh.raw 'echo "Unfortunately, we do not know much about this error."' unless exception.is_a?(Travis::Build::CompilationError)
           error_message_ary(exception).each { |line| sh.raw "echo -e \"\033[31;1m#{line}\033[0m\"" }
-          sh.raw "echo #{exception.class}: #{exception.message}" unless exception.is_a?(Travis::Build::CompilationError)
           sh.raw "exit 2"
           Shell.generate(sh.to_sexp)
         end


### PR DESCRIPTION
When users' `.travis.yml` has problems with the data structure (rather than invalid YAML), `travis-build` just generally throws an exception, and we display a generic error message:

    An error occurred while generating the build script.

(e.g., https://travis-ci.org/gligoran/cordova-set-version/jobs/223634347#L1)

This is not very helpful. Here, we `rescue` the Exception, and give some advice if we can.