### PR TITLE
Allow `pypy` versions without a hyphen

### DIFF
--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -102,6 +102,7 @@ module Travis
       end
 
       def archive_url_for(bucket, version, lang = self.class.name.split('::').last.downcase, ext = 'bz2')
+        file_name = "#{[version, lang].compact.join("-")}.tar.#{ext}"
         sh.if "$(uname) = 'Linux'" do
           sh.raw "travis_host_os=$(lsb_release -is | tr 'A-Z' 'a-z')"
           sh.raw "travis_rel_version=$(lsb_release -rs)"
@@ -111,7 +112,7 @@ module Travis
           sh.raw "travis_rel=$(sw_vers -productVersion)"
           sh.raw "travis_rel_version=${travis_rel%*.*}"
         end
-        "archive_url=https://s3.amazonaws.com/#{bucket}/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/#{lang}-#{version}.tar.#{ext}"
+        "archive_url=https://s3.amazonaws.com/#{bucket}/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/#{file_name}"
       end
 
       def debug_build_via_api?

--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -98,7 +98,7 @@ module Travis
 
           def install_python_archive(version = 'nightly')
             if version =~ /^pypy/
-              if md = /^(?<interpreter>pypy[^-]*)-(?<version>.*)/.match(version)
+              if md = /^(?<interpreter>pypy[^-]*)(-(?<version>.*))?/.match(version)
                 lang = md[:interpreter]
                 vers = md[:version]
               end
@@ -108,7 +108,8 @@ module Travis
             end
             sh.raw archive_url_for('travis-python-archives', vers, lang)
             sh.echo "Downloading archive: ${archive_url}", ansi: :yellow
-            archive_filename = "#{lang}-#{vers}.tar.bz2"
+            archive_basename = [lang, vers].compact.join("-")
+            archive_filename = "#{archive_basename}.tar.bz2"
             sh.cmd "curl -s -o #{archive_filename} ${archive_url}", assert: true
             sh.cmd "sudo tar xjf #{archive_filename} --directory /", echo: true, assert: true
             sh.cmd "rm #{archive_filename}", echo: false

--- a/spec/build/script/python_spec.rb
+++ b/spec/build/script/python_spec.rb
@@ -26,6 +26,7 @@ describe Travis::Build::Script::Python, :sexp do
   it 'sets up the python version (pypy)' do
     data[:config][:python] = 'pypy'
     should include_sexp [:cmd,  'source ~/virtualenv/pypy/bin/activate', assert: true, echo: true, timing: true]
+    should include_sexp [:cmd,  "curl -s -o pypy.tar.bz2 ${archive_url}", assert: true]
   end
 
   it 'sets up the python version (pypy-5.3.1)' do


### PR DESCRIPTION
The regexp no longer assumes there is a `-` in the version name when
dealing with pypy*.