### PR TITLE
Retry failed downloads for OS X

### DIFF
--- a/lib/travis/build/script/julia.rb
+++ b/lib/travis/build/script/julia.rb
@@ -43,7 +43,7 @@ module Travis
               sh.cmd %Q{curl -A "$CURL_USER_AGENT" -s -L --retry 7 '#{julia_url}' } \
                        '| tar -C ~/julia -x -z --strip-components=1 -f -'
             when 'osx'
-              sh.cmd %Q{curl -A "$CURL_USER_AGENT" -s -L -o julia.dmg '#{julia_url}'}
+              sh.cmd %Q{curl -A "$CURL_USER_AGENT" -s -L --retry 7 -o julia.dmg '#{julia_url}'}
               sh.cmd 'mkdir juliamnt'
               sh.cmd 'hdiutil mount -readonly -mountpoint juliamnt julia.dmg'
               sh.cmd 'cp -a juliamnt/*.app/Contents/Resources/julia ~/'


### PR DESCRIPTION
As discussed in travis-ci/travis-ci#7935, we should retry failed downloads on OS X to make the process more robust.