### PR TITLE
Install libmariadbclient18 for compatibility with MariaDB 10.2

### DIFF
--- a/lib/travis/build/addons/mariadb.rb
+++ b/lib/travis/build/addons/mariadb.rb
@@ -17,7 +17,7 @@ module Travis
             sh.cmd "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 #{MARIADB_GPG_KEY}", sudo: true
             sh.cmd 'add-apt-repository "deb http://%p/mariadb/repo/%p/ubuntu $(lsb_release -cs) main"' % [MARIADB_MIRROR, mariadb_version], sudo: true
             sh.cmd "apt-get update -qq", assert: false, sudo: true
-            sh.cmd "apt-get install -y -o Dpkg::Options::='--force-confnew' mariadb-server mariadb-server-#{mariadb_version} libmariadbclient-dev", sudo: true, echo: true, timing: true
+            sh.cmd "apt-get install -y -o Dpkg::Options::='--force-confnew' mariadb-server mariadb-server-#{mariadb_version} #{mariadb_client}", sudo: true, echo: true, timing: true
             sh.echo "Starting MariaDB v#{mariadb_version}", ansi: :yellow
             sh.cmd "service mysql start", sudo: true, assert: false, echo: true, timing: true
             sh.export 'TRAVIS_MARIADB_VERSION', mariadb_version, echo: false
@@ -28,6 +28,15 @@ module Travis
         private
         def mariadb_version
           config.to_s.shellescape
+        end
+
+        def mariadb_client
+          if config >= 10.2
+            # As of MariaDB 10.2 the headers are included
+            'libmariadbclient18'
+          else
+            'libmariadbclient18 libmariadbclient-dev'
+          end
         end
       end
     end

--- a/spec/build/addons/mariadb_spec.rb
+++ b/spec/build/addons/mariadb_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Travis::Build::Addons::Mariadb, :sexp do
   let(:script) { stub('script') }
-  let(:config) { '10.0' }
+  let(:config) { '10.2' }
   let(:data)   { payload_for(:push, :ruby, config: { addons: { mariadb: config } }) }
   let(:sh)     { Travis::Shell::Builder.new }
   let(:addon)  { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
@@ -16,14 +16,14 @@ describe Travis::Build::Addons::Mariadb, :sexp do
   end
 
   it 'sets TRAVIS_MARIADB_VERSION' do
-    should include_sexp [:export,  ['TRAVIS_MARIADB_VERSION', '10.0']]
+    should include_sexp [:export,  ['TRAVIS_MARIADB_VERSION', '10.2']]
   end
 
   it { should include_sexp [:cmd, "service mysql stop", sudo: true] }
   it { should include_sexp [:cmd, "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 #{Travis::Build::Addons::Mariadb::MARIADB_GPG_KEY}", sudo: true] }
   it { should include_sexp [:cmd, 'add-apt-repository "deb http://%p/mariadb/repo/%p/ubuntu $(lsb_release -cs) main"' % [Travis::Build::Addons::Mariadb::MARIADB_MIRROR, config], sudo: true] }
   it { should include_sexp [:cmd, "apt-get update -qq", sudo: true] }
-  it { should include_sexp [:cmd, "apt-get install -y -o Dpkg::Options::='--force-confnew' mariadb-server mariadb-server-10.0 libmariadbclient-dev", sudo: true, echo: true, timing: true] }
+  it { should include_sexp [:cmd, "apt-get install -y -o Dpkg::Options::='--force-confnew' mariadb-server mariadb-server-10.2 libmariadbclient18", sudo: true, echo: true, timing: true] }
   it { should include_sexp [:cmd, "service mysql start", sudo: true, echo: true, timing: true] }
   it { should include_sexp [:cmd, "mysql --version", echo: true] }
 end


### PR DESCRIPTION
This revisits #552, #555, and commit 22c48698.

As of MariaDB 10.2, `libmariadbclient-dev` no longer pulls in `libmariadbclient18` as expected. All versions of MariaDB to date (all 5.x and 10.x including 10.3 alpha) provide `libmariadbclient18` as the client API major-number package.