### PR TITLE
Do not fail the build if `tlmgr update` returns non 0 error code

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -444,7 +444,7 @@ module Travis
             sh.cmd "curl -fLo /tmp/#{texlive_filename} #{texlive_url}"
             sh.cmd "tar xzf /tmp/#{texlive_filename} -C ~"
             sh.export 'PATH', "/$HOME/texlive/bin/x86_64-linux:$PATH"
-            sh.cmd 'tlmgr update --self'
+            sh.cmd 'tlmgr update --self', assert: false
           when 'osx'
             # We use basictex due to disk space constraints.
             mactex = 'BasicTeX.pkg'
@@ -458,11 +458,11 @@ module Travis
             sh.rm "/tmp/#{mactex}"
             sh.export 'PATH', '/usr/texbin:/Library/TeX/texbin:$PATH'
 
-            sh.cmd 'sudo tlmgr update --self'
+            sh.cmd 'sudo tlmgr update --self', assert: false
 
             # Install common packages
             sh.cmd 'sudo tlmgr install inconsolata upquote '\
-              'courier courier-scaled helvetic'
+              'courier courier-scaled helvetic', assert: false
           end
         end
 


### PR DESCRIPTION
This should hopefully work around these errors, caused by the release of TeXLive 2017 yesterday. Complicating the matter the CTAN mirrors do not all seem to be updated yet, so I cannot simply update the texlive bundle to 2017 to fix this. However I think this will work in the short term, and prevent this breakage next year as well.

Fixes https://github.com/craigcitro/r-travis/issues/174, https://github.com/travis-ci/travis-ci/issues/7852