### PR TITLE
Set up RVM aliases when one is required

### DIFF
--- a/spec/build/script/ruby_spec.rb
+++ b/spec/build/script/ruby_spec.rb
@@ -141,6 +141,18 @@ describe Travis::Build::Script::Ruby, :sexp do
     end
   end
 
+  context 'when testing with 2.3' do
+    before :each do
+      data[:config][:rvm] = '2.3'
+    end
+
+    it 'ensures rvm alias is defined' do
+      sexp = sexp_find(subject, [:if, "-z $(rvm alias list | grep ^2\\\\.3)"], [:then])
+      store_example "rvm-alias"
+      expect(sexp).to include_sexp [:cmd, "rvm alias create 2.3 ruby-2.3.4", assert: true, echo: true, timing: true]
+    end
+  end
+
   context 'when testing with rbx' do
     before :each do
       data[:config][:rvm] = 'rbx'


### PR DESCRIPTION
The build image may not know about the MAJOR.MINOR Ruby version
aliases, so we ensure that they exist.

Ideally, RVM_VERSION_ALIASES should be discovered at the build time
(or `travis-build` deploy time), but it is a surprisingly difficult
problem to solve reliably at the moment. So we simply hard code the
known releases for now.