### PR TITLE
Allow docker job to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ stages:
   - ":ship: it to Quay.io"
 
 jobs:
+  allow_failures:
+    - script: ./script/docker-build-and-push
   include:
     - stage: "test"
       sudo: required


### PR DESCRIPTION
This job requires secrets, and will fail on external PR builds.

Ideally, we should not run this job at all, but until we have such capability, we just allow it to fail.