### PR TITLE
Return "default" if none of pre-installed rubies match regexp

### DIFF
--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -135,10 +135,14 @@ travis_internal_ruby() {
   bash_qsort_numeric "${rubies_array[@]}"
   rubies_array_sorted=( ${bash_qsort_numeric_ret[@]} )
   rubies_array_len="${#rubies_array_sorted[@]}"
-  i=$(( rubies_array_len - 1 ))
-  selected_ruby="${rubies_array_sorted[${i}]}"
-  selected_ruby="${selected_ruby##*_}"
-  echo "${selected_ruby:-default}"
+  if (( rubies_array_len <= 0 )); then
+    echo "default"
+  else
+    i=$(( rubies_array_len - 1 ))
+    selected_ruby="${rubies_array_sorted[${i}]}"
+    selected_ruby="${selected_ruby##*_}"
+    echo "${selected_ruby:-default}"
+  fi
 }
 
 travis_assert() {


### PR DESCRIPTION
When looking for rubies that is desirable for `travis_internal_ruby`,
we only consider rubies that match the env `TRAVIS_BUILD_INTERNAL_RUBY_REGEX`.
As of 2017-06-29, this is one of 1.9.3, 2.0.x, 2.1.x, or 2.2.x.

If none of pre-installed rubies satisfies this assumption, the
local array rubies_array_len is empty, which leads to $i being -1.
This causes a confusing error message:

    /home/travis/.travis/job_stages: line 890: rubies_array_sorted: bad array subscript

This error message is benign, as the function will go on to echo
"default" in this case, but it is best not to show this.