### PR TITLE
Update firefox dev edition URL

### DIFF
--- a/lib/travis/build/addons/firefox.rb
+++ b/lib/travis/build/addons/firefox.rb
@@ -75,7 +75,7 @@ module Travis
               # The name 'aurora' is nickname for "developer edition",
               # documented in https://wiki.mozilla.org/Firefox/Channels#Developer_Edition_.28aka_Aurora.29
               # This may change in the future and break builds.
-              product = 'firefox-aurora-latest'
+              product = 'firefox-devedition-latest'
             when 'latest-nightly'
               product = 'firefox-nightly-latest'
             when 'latest-unsigned'


### PR DESCRIPTION
This just landed so this PR updates the ```product``` variable based on the new URL.

https://bugzilla.mozilla.org/show_bug.cgi?id=1357378