### PR TITLE
Run `npm ls` for npm 5+

### DIFF
--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -6,6 +6,8 @@ module Travis
 
         YARN_REQUIRED_NODE_VERSION = '4'
 
+        NPM_QUIET_TREE_VERSION = '5'
+
         def export
           super
           if node_js_given_in_config?
@@ -196,7 +198,12 @@ module Travis
           end
 
           def npm_install(args)
-            sh.cmd "npm install #{args}", retry: true, fold: 'install'
+            sh.fold "install.pm" do
+              sh.cmd "npm install #{args}", retry: true
+              sh.if "$(vers2int `npm -v`) -gt $(vers2int #{NPM_QUIET_TREE_VERSION})" do
+                sh.cmd "npm ls", echo: true
+              end
+            end
           end
 
           def install_yarn

--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -198,7 +198,7 @@ module Travis
           end
 
           def npm_install(args)
-            sh.fold "install.pm" do
+            sh.fold "install.npm" do
               sh.cmd "npm install #{args}", retry: true
               sh.if "$(vers2int `npm -v`) -gt $(vers2int #{NPM_QUIET_TREE_VERSION})" do
                 sh.cmd "npm ls", echo: true


### PR DESCRIPTION
Starting with version 5, npm no longer displays dependency tree
when you run `npm install`.

As there is no single command that can produce the dependency tree for both
npm <= 4 and 5+, we check for the npm version, and run `npm ls` if
necessary.

This resolves https://github.com/travis-ci/travis-ci/issues/7991.