### PR TITLE
Separate Linux and Mac firefox source url vars

### DIFF
--- a/lib/travis/build/addons/firefox.rb
+++ b/lib/travis/build/addons/firefox.rb
@@ -83,18 +83,19 @@ module Travis
               host = 'index.taskcluster.net'
               path = "v1/task/gecko.v2.mozilla-release.latest.firefox.%s-add-on-devel/artifacts/public/build"
               unsigned_archive_file = "firefox-%s.en-US.%s-add-on-devel.%s"
-              source_url = "\"https://#{host}/#{path}/#{unsigned_archive_file}\""
+              source_url_linux = "\"https://#{host}/#{path}/#{unsigned_archive_file}\""
+              source_url_mac   = "\"https://#{host}/#{path}/#{unsigned_archive_file}\""
             else
               product = "firefox-#{version}"
             end
 
             sh.if "$(uname) = 'Linux'" do
-              source_url ||= "'https://#{host}/?product=#{product}&lang=en-US&os=linux64'"
-              sh.export 'FIREFOX_SOURCE_URL', source_url % [ "linux64", "$(curl -sfL https://#{host}/#{path}/buildbot_properties.json | jq -r .properties.appVersion)" % "linux64", "linux-x86_64", "tar.bz2" ]
+              source_url_linux ||= "'https://#{host}/?product=#{product}&lang=en-US&os=linux64'"
+              sh.export 'FIREFOX_SOURCE_URL', source_url_linux % [ "linux64", "$(curl -sfL https://#{host}/#{path}/buildbot_properties.json | jq -r .properties.appVersion)" % "linux64", "linux-x86_64", "tar.bz2" ]
             end
             sh.else do
-              source_url ||= "'https://#{host}/?product=#{product}&lang=en-US&os=osx'"
-              sh.export 'FIREFOX_SOURCE_URL', source_url % ["macosx64", "$(curl -sfL https://#{host}/#{path}/buildbot_properties.json | jq -r .properties.appVersion)" % "macosx64", "mac", "dmg" ]
+              source_url_mac ||= "'https://#{host}/?product=#{product}&lang=en-US&os=osx'"
+              sh.export 'FIREFOX_SOURCE_URL', source_url_mac % ["macosx64", "$(curl -sfL https://#{host}/#{path}/buildbot_properties.json | jq -r .properties.appVersion)" % "macosx64", "mac", "dmg" ]
             end
           end
 

--- a/spec/build/addons/firefox_spec.rb
+++ b/spec/build/addons/firefox_spec.rb
@@ -41,6 +41,11 @@ describe Travis::Build::Addons::Firefox, :sexp do
   context 'given a valid version "latest"' do
     let(:config) { 'latest' }
     it { should include_sexp [:export, ['PATH', "$HOME/firefox-latest/firefox:$PATH"], echo: true] }
+    it "exports correct FIREFOX_SOURCE_URL for the Mac" do
+      expect(sexp_find(subject, [:if, "$(uname) = 'Linux'"], [:else])).to include_sexp(
+        [:export, ['FIREFOX_SOURCE_URL', "\'https://#{host}/?product=firefox-latest&lang=en-US&os=osx'"], echo: true]
+      )
+    end
   end
 
   context 'given a valid version "latest-beta"' do


### PR DESCRIPTION
The assignment for the Mac was ineffective because source_url was
previously defined.
By using separate variables, we correctly set `FIREFOX_SOURCE_URL`
for the Mac.

Resolves https://github.com/travis-ci/travis-ci/issues/7690