### PR TITLE
Fix dynamic GHC installation

### DIFF
--- a/lib/travis/build/config.rb
+++ b/lib/travis/build/config.rb
@@ -29,7 +29,7 @@ module Travis
           trusty: ENV.fetch('TRAVIS_BUILD_APT_SOURCE_WHITELIST_TRUSTY', '')
         },
         apt_whitelist_skip: ENV.fetch('TRAVIS_BUILD_APT_WHITELIST_SKIP', ''),
-        cabal_default: ENV.fetch('TRAVIS_BUILD_CABAL_DEFAULT', '1.22'),
+        cabal_default: ENV.fetch('TRAVIS_BUILD_CABAL_DEFAULT', '2.0'),
         auth_disabled: ENV.fetch('TRAVIS_BUILD_AUTH_DISABLED', ''),
         enable_debug_tools: ENV.fetch(
           'TRAVIS_BUILD_ENABLE_DEBUG_TOOLS',

--- a/lib/travis/build/script/haskell.rb
+++ b/lib/travis/build/script/haskell.rb
@@ -34,7 +34,13 @@ module Travis
         def setup
           super
           sh.export 'PATH', "/opt/ghc/bin:${TRAVIS_GHC_ROOT}/${TRAVIS_HASKELL_VERSION}/bin:${PATH}", assert: true
+          sh.raw "if test -x /opt/ghc/${TRAVIS_HASKELL_VERSION}/bin/ghc; then"
+          sh.export "PATH", "/opt/ghc/${TRAVIS_HASKELL_VERSION}/bin:${PATH}"
+          sh.raw "fi"
           sh.export 'TRAVIS_HASKELL_VERSION', "$(travis_ghc_find '#{version}')"
+          sh.raw "if test -x /opt/ghc/#{cabal_version}/bin/cabal; then"
+          sh.export "PATH", "/opt/ghc/#{cabal_version}/bin:${PATH}"
+          sh.raw "fi"
           sh.cmd 'cabal update', fold: 'cabal', retry: true
         end
 

--- a/lib/travis/build/script/haskell.rb
+++ b/lib/travis/build/script/haskell.rb
@@ -33,8 +33,8 @@ module Travis
 
         def setup
           super
+          sh.export 'PATH', "/opt/ghc/bin:${TRAVIS_GHC_ROOT}/${TRAVIS_HASKELL_VERSION}/bin:${PATH}", assert: true
           sh.export 'TRAVIS_HASKELL_VERSION', "$(travis_ghc_find '#{version}')"
-          sh.export 'PATH', "${TRAVIS_GHC_ROOT}/${TRAVIS_HASKELL_VERSION}/bin:${PATH}", assert: true
           sh.cmd 'cabal update', fold: 'cabal', retry: true
         end
 

--- a/lib/travis/build/script/haskell.rb
+++ b/lib/travis/build/script/haskell.rb
@@ -37,7 +37,7 @@ module Travis
           sh.raw "if test -x /opt/ghc/${TRAVIS_HASKELL_VERSION}/bin/ghc; then"
           sh.export "PATH", "/opt/ghc/${TRAVIS_HASKELL_VERSION}/bin:${PATH}"
           sh.raw "fi"
-          sh.raw "if ! travis_ghc_find #{version}; then travis_terminate 1; fi"
+          sh.raw "if ! travis_ghc_find #{version} >&/dev/null; then travis_terminate 1; fi"
           sh.export 'TRAVIS_HASKELL_VERSION', "$(travis_ghc_find '#{version}')"
           sh.raw "if test -x /opt/cabal/#{cabal_version}/bin/cabal; then"
           sh.export "PATH", "/opt/cabal/#{cabal_version}/bin:${PATH}"

--- a/lib/travis/build/script/haskell.rb
+++ b/lib/travis/build/script/haskell.rb
@@ -22,7 +22,7 @@ module Travis
           )
           # Automatic installation of exact versions *only*.
           if version =~ /^(\d+\.\d+\.\d+|head)$/ && cabal_version =~ /^(\d+\.\d+|head)$/
-            sh.raw "if ! travis_ghc_find '#{version}' &>/dev/null; then"
+            sh.raw "if [[ !(travis_ghc_find '#{version}' &>/dev/null) || $(cabal --numeric-version 2>/dev/null) = #{cabal_version}* ]]; then"
             sh.raw 'travis_fold start ghc.install'
             sh.echo "ghc-#{version} is not installed; attempting installation", ansi: :yellow
             sh.raw "travis_ghc_install '#{version}' '#{cabal_version}'"
@@ -39,13 +39,13 @@ module Travis
             sh.export "PATH", "/opt/ghc/${TRAVIS_HASKELL_VERSION}/bin:${PATH}"
           end
           sh.if "! $(ghc --numeric-version 2>/dev/null) = #{version}*" do
-            sh.terminate 2, "GHC #{version} not found. Terminating."
+            sh.terminate 2, "${ANSI_RED}GHC #{version} not found. Terminating.${ANSI_RESET}"
           end
           sh.if "-x /opt/cabal/#{cabal_version}/bin/cabal" do
             sh.export "PATH", "/opt/cabal/#{cabal_version}/bin:${PATH}"
           end
           sh.if "! $(cabal --numeric-version 2>/dev/null) = #{cabal_version}*" do
-            sh.terminate 2, "cabal #{cabal_version} not found. Terminating."
+            sh.terminate 2, "${ANSI_RED}cabal #{cabal_version} not found. Terminating.${ANSI_RESET}"
           end
           sh.cmd 'cabal update', fold: 'cabal', retry: true
         end

--- a/lib/travis/build/script/haskell.rb
+++ b/lib/travis/build/script/haskell.rb
@@ -37,6 +37,7 @@ module Travis
           sh.raw "if test -x /opt/ghc/${TRAVIS_HASKELL_VERSION}/bin/ghc; then"
           sh.export "PATH", "/opt/ghc/${TRAVIS_HASKELL_VERSION}/bin:${PATH}"
           sh.raw "fi"
+          sh.raw "if ! travis_ghc_find #{version}; then travis_terminate 1; fi"
           sh.export 'TRAVIS_HASKELL_VERSION', "$(travis_ghc_find '#{version}')"
           sh.raw "if test -x /opt/cabal/#{cabal_version}/bin/cabal; then"
           sh.export "PATH", "/opt/cabal/#{cabal_version}/bin:${PATH}"

--- a/lib/travis/build/script/haskell.rb
+++ b/lib/travis/build/script/haskell.rb
@@ -45,7 +45,7 @@ module Travis
             sh.export "PATH", "/opt/cabal/#{cabal_version}/bin:${PATH}"
           end
           sh.if "! $(cabal --numeric-version 2>/dev/null) = #{cabal_version}*" do
-            sh.terminate 2, "cabal #{version} not found. Terminating."
+            sh.terminate 2, "cabal #{cabal_version} not found. Terminating."
           end
           sh.cmd 'cabal update', fold: 'cabal', retry: true
         end

--- a/lib/travis/build/script/haskell.rb
+++ b/lib/travis/build/script/haskell.rb
@@ -33,6 +33,7 @@ module Travis
 
         def setup
           super
+          sh.export 'TRAVIS_HASKELL_VERSION', "$(travis_ghc_find '#{version}')"
           sh.export 'PATH', "/opt/ghc/bin:${TRAVIS_GHC_ROOT}/${TRAVIS_HASKELL_VERSION}/bin:${PATH}", assert: true
           sh.if "-x /opt/ghc/${TRAVIS_HASKELL_VERSION}/bin/ghc" do
             sh.export "PATH", "/opt/ghc/${TRAVIS_HASKELL_VERSION}/bin:${PATH}"
@@ -40,7 +41,6 @@ module Travis
           sh.if "! $(ghc --numeric-version 2>/dev/null) = #{version}*" do
             sh.terminate 2, "GHC #{version} not found. Terminating."
           end
-          sh.export 'TRAVIS_HASKELL_VERSION', "$(travis_ghc_find '#{version}')"
           sh.if "-x /opt/cabal/#{cabal_version}/bin/cabal" do
             sh.export "PATH", "/opt/cabal/#{cabal_version}/bin:${PATH}"
           end

--- a/lib/travis/build/script/haskell.rb
+++ b/lib/travis/build/script/haskell.rb
@@ -24,7 +24,7 @@ module Travis
           if version =~ /^(\d+\.\d+\.\d+|head)$/ && cabal_version =~ /^(\d+\.\d+|head)$/
             sh.raw "if [[ !(travis_ghc_find '#{version}' &>/dev/null) || $(cabal --numeric-version 2>/dev/null) = #{cabal_version}* ]]; then"
             sh.raw 'travis_fold start ghc.install'
-            sh.echo "ghc-#{version} is not installed; attempting installation", ansi: :yellow
+            sh.echo "Updating ghc-#{version} and cabal-#{cabal_version}", ansi: :yellow
             sh.raw "travis_ghc_install '#{version}' '#{cabal_version}'"
             sh.raw 'travis_fold end ghc.install'
             sh.raw 'fi'

--- a/lib/travis/build/script/haskell.rb
+++ b/lib/travis/build/script/haskell.rb
@@ -38,8 +38,8 @@ module Travis
           sh.export "PATH", "/opt/ghc/${TRAVIS_HASKELL_VERSION}/bin:${PATH}"
           sh.raw "fi"
           sh.export 'TRAVIS_HASKELL_VERSION', "$(travis_ghc_find '#{version}')"
-          sh.raw "if test -x /opt/ghc/#{cabal_version}/bin/cabal; then"
-          sh.export "PATH", "/opt/ghc/#{cabal_version}/bin:${PATH}"
+          sh.raw "if test -x /opt/cabal/#{cabal_version}/bin/cabal; then"
+          sh.export "PATH", "/opt/cabal/#{cabal_version}/bin:${PATH}"
           sh.raw "fi"
           sh.cmd 'cabal update', fold: 'cabal', retry: true
         end

--- a/lib/travis/build/script/haskell.rb
+++ b/lib/travis/build/script/haskell.rb
@@ -38,14 +38,18 @@ module Travis
           sh.if "-x /opt/ghc/${TRAVIS_HASKELL_VERSION}/bin/ghc" do
             sh.export "PATH", "/opt/ghc/${TRAVIS_HASKELL_VERSION}/bin:${PATH}"
           end
-          sh.if "! $(ghc --numeric-version 2>/dev/null) = #{version}*" do
-            sh.terminate 2, "${ANSI_RED}GHC #{version} not found. Terminating.${ANSI_RESET}"
+          unless version =~ /\Ahead\z/
+            sh.if "! $(ghc --numeric-version 2>/dev/null) = #{version}*" do
+              sh.terminate 2, "${ANSI_RED}GHC #{version} not found. Terminating.${ANSI_RESET}"
+            end
           end
           sh.if "-x /opt/cabal/#{cabal_version}/bin/cabal" do
             sh.export "PATH", "/opt/cabal/#{cabal_version}/bin:${PATH}"
           end
-          sh.if "! $(cabal --numeric-version 2>/dev/null) = #{cabal_version}*" do
-            sh.terminate 2, "${ANSI_RED}cabal #{cabal_version} not found. Terminating.${ANSI_RESET}"
+          unless cabal_version =~ /\Ahead\z/
+            sh.if "! $(cabal --numeric-version 2>/dev/null) = #{cabal_version}*" do
+              sh.terminate 2, "${ANSI_RED}cabal #{cabal_version} not found. Terminating.${ANSI_RESET}"
+            end
           end
           sh.cmd 'cabal update', fold: 'cabal', retry: true
         end

--- a/lib/travis/build/script/haskell.rb
+++ b/lib/travis/build/script/haskell.rb
@@ -22,7 +22,7 @@ module Travis
           )
           # Automatic installation of exact versions *only*.
           if version =~ /^(\d+\.\d+\.\d+|head)$/ && cabal_version =~ /^(\d+\.\d+|head)$/
-            sh.raw "if [[ !(travis_ghc_find '#{version}' &>/dev/null) || $(cabal --numeric-version 2>/dev/null) = #{cabal_version}* ]]; then"
+            sh.raw "if [[ !(travis_ghc_find '#{version}' &>/dev/null) || $(cabal --numeric-version 2>/dev/null) != #{cabal_version}* ]]; then"
             sh.raw 'travis_fold start ghc.install'
             sh.echo "Updating ghc-#{version} and cabal-#{cabal_version}", ansi: :yellow
             sh.raw "travis_ghc_install '#{version}' '#{cabal_version}'"

--- a/lib/travis/build/script/haskell.rb
+++ b/lib/travis/build/script/haskell.rb
@@ -34,7 +34,7 @@ module Travis
         def setup
           super
           sh.export 'TRAVIS_HASKELL_VERSION', "$(travis_ghc_find '#{version}')"
-          sh.export 'PATH', "/opt/ghc/bin:${TRAVIS_GHC_ROOT}/${TRAVIS_HASKELL_VERSION}/bin:${PATH}", assert: true
+          sh.export 'PATH', "${TRAVIS_GHC_ROOT}/${TRAVIS_HASKELL_VERSION}/bin:${PATH}", assert: true
           sh.if "-x /opt/ghc/${TRAVIS_HASKELL_VERSION}/bin/ghc" do
             sh.export "PATH", "/opt/ghc/${TRAVIS_HASKELL_VERSION}/bin:${PATH}"
           end

--- a/lib/travis/build/templates/haskell.sh
+++ b/lib/travis/build/templates/haskell.sh
@@ -48,7 +48,7 @@ function travis_ghc_install() {
   fi
   if [[ ! -f '<%= root %>/etc/apt/sources.list.d/hvr-ghc.list' ]]; then
     echo -e "\n${ANSI_GREEN}Adding ppa:hvr/ghc.${ANSI_RESET}" >&2
-    sudo apt-add-repository -yq ppa:hvr/ghc
+    sudo apt-add-repository -y ppa:hvr/ghc
   fi
   sudo apt-get update -yqq
   if sudo apt-get install -yq "ghc-${ghc_version}"; then

--- a/lib/travis/build/templates/haskell.sh
+++ b/lib/travis/build/templates/haskell.sh
@@ -12,9 +12,6 @@ function travis_ghc_find() {
   local v
   if [[ ! "${search}" ]]; then
     echo -e "${ANSI_RED}No ghc version given.${ANSI_RESET}" >&2
-    echo -e "${ANSI_YELLOW}Using default ghc version '${TRAVIS_GHC_DEFAULT}'.${ANSI_RESET}" >&2
-    echo "${TRAVIS_GHC_DEFAULT}"
-    return 1
   else
     for v in "${TRAVIS_GHC_ROOT}"/*/; do
       v=${v%%/}
@@ -28,8 +25,10 @@ function travis_ghc_find() {
       fi
     done
     echo -e "${ANSI_RED}No such ghc version '${search}'.${ANSI_RESET}" >&2
-    return 1
   fi
+  echo -e "${ANSI_YELLOW}Using default ghc version '${TRAVIS_GHC_DEFAULT}'.${ANSI_RESET}" >&2
+  echo "${TRAVIS_GHC_DEFAULT}"
+  return 1
 }
 
 function travis_ghc_install() {

--- a/lib/travis/build/templates/haskell.sh
+++ b/lib/travis/build/templates/haskell.sh
@@ -12,6 +12,9 @@ function travis_ghc_find() {
   local v
   if [[ ! "${search}" ]]; then
     echo -e "${ANSI_RED}No ghc version given.${ANSI_RESET}" >&2
+    echo -e "${ANSI_YELLOW}Using default ghc version '${TRAVIS_GHC_DEFAULT}'.${ANSI_RESET}" >&2
+    echo "${TRAVIS_GHC_DEFAULT}"
+    return 1
   else
     for v in "${TRAVIS_GHC_ROOT}"/*/; do
       v=${v%%/}
@@ -25,10 +28,8 @@ function travis_ghc_find() {
       fi
     done
     echo -e "${ANSI_RED}No such ghc version '${search}'.${ANSI_RESET}" >&2
+    return 1
   fi
-  echo -e "${ANSI_YELLOW}Using default ghc version '${TRAVIS_GHC_DEFAULT}'.${ANSI_RESET}" >&2
-  echo "${TRAVIS_GHC_DEFAULT}"
-  return 1
 }
 
 function travis_ghc_install() {

--- a/spec/build/script/haskell_spec.rb
+++ b/spec/build/script/haskell_spec.rb
@@ -14,7 +14,7 @@ describe Travis::Build::Script::Haskell, :sexp do
   it_behaves_like 'a build script sexp'
 
   it "exports PATH variable" do
-    should include_sexp [:export, ['PATH', "${TRAVIS_GHC_ROOT}/${TRAVIS_HASKELL_VERSION}/bin:${PATH}"], echo: true, assert: true]
+    should include_sexp [:export, ['PATH', "/opt/ghc/bin:${TRAVIS_GHC_ROOT}/${TRAVIS_HASKELL_VERSION}/bin:${PATH}"], echo: true, assert: true]
   end
 
   it 'exports TRAVIS_HASKELL_VERSION variable' do

--- a/spec/build/script/haskell_spec.rb
+++ b/spec/build/script/haskell_spec.rb
@@ -14,7 +14,7 @@ describe Travis::Build::Script::Haskell, :sexp do
   it_behaves_like 'a build script sexp'
 
   it "exports PATH variable" do
-    should include_sexp [:export, ['PATH', "/opt/ghc/bin:${TRAVIS_GHC_ROOT}/${TRAVIS_HASKELL_VERSION}/bin:${PATH}"], echo: true, assert: true]
+    should include_sexp [:export, ['PATH', "${TRAVIS_GHC_ROOT}/${TRAVIS_HASKELL_VERSION}/bin:${PATH}"], echo: true, assert: true]
   end
 
   it 'exports TRAVIS_HASKELL_VERSION variable' do

--- a/spec/build/script/haskell_spec.rb
+++ b/spec/build/script/haskell_spec.rb
@@ -54,11 +54,11 @@ describe Travis::Build::Script::Haskell, :sexp do
       end
 
       it 'checks for existing installation' do
-        should include_sexp [:raw, %(if ! travis_ghc_find '#{ghc_config[:ghc]}' &>/dev/null; then)]
+        should include_sexp [:raw, %(if [[ !(travis_ghc_find '#{ghc_config[:ghc]}' &>/dev/null) || $(cabal --numeric-version 2>/dev/null) = #{ghc_config[:cabal]}* ]]; then)]
       end
 
       it 'installs ghc version when not present' do
-        should include_sexp [:echo, %(ghc-#{ghc_config[:ghc]} is not installed; attempting installation), ansi: :yellow]
+        should include_sexp [:echo, %(Updating ghc-#{ghc_config[:ghc]} and cabal-#{ghc_config[:cabal]}), ansi: :yellow]
         should include_sexp [:raw, %(travis_ghc_install '#{ghc_config[:ghc]}' '#{ghc_config[:cabal]}')]
         should include_sexp [:export, ['TRAVIS_HASKELL_VERSION', %($(travis_ghc_find '#{ghc_config[:ghc]}'))], echo: true]
       end

--- a/spec/build/script/haskell_spec.rb
+++ b/spec/build/script/haskell_spec.rb
@@ -54,7 +54,7 @@ describe Travis::Build::Script::Haskell, :sexp do
       end
 
       it 'checks for existing installation' do
-        should include_sexp [:raw, %(if [[ !(travis_ghc_find '#{ghc_config[:ghc]}' &>/dev/null) || $(cabal --numeric-version 2>/dev/null) = #{ghc_config[:cabal]}* ]]; then)]
+        should include_sexp [:raw, %(if [[ !(travis_ghc_find '#{ghc_config[:ghc]}' &>/dev/null) || $(cabal --numeric-version 2>/dev/null) != #{ghc_config[:cabal]}* ]]; then)]
       end
 
       it 'installs ghc version when not present' do


### PR DESCRIPTION
Set up `$PATH` correctly, and terminate the build if `ghc` or `cabal` versions do not match the value defined in `.travis.yml`.