### PR TITLE
Add support for unsigned Firefox for add-on development

### DIFF
--- a/lib/travis/build/addons/firefox.rb
+++ b/lib/travis/build/addons/firefox.rb
@@ -38,6 +38,7 @@ module Travis
             end
             sh.cd :back, echo: false, stack: true
           end
+          sh.cmd "firefox --version", echo: true
         end
 
         private

--- a/lib/travis/build/addons/firefox.rb
+++ b/lib/travis/build/addons/firefox.rb
@@ -63,19 +63,19 @@ module Travis
           def export_source_url
             host = 'download.mozilla.org'
 
-            product = case latest
+            case latest
 
             when 'latest'
-              'firefox-latest'
+              product = 'firefox-latest'
             when 'latest-beta'
-              'firefox-beta-latest'
+              product = 'firefox-beta-latest'
             when 'latest-esr'
-              'firefox-esr-latest'
+              product = 'firefox-esr-latest'
             when 'latest-dev'
               # The name 'aurora' is nickname for "developer edition",
               # documented in https://wiki.mozilla.org/Firefox/Channels#Developer_Edition_.28aka_Aurora.29
               # This may change in the future and break builds.
-              'firefox-aurora-latest'
+              product = 'firefox-aurora-latest'
             when 'latest-nightly'
               'firefox-nightly-latest'
             when 'latest-unsigned'
@@ -84,7 +84,7 @@ module Travis
               unsigned_archive_file = "firefox-%s.en-US.%s-add-on-devel.%s"
               source_url = "\"https://#{host}/#{path}/#{unsigned_archive_file}\""
             else
-              "firefox-#{version}"
+              product = "firefox-#{version}"
             end
 
             sh.if "$(uname) = 'Linux'" do

--- a/spec/build/addons/firefox_spec.rb
+++ b/spec/build/addons/firefox_spec.rb
@@ -53,6 +53,16 @@ describe Travis::Build::Addons::Firefox, :sexp do
     it { should include_sexp [:export, ['PATH', "$HOME/firefox-latest-esr/firefox:$PATH"], echo: true] }
   end
 
+  context 'given a valid version "latest-unsigned"' do
+    let(:config) { 'latest-unsigned' }
+    it "exports latest-unsigned source URL" do
+      expect(sexp_find(subject, [:if, "$(uname) = 'Linux'"])).to include_sexp(
+        [:export, ['FIREFOX_SOURCE_URL', "\"https://index.taskcluster.net/v1/task/gecko.v2.mozilla-release.latest.firefox.linux64-add-on-devel/artifacts/public/build/firefox-$(curl -sfL https://index.taskcluster.net/v1/task/gecko.v2.mozilla-release.latest.firefox.linux64-add-on-devel/artifacts/public/build/buildbot_properties.json | jq -r .properties.appVersion).en-US.linux-x86_64-add-on-devel.tar.bz2\""], echo: true]
+      )
+    end
+    it { should include_sexp [:export, ['PATH', "$HOME/firefox-latest-unsigned/firefox:$PATH"], echo: true] }
+  end
+
   context 'given a invalid version string' do
     let(:config) { '20.0; sudo rm -rf /' }
 


### PR DESCRIPTION
Using the information I gathered from Mozilla's release engineering team, we download and install the unsigned binary when we have:

```yaml
addons:
  firefox: latest-unsigned
```

While it is *probably* conceivable that a past version of unsigned binaries may exist, we do not support them for now.

This resolves https://github.com/travis-ci/travis-ci/issues/4064.