### PR TITLE
Upgrade to Composer 1.0.0 only by detecting version 1.0-dev

### DIFF
--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -174,8 +174,12 @@ hhvm.libxml.ext_entity_whitelist=file,http,https
         end
 
         def composer_self_update
-          sh.cmd "composer self-update 1.0.0", assert: false unless version =~ /^5\.2/
-          sh.cmd "composer self-update", assert: false unless version =~ /^5\.2/
+          unless version =~ /^5\.2/
+            sh.if '-n $(composer --version | grep -o "version [^ ]*1\\.0-dev")' do
+              sh.cmd "composer self-update 1.0.0", assert: false
+            end
+            sh.cmd "composer self-update", assert: false
+          end
         end
       end
     end


### PR DESCRIPTION
`[^ ]*` is necessary because Composer 1.0-dev inserts
ANSI escape sequence for yellow.

Resolves https://github.com/travis-ci/travis-ci/issues/782.