### PR TITLE
Let 'npm ls' fail

### DIFF
--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -201,7 +201,7 @@ module Travis
             sh.fold "install.npm" do
               sh.cmd "npm install #{args}", retry: true
               sh.if "$(vers2int `npm -v`) -gt $(vers2int #{NPM_QUIET_TREE_VERSION})" do
-                sh.cmd "npm ls", echo: true
+                sh.cmd "npm ls", echo: true, assert: false
               end
             end
           end


### PR DESCRIPTION
The command can fail with nonzero status when dependencies are not
met. This deviates from the previous desirable behavior, so we
let this command fail (but retain output).