### PR TITLE
Exit early on all HHVM+Precise combination

### DIFF
--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -103,6 +103,11 @@ module Travis
         end
 
         def configure_hhvm
+          sh.if '"$(lsb_release -sc 2>/dev/null)" = "precise"' do
+            sh.echo "HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with \\`dist: trusty\\`.", ansi: :yellow
+            sh.raw "travis_terminate 1"
+          end
+
           if nightly?
             install_hhvm_nightly
           elsif hhvm?
@@ -133,10 +138,6 @@ module Travis
         end
 
         def install_hhvm_nightly
-          sh.if '"$(lsb_release -sc 2>/dev/null)" = "precise"' do
-            sh.echo "HHVM nightly is no longer supported on Ubuntu Precise. See https://github.com/travis-ci/travis-ci/issues/3788 and https://github.com/facebook/hhvm/issues/5220", ansi: :yellow
-            sh.raw "travis_terminate 1"
-          end
           sh.echo 'Installing HHVM nightly', ansi: :yellow
           sh.cmd 'sudo apt-get update -qq'
           sh.cmd 'sudo apt-get install hhvm-nightly -y 2>&1 >/dev/null'


### PR DESCRIPTION
Not just nightlies.

Resolves https://github.com/travis-ci/travis-ci/issues/7712 by documenting that it doesn't work.