### PR TITLE
Lax filter spec timeout

### DIFF
--- a/spec/filter_spec.rb
+++ b/spec/filter_spec.rb
@@ -45,6 +45,6 @@ describe Filter do
 
   it 'live streams' do
     command = %q[ruby public/filter.rb 'ruby -e "print :foo; sleep 0.01; print :bar; sleep"']
-    expect(with_timeout(command, 1)).to be == 'foobar'
+    expect(with_timeout(command, 2)).to be == 'foobar'
   end
 end


### PR DESCRIPTION
1 second may be too short in some cases.

The error:

  1) Filter live streams
     Failure/Error: expect(with_timeout(command, 1)).to be == 'foobar'

       expected: == "foobar"
            got:    ""