### PR TITLE
Do not add dpkg arch i386 on os: power

### DIFF
--- a/lib/travis/build/appliances/enable_i386.rb
+++ b/lib/travis/build/appliances/enable_i386.rb
@@ -5,7 +5,7 @@ module Travis
     module Appliances
       class EnableI386 < Base
         def apply
-          sh.if "$(command -v lsb_release) && $(lsb_release -cs) != 'precise' " do
+          sh.if "$TRAVIS_OS_NAME != power && $(command -v lsb_release) && $(lsb_release -cs) != precise" do
             sh.cmd 'dpkg --add-architecture i386', echo: false, assert: false, sudo: true
           end
         end

--- a/lib/travis/build/script/smalltalk.rb
+++ b/lib/travis/build/script/smalltalk.rb
@@ -119,7 +119,7 @@ module Travis
             sh.fold 'install_packages' do
               sh.echo 'Installing dependencies', ansi: :yellow
 
-              sh.if '$(lsb_release -cs) != precise' do
+              sh.if '$TRAVIS_OS_NAME != power && $(lsb_release -cs) != precise' do
                 sh.cmd 'sudo dpkg --add-architecture i386'
               end
 
@@ -199,7 +199,7 @@ module Travis
               sh.cmd 'sudo ln -f -s /lib/i386-linux-gnu/libpam.so.0 /lib/libpam.so.0'
               sh.cmd 'sudo ln -f -s /usr/lib/i386-lin-gnu/libstdc++.so.6 /usr/lib/i386-linux-gnu/libstdc++.so'
             end
-            sh.if '$(lsb_release -cs) = trusty' do
+            sh.if '$TRAVIS_OS_NAME != power && $(lsb_release -cs) = trusty' do
               sh.cmd 'sudo dpkg --add-architecture i386'
               gemstone_install_linux_dependencies
               sh.cmd 'sudo ln -f -s /usr/lib/i386-lin-gnu/libstdc++.so.6 /usr/lib/i386-linux-gnu/libstdc++.so'


### PR DESCRIPTION
This change is the result of a conversation with a human who is developing support for `os: power` in https://github.com/travis-ci/worker, where adding this arch causes 💥.