### PR TITLE
Use sbt for building JVM builds

### DIFF
--- a/lib/travis/build/script/scala.rb
+++ b/lib/travis/build/script/scala.rb
@@ -10,30 +10,9 @@ module Travis
           jdk:   'default'
         }
 
-        SBT_PATH = '/usr/local/bin/sbt'
-        SBT_SHA  = '4ad1b8a325f75c1a66f3fd100635da5eb28d9c91'
-        SBT_URL  = "https://raw.githubusercontent.com/paulp/sbt-extras/#{SBT_SHA}/sbt"
-
-        def configure
-          super
-          if use_sbt?
-            sh.echo "Updating sbt", ansi: :green
-
-            update_sbt
-          end
-        end
-
         def export
           super
           sh.export 'TRAVIS_SCALA_VERSION', version, echo: false
-        end
-
-        def setup
-          super
-          sh.if use_sbt? do
-            sh.export 'JVM_OPTS', '@/etc/sbt/jvmopts', echo: true
-            sh.export 'SBT_OPTS', '@/etc/sbt/sbtopts', echo: true
-          end
         end
 
         def announce
@@ -41,52 +20,9 @@ module Travis
           sh.echo "Using Scala #{version}"
         end
 
-        def install
-          sh.if not_use_sbt? do
-            super
-          end
-        end
-
-        def script
-          sh.if use_sbt? do
-            sh.cmd "sbt#{sbt_args} ++#{version} test"
-          end
-          sh.else do
-            super
-          end
-        end
-
         def cache_slug
           super << "--scala-" << version
         end
-
-        private
-
-          def version
-            config[:scala].to_s
-          end
-
-          def sbt_args
-            config[:sbt_args] && " #{config[:sbt_args]}"
-          end
-
-          def use_sbt?
-            '-d project || -f build.sbt'
-          end
-
-          def not_use_sbt?
-            '! -d project && ! -f build.sbt'
-          end
-
-          def update_sbt
-            return if app_host.empty?
-
-            sh.cmd "curl -sf -o sbt.tmp https://#{app_host}/files/sbt", echo: false
-            sh.if "$? -ne 0" do
-              sh.cmd "curl -sf -o sbt.tmp #{SBT_URL}", assert: true
-            end
-            sh.raw "sed -e '/addSbt \\(warn\\|info\\)/d' sbt.tmp | sudo tee #{SBT_PATH} > /dev/null && rm -f sbt.tmp"
-          end
       end
     end
   end

--- a/lib/travis/build/script/shared/jvm.rb
+++ b/lib/travis/build/script/shared/jvm.rb
@@ -5,6 +5,7 @@ module Travis
         include Jdk
 
         DEFAULTS = {
+          scala: '2.10.4',
           jdk: 'default'
         }
 
@@ -13,10 +14,28 @@ module Travis
           { directory: '$HOME/.sbt',  glob: "*.lock"}
         ]
 
+        SBT_PATH = '/usr/local/bin/sbt'
+        SBT_SHA  = '4ad1b8a325f75c1a66f3fd100635da5eb28d9c91'
+        SBT_URL  = "https://raw.githubusercontent.com/paulp/sbt-extras/#{SBT_SHA}/sbt"
+
+        def configure
+          super
+          if use_sbt?
+            sh.echo "Updating sbt", ansi: :green
+
+            update_sbt
+          end
+        end
+
         def setup
           super
           CLEANUPS.each do |find_arg|
             sh.raw "find #{find_arg[:directory]} -name #{find_arg[:glob]} -delete 2>/dev/null"
+          end
+
+          sh.if use_sbt? do
+            sh.export 'JVM_OPTS', '@/etc/sbt/jvmopts', echo: true
+            sh.export 'SBT_OPTS', '@/etc/sbt/sbtopts', echo: true
           end
         end
 
@@ -48,9 +67,36 @@ module Travis
           sh.elif '-f pom.xml' do
             sh.cmd 'mvn test -B'
           end
+          sh.elif use_sbt? do
+            sh.cmd "sbt#{sbt_args} ++#{version} test"
+          end
           sh.else do
             sh.cmd 'ant test'
           end
+        end
+
+        private
+
+        def use_sbt?
+          '-d project || -f build.sbt'
+        end
+
+        def sbt_args
+          config[:sbt_args] && " #{config[:sbt_args]}"
+        end
+
+        def version
+          config[:scala].to_s
+        end
+
+        def update_sbt
+          return if app_host.empty?
+
+          sh.cmd "curl -sf -o sbt.tmp https://#{app_host}/files/sbt", echo: false
+          sh.if "$? -ne 0" do
+            sh.cmd "curl -sf -o sbt.tmp #{SBT_URL}", assert: true
+          end
+          sh.raw "sed -e '/addSbt \\(warn\\|info\\)/d' sbt.tmp | sudo tee #{SBT_PATH} > /dev/null && rm -f sbt.tmp"
         end
       end
     end

--- a/lib/travis/build/script/shared/jvm.rb
+++ b/lib/travis/build/script/shared/jvm.rb
@@ -90,11 +90,13 @@ module Travis
         end
 
         def update_sbt
-          return if app_host.empty?
-
-          sh.cmd "curl -sf -o sbt.tmp https://#{app_host}/files/sbt", echo: false
-          sh.if "$? -ne 0" do
+          if app_host.empty?
             sh.cmd "curl -sf -o sbt.tmp #{SBT_URL}", assert: true
+          else
+            sh.cmd "curl -sf -o sbt.tmp https://#{app_host}/files/sbt", echo: false
+            sh.if "$? -ne 0" do
+              sh.cmd "curl -sf -o sbt.tmp #{SBT_URL}", assert: true
+            end
           end
           sh.raw "sed -e '/addSbt \\(warn\\|info\\)/d' sbt.tmp | sudo tee #{SBT_PATH} > /dev/null && rm -f sbt.tmp"
         end

--- a/spec/build/script/scala_spec.rb
+++ b/spec/build/script/scala_spec.rb
@@ -52,9 +52,10 @@ describe Travis::Build::Script::Scala, :sexp do
 
   describe 'script' do
     describe 'if ./project directory or build.sbt file exists' do
-      let(:sexp) { sexp_find(sexp_filter(subject, [:if, '-d project || -f build.sbt'])[1], [:then]) }
+      let(:sexp) { sexp_find(sexp_filter(subject, [:elif, '-d project || -f build.sbt'])[0]) }
 
       it 'runs sbt with default arguments' do
+        # puts sexp_filter(subject, [:elif, '-d project || -f build.sbt']).inspect
         expect(sexp).to include_sexp [:cmd, 'sbt ++2.10.4 test', echo: true, timing: true]
       end
 


### PR DESCRIPTION
The use of `sbt` is detected by the presence of the directory named `project` or the file named `build.sbt`, which is identical to the current Scala logic.

The default Scala version is 2.10.4, but it is not exported for non-Scala builds.