### PR TITLE
Transition julia download links to *.julialang.org URLs

### DIFF
--- a/lib/travis/build/script/julia.rb
+++ b/lib/travis/build/script/julia.rb
@@ -101,13 +101,13 @@ module Travis
             case config[:julia].to_s
             when 'release'
               # CHANGEME on new minor releases (once or twice a year)
-              url = "s3.amazonaws.com/julialang/bin/#{osarch}/0.5/julia-0.5-latest-#{ext}"
+              url = "julialang-s3.julialang.org/bin/#{osarch}/0.5/julia-0.5-latest-#{ext}"
             when 'nightly'
-              url = "s3.amazonaws.com/julianightlies/bin/#{osarch}/julia-latest-#{nightlyext}"
+              url = "julialangnightlies-s3.julialang.org/bin/#{osarch}/julia-latest-#{nightlyext}"
             when /^(\d+\.\d+)\.\d+$/
-              url = "s3.amazonaws.com/julialang/bin/#{osarch}/#{$1}/julia-#{config[:julia]}-#{ext}"
+              url = "julialang-s3.julialang.org/bin/#{osarch}/#{$1}/julia-#{config[:julia]}-#{ext}"
             when /^(\d+\.\d+)$/
-              url = "s3.amazonaws.com/julialang/bin/#{osarch}/#{$1}/julia-#{$1}-latest-#{ext}"
+              url = "julialang-s3.julialang.org/bin/#{osarch}/#{$1}/julia-#{$1}-latest-#{ext}"
             else
               sh.failure "Unknown Julia version: #{config[:julia]}"
             end


### PR DESCRIPTION
We are transitioning over to using an intermediate caching layer in front of our S3 buckets.  This DNS change addresses that.

CC @tkelman @ninjin 