### PR TITLE
Redirect stdin/stderr instead of setting up a new PTY to re-run the build script

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'rack-ssl', '~> 1.4'
 gem 'sentry-raven'
 gem 'sinatra', '~> 1.4'
 gem 'travis-config'
+gem 'travis-rollout', git: 'https://github.com/travis-ci/travis-rollout', ref: 'sf-refactor'
 gem 'travis-support', git: 'https://github.com/travis-ci/travis-support'
 
 gem 'faraday'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,13 @@ GIT
     jemalloc (1.4.5)
 
 GIT
+  remote: https://github.com/travis-ci/travis-rollout
+  revision: 643477fb44ea35d483ed24cc89ced459719c6e6c
+  ref: sf-refactor
+  specs:
+    travis-rollout (0.0.1)
+
+GIT
   remote: https://github.com/travis-ci/travis-support
   revision: 113cff17fe383bb72fcfae3a97a8ce98c228342f
   specs:
@@ -146,7 +153,8 @@ DEPENDENCIES
   sinatra (~> 1.4)
   sinatra-contrib
   travis-config
+  travis-rollout!
   travis-support!
 
 BUNDLED WITH
-   1.13.7
+   1.14.6

--- a/lib/travis/build.rb
+++ b/lib/travis/build.rb
@@ -1,3 +1,5 @@
+require 'travis/support'
+
 module Travis
   module Build
     autoload :Config, 'travis/build/config'
@@ -43,6 +45,12 @@ module Travis
           Script.const_get(name, false) rescue Script::Ruby
         end
       end
+
+      def logger
+        @logger ||= Travis::Logger.configure(Logger.new(STDOUT))
+      end
+
+      attr_writer :logger
     end
   end
 end

--- a/lib/travis/build/appliances/setup_filter.rb
+++ b/lib/travis/build/appliances/setup_filter.rb
@@ -1,43 +1,78 @@
 require 'travis/build/appliances/base'
 require 'travis/build/git'
+require 'travis/rollout'
 
 module Travis
   module Build
     module Appliances
       class SetupFilter < Base
+        class Rollout < Struct.new(:data)
+          def matches?
+            Travis::Rollout.matches?(:redirect_io, uid: repo_id, owner: owner_login)
+          end
+
+          def repo_id
+            data.repository[:github_id]
+          end
+
+          def repo_slug
+            data.repository[:slug].to_s
+          end
+
+          def owner_login
+            repo_slug.split('/').first
+          end
+        end
+
         DEFAULT_SETTING = true
+
+        SH = {
+          pty: %(
+            if [[ -z "$TRAVIS_FILTERED" ]]; then
+              export TRAVIS_FILTERED=1
+              curl -sf -o ~/filter.rb %s
+              %s
+              exec ruby ~/filter.rb "/usr/bin/env TERM=xterm /bin/bash --login $HOME/build.sh" %s
+            fi
+          ),
+          redirect_io: %(
+            exec > >(
+              curl -sf -o ~/filter.rb %s
+              %s
+              ruby ~/filter.rb %s
+            ) 2>&1
+          )
+        }
+
+        MSGS = {
+          filter: 'Using filter strategy %p for repo %s on job id=%s number=%s'
+        }
 
         def apply?
           enabled? and secrets.any?
         end
 
-        def enabled?
-          config[:filter_secrets].nil? ? DEFAULT_SETTING : config[:filter_secrets]
-        end
-
         def apply
-          sh.raw <<-SHELL
-            curl -sf -o ~/filter.rb #{Shellwords.escape(download_url)}
-            exec > >(
-              #{exports}
-              ruby ~/filter.rb #{args}
-            ) 2>&1
-          SHELL
+          info :filter, strategy, data.repository[:slug].to_s, data.job[:id], data.job[:number]
+          sh.raw SH[strategy] % [Shellwords.escape(download_url), exports, args]
         end
 
         private
 
-          def host
-            return 'build.travis-ci.com' if app_host.empty?
-            app_host
+          def enabled?
+            config[:filter_secrets].nil? ? DEFAULT_SETTING : config[:filter_secrets]
+          end
+
+          def strategy
+            @strategy ||= Rollout.new(data).matches? ? :redirect_io : :pty
           end
 
           def download_url
-            "https://#{host}/filter.rb".untaint
+            "https://#{host}/filter#{'_pty' if strategy == :pty}.rb".untaint
           end
 
           def args
-            secrets.size.times.map { |ix| "-e SECRET_#{ix}" }.join(" ")
+            secrets.size.times.map { |ix| "-e \"SECRET_#{ix}\"" }.join(" ")
           end
 
           def exports
@@ -53,6 +88,14 @@ module Travis
 
           def env
             @env ||= Build::Env.new(data)
+          end
+
+          def host
+            app_host.empty? ? 'build.travis-ci.com' : app_host
+          end
+
+          def info(msg, *args)
+            Travis::Build.logger.info(MSGS[msg] % args)
           end
       end
     end

--- a/lib/travis/build/appliances/setup_filter.rb
+++ b/lib/travis/build/appliances/setup_filter.rb
@@ -54,6 +54,7 @@ module Travis
 
         def apply
           info :filter, strategy, data.repository[:slug].to_s, data.job[:id], data.job[:number]
+          puts SH[strategy] % [Shellwords.escape(download_url), exports, args] if ENV['ROLLOUT_DEBUG']
           sh.raw SH[strategy] % [Shellwords.escape(download_url), exports, args]
         end
 

--- a/public/filter.rb
+++ b/public/filter.rb
@@ -1,3 +1,5 @@
+require 'shellwords'
+
 module Filter
   class Scanner < Struct.new(:reader)
     def run(io)
@@ -37,6 +39,10 @@ module Filter
   end
 end
 
+def unescape(str)
+  `echo #{str}`.chomp rescue ''
+end
+
 if __FILE__ == $0
   secrets = []
 
@@ -51,6 +57,7 @@ if __FILE__ == $0
   end
 
   secrets = secrets.reject { |s| s.length < 3 }
+  secrets = secrets.map { |s| [s, unescape(s)] }.flatten
   secrets = secrets.uniq.sort_by { |s| -s.length }
 
   filter = secrets.inject(Filter::Stdin.new($stdin)) do |filter, secret|

--- a/public/filter_pty.rb
+++ b/public/filter_pty.rb
@@ -1,0 +1,96 @@
+require 'pty'
+require 'shellwords'
+
+module Filter
+  class Scanner
+    attr_reader :reader
+
+    def initialize(reader)
+      @reader = reader
+    end
+
+    def read(&block)
+      reader.read(&block)
+    end
+
+    def run(io)
+      read { |char| io.print char }
+    end
+  end
+
+  class Runner < Scanner
+    def read
+      PTY.spawn(reader) do |stdout, stdin, pid|
+        begin
+          yield stdout.readchar until stdout.eof?
+        rescue Errno::EIO
+        end
+
+        until PTY.check(pid, true)
+          sleep 0.1
+        end
+      end
+    rescue PTY::ChildExited => e
+      e.status.exitstatus
+    end
+  end
+
+  class StringFilter < Scanner
+    attr_reader :string
+
+    def initialize(reader, string)
+      @string = string
+      super(reader)
+    end
+
+    def read(&block)
+      buffer = ""
+      reader.read do |char|
+        buffer << char
+        if string == buffer
+          yield '[secure]'
+          buffer = ""
+        elsif !string.start_with?(buffer)
+          buffer.each_char(&block)
+          buffer = ""
+        end
+      end
+    end
+  end
+end
+
+def unescape(str)
+  `echo #{str}`.chomp rescue ''
+end
+
+if __FILE__ == $0
+  unless command = ARGV.shift
+    $stderr.puts DATA.read
+    exit 1
+  end
+
+  runner = Filter::Runner.new(command)
+  secrets = []
+
+  until ARGV.empty?
+    case option = ARGV.shift
+    when '-e' then secrets << ENV[ARGV.shift].to_s
+    when '-s' then secrets << ARGV.shift
+    else
+      $stderr.puts "unknown option", DATA.read
+      exit 1
+    end
+  end
+
+  secrets = secrets.map { |s| [s, unescape(s)] }.flatten
+  secrets.uniq.sort_by { |s| -s.length }.each do |secret|
+    runner = Filter::StringFilter.new(runner, secret) if secret.length >= 3
+  end
+
+  exit runner.run($stdout)
+end
+
+__END__
+Usage: filter.rb COMMAND [OPTIONS]
+          -e VAR    filter environment variable named VAR
+          -s STR    filter string STR

--- a/spec/filter_spec.rb
+++ b/spec/filter_spec.rb
@@ -4,18 +4,11 @@ require 'timeout'
 require_relative '../public/filter'
 
 describe Filter do
+  let(:cmd) { File.expand_path('../../public/filter.rb', __FILE__) }
   def filter(input, *secrets)
-    path = File.expand_path('../../public/filter.rb', __FILE__)
-    secrets = secrets.map { |s| "-s #{Shellwords.escape(s)}" }.join " "
-    `ruby #{path} echo\\ #{Shellwords.escape(input)} #{secrets}`.chomp
-  end
-
-  def with_timeout(command, timeout)
-    output = ""
-    Timeout.timeout(timeout) { Filter::Runner.new(command).read { |c| output << c} }
-    output
-  rescue Timeout::Error
-    output
+    args  = secrets.map { |s| "-s #{Shellwords.escape(s)}" }.join " "
+    input = Shellwords.escape(input)
+    `echo #{input} | ruby #{cmd} #{args}`.chomp
   end
 
   describe 'simple replacements' do
@@ -26,25 +19,16 @@ describe Filter do
     example { expect(filter('abcdef', 'a', 'bc', 'def')).to be == 'abc[secure]' }
   end
 
-  describe 'sets the status code correctly' do
-    example do
-      with_timeout('true', 1)
-      expect($?.exitstatus).to be == 0
-    end
-
-    example do
-      with_timeout('false', 1)
-      expect($?.exitstatus).to be == 1
-    end
-
-    example do
-      with_timeout('sleep 0.2; exit 128', 1)
-      expect($?.exitstatus).to be == 128
-    end
-  end
-
   it 'live streams' do
-    command = %q[ruby public/filter.rb 'ruby -e "print :foo; sleep 0.01; print :bar; sleep"']
-    expect(with_timeout(command, 2)).to be == 'foobar'
+    code = %(
+      print 'foo'
+      sleep 0.01
+      print 'bar'
+      sleep 0.01
+      print 'baz'
+      sleep 0.01
+    )
+    output = `ruby -e "#{code}" | ruby #{cmd} -s bar`
+    expect(output).to be == 'foo[secure]baz'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ integration_enabled = ENV['INTEGRATION_SPECS'] == '1'
 ENV['TOP'] = `git rev-parse --show-toplevel`.strip if integration_enabled
 
 RSpec.configure do |c|
+  c.include SpecHelpers::Logger
   c.include SpecHelpers::Payload
   c.include SpecHelpers::Node, :include_node_helpers
   c.include SpecHelpers::Sexp, :sexp

--- a/spec/support/logger.rb
+++ b/spec/support/logger.rb
@@ -1,0 +1,12 @@
+module SpecHelpers
+  module Logger
+    def self.included(const)
+      const.module_eval do
+        let(:stdout) { io.string }
+        let(:io)     { StringIO.new }
+        let(:logger) { Travis::Build.logger }
+        before       { Travis::Build.logger = Travis::Logger.new(io) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds another strategy for hooking up the logs filtering logic which, i think, is a little more "unix'ish". Instead of setting up a new PTY in the filter, and the rerunning the build script inside of that PTY the new strategy just redirects stdin and stderr to the filter. The build script continues to run in the same process, but all output gets redirected to the filter.

Issues with the current PTY strategy:

* setting up a new PTY there are some inconsistencies across infrastructures with regards to, e.g., the terminal size
* grandchild processes can get detached which causes the build script to hang, and time out
* we add extra `\r` carriage returns to the log output

This also adds the ability to roll this out incrementally using travis-rollout. Since travis-build does not use a Redis instance we'll want to control this via env vars:

```
ROLLOUT=redirect_io
ROLLOUT_REDIRECT_IO_OWNERS=svenfuchs
ROLLOUT_REDIRECT_IO_PERCENT=25
```