### PR TITLE
Migrate xbuild to msbuild

### DIFF
--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -138,7 +138,7 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
           super
 
           sh.cmd 'mono --version', timing: true if is_mono_enabled
-          sh.cmd 'msbuild /version', timing: true if is_mono_enabled
+          sh.cmd "#{mono_build_cmd} /version", timing: true if is_mono_enabled
           sh.echo ''
 
           sh.cmd 'dotnet --info', timing: true if is_dotnet_enabled
@@ -157,7 +157,7 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
 
         def script
           if config[:solution] && is_mono_enabled
-            sh.cmd "msbuild /p:Configuration=Release #{config[:solution]}", timing: true
+            sh.cmd "#{mono_build_cmd} /p:Configuration=Release #{config[:solution]}", timing: true
           else
             sh.failure 'No solution or script defined, exiting'
           end
@@ -271,6 +271,19 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
           return false if MONO_VERSION_REGEXP.match(config[:mono])[1] == '4' && MONO_VERSION_REGEXP.match(config[:mono])[2].to_i < 4
 
           true
+        end
+
+        def is_mono_after_5
+          return false unless is_mono_version_valid?
+          return true if is_mono_version_keyword?
+
+          return false if MONO_VERSION_REGEXP.match(config[:mono])[1].to_i < 5
+
+          true
+        end
+
+        def mono_build_cmd
+          is_mono_after_5 ? "msbuild" : "xbuild" 
         end
       end
     end

--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -138,7 +138,7 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
           super
 
           sh.cmd 'mono --version', timing: true if is_mono_enabled
-          sh.cmd 'xbuild /version', timing: true if is_mono_enabled
+          sh.cmd 'msbuild /version', timing: true if is_mono_enabled
           sh.echo ''
 
           sh.cmd 'dotnet --info', timing: true if is_dotnet_enabled
@@ -157,7 +157,7 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
 
         def script
           if config[:solution] && is_mono_enabled
-            sh.cmd "xbuild /p:Configuration=Release #{config[:solution]}", timing: true
+            sh.cmd "msbuild /p:Configuration=Release #{config[:solution]}", timing: true
           else
             sh.failure 'No solution or script defined, exiting'
           end

--- a/spec/build/script/csharp_spec.rb
+++ b/spec/build/script/csharp_spec.rb
@@ -131,7 +131,13 @@ describe Travis::Build::Script::Csharp, :sexp do
       should include_sexp [:cmd, 'mono --version', echo: true, timing: true]
     end
 
+    it 'announces xbuild version' do
+      data[:config][:mono] = '3.8.0'
+      should include_sexp [:cmd, 'xbuild /version', echo: true, timing: true]
+    end
+
     it 'announces msbuild version' do
+      data[:config][:mono] = '5.0.0'
       should include_sexp [:cmd, 'msbuild /version', echo: true, timing: true]
     end
   end

--- a/spec/build/script/csharp_spec.rb
+++ b/spec/build/script/csharp_spec.rb
@@ -131,8 +131,8 @@ describe Travis::Build::Script::Csharp, :sexp do
       should include_sexp [:cmd, 'mono --version', echo: true, timing: true]
     end
 
-    it 'announces xbuild version' do
-      should include_sexp [:cmd, 'xbuild /version', echo: true, timing: true]
+    it 'announces msbuild version' do
+      should include_sexp [:cmd, 'msbuild /version', echo: true, timing: true]
     end
   end
 
@@ -151,7 +151,7 @@ describe Travis::Build::Script::Csharp, :sexp do
 
     it 'builds specified solution' do
       data[:config][:solution] = 'foo.sln'
-      should include_sexp [:cmd, 'xbuild /p:Configuration=Release foo.sln', echo: true, timing: true]
+      should include_sexp [:cmd, 'msbuild /p:Configuration=Release foo.sln', echo: true, timing: true]
     end
   end
 


### PR DESCRIPTION
With the release of Mono 5, xbuild has been deprecated in favor of msbuild (Further details [here](http://www.mono-project.com/docs/about-mono/releases/5.0.0/#msbuild)). Luckily, the syntax is exactly the same, so updating just a matter of changing every reference of xbuild to msbuild.