### PR TITLE
Export GIT_LFS_SKIP_SMUDGE when `git.lfs_skip_smudge == true`

### DIFF
--- a/lib/travis/build/git.rb
+++ b/lib/travis/build/git.rb
@@ -7,7 +7,13 @@ module Travis
   module Build
     class Git
       DEFAULTS = {
-        git: { depth: 50, submodules: true, strategy: 'clone', quiet: false }
+        git: {
+          depth: 50,
+          submodules: true,
+          strategy: 'clone',
+          quiet: false,
+          lfs_skip_smudge: false
+        }
       }
 
       attr_reader :sh, :data

--- a/lib/travis/build/git/clone.rb
+++ b/lib/travis/build/git/clone.rb
@@ -9,6 +9,7 @@ module Travis
           write_netrc if data.prefer_https? && data.token
 
           sh.fold 'git.checkout' do
+            sh.export 'GIT_LFS_SKIP_SMUDGE', '1' if lfs_skip_smudge?
             clone_or_fetch
             delete_netrc
             sh.cd dir
@@ -65,6 +66,10 @@ module Travis
 
           def quiet?
             config[:git][:quiet]
+          end
+
+          def lfs_skip_smudge?
+            config[:git][:lfs_skip_smudge] == true
           end
 
           def dir

--- a/spec/build/git/clone_spec.rb
+++ b/spec/build/git/clone_spec.rb
@@ -82,7 +82,7 @@ describe Travis::Build::Git::Clone, :sexp do
   end
 
 
-  describe 'when the repository is cloned not yet' do
+  describe 'when the repository is not yet cloned' do
     let(:args) { "--depth=#{depth} --branch=#{branch.shellescape}" }
     let(:cmd)  { "git clone #{args} #{url} #{dir}" }
     subject    { sexp_find(sexp, [:if, "! -d #{dir}/.git"]) }
@@ -97,6 +97,11 @@ describe Travis::Build::Git::Clone, :sexp do
       let(:depth) { 1 }
       before { payload[:config][:git]['depth'] = depth }
       it { should include_sexp clone }
+    end
+
+    describe 'with lfs_skip_smudge true' do
+      before { payload[:config][:git]['lfs_skip_smudge'] = true }
+      it { expect(sexp).to include_sexp [:export, ['GIT_LFS_SKIP_SMUDGE', '1'], echo: true] }
     end
 
     describe 'escapes the branch name' do


### PR DESCRIPTION
in order to skip download of LFS files on initial clone.