### PR TITLE
Revert APT cache purge changes

### DIFF
--- a/lib/travis/build/appliances/fix_rwky_redis.rb
+++ b/lib/travis/build/appliances/fix_rwky_redis.rb
@@ -7,16 +7,12 @@ module Travis
         def apply
           command = <<-EOF
           if [[ -d /var/lib/apt/lists && -n $(command -v apt-get) ]]; then
-            RWKY_REDIS_PURGE_NEEDED=
+            sudo rm -rf /var/lib/apt/lists/*
             for f in $(grep -l rwky/redis /etc/apt/sources.list.d/*); do
               sed 's,rwky/redis,rwky/ppa,g' $f > /tmp/${f##**/}
               sudo mv /tmp/${f##**/} /etc/apt/sources.list.d
-              RWKY_REDIS_PURGE_NEEDED=1
             done
-            if [[ $RWKY_REDIS_PURGE_NEEDED ]]; then
-              sudo rm -rf /var/lib/apt/lists/*
-              sudo apt-get update -qq &>/dev/null
-            fi
+            sudo apt-get update -qq 2>&1 >/dev/null
           fi
           EOF
           sh.cmd command, echo: false


### PR DESCRIPTION
We are reverting to the previous version because we believe it's now preventing customers to install some packages on Precise e.g.

- jq
- beanstalkd
- python-scipy
- python-numpy