### PR TITLE
Add a Stage::Skip, call travis_result on script

### DIFF
--- a/example_payloads/skip.json
+++ b/example_payloads/skip.json
@@ -1,0 +1,9 @@
+{
+  "config":{
+    "script": "skip"
+  },
+  "repository":{
+    "slug":"travis-repos/chirp-org-staging",
+    "source_url":"https://github.com/travis-repos/chirp-org-staging.git"
+  }
+}

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -3,6 +3,7 @@ require 'travis/build/stages/base'
 require 'travis/build/stages/builtin'
 require 'travis/build/stages/custom'
 require 'travis/build/stages/conditional'
+require 'travis/build/stages/skip'
 
 module Travis
   module Build
@@ -75,14 +76,12 @@ module Travis
         define_header_stage
 
         STAGES.each do |stage|
-          define_stage(stage.type, stage.name) unless skip?(stage)
+          define_stage(stage.type, stage.name)
         end
 
         sh.raw "source $HOME/.travis/job_stages"
 
         STAGES.each do |stage|
-          next if skip?(stage)
-
           case stage.run_in_debug
           when :always
             sh.raw "travis_run_#{stage.name}"
@@ -114,6 +113,7 @@ module Travis
 
       def run_stage(type, name)
         type = :builtin if fallback?(type, name)
+        type = :skip    if skip?(type, name)
         stage = self.class.const_get(type.to_s.camelize).new(script, name)
         stage.run
       end
@@ -122,8 +122,8 @@ module Travis
         script.debug_build_via_api?
       end
 
-      def skip?(stage)
-        stage.type == :custom && SKIP_KEYWORDS.any? { |kw| config[stage.name] == kw }
+      def skip?(type, name)
+        type == :custom && SKIP_KEYWORDS.any? { |word| config[name] == word }
       end
     end
   end

--- a/lib/travis/build/stages/skip.rb
+++ b/lib/travis/build/stages/skip.rb
@@ -1,0 +1,13 @@
+require 'travis/build/stages/base'
+
+module Travis
+  module Build
+    class Stages
+      class Skip < Base
+        def run
+          sh.raw 'travis_result 0' if script?
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/build/stages/skip.rb
+++ b/lib/travis/build/stages/skip.rb
@@ -5,6 +5,7 @@ module Travis
     class Stages
       class Skip < Base
         def run
+          sh.echo "Skipping the #{name} stage due to the configuration."
           sh.raw 'travis_result 0' if script?
         end
       end

--- a/spec/build/script_spec.rb
+++ b/spec/build/script_spec.rb
@@ -54,10 +54,18 @@ describe Travis::Build::Script, :sexp do
   end
 
   context 'when install phase is `"skip"`' do
-    it 'does not execute `travis_run_install` function' do
+    it 'execute `travis_run_install` function, and set the test result' do
       payload[:config][:install] = 'skip'
+      should include_sexp [:raw, 'travis_run_install']
+      should_not include_sexp [:raw, 'travis_result 0'] # these functions are hard to test, extract an bash ast type :function?
+    end
+  end
 
-      should_not include_sexp [:raw, 'travis_run_install']
+  context 'when script phase is `"skip"`' do
+    it 'execute `travis_run_script` function, and set the test result' do
+      payload[:config][:script] = 'skip'
+      should include_sexp [:raw, 'travis_run_install']
+      should include_sexp [:raw, 'travis_result 0'] # these functions are hard to test, extract an bash ast type :function?
     end
   end
 


### PR DESCRIPTION
The current strategy of skipping a stage does not play well with the `TRAVIS_TEST_RESULT`, which needs to be set in order for deployments to proceed.