### PR TITLE
Run `rvm use` in configure

### DIFF
--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -24,7 +24,7 @@ module Travis
           sh.export 'TRAVIS_RUBY_VERSION', config[:rvm], echo: false if rvm?
         end
 
-        def setup
+        def configure
           super
           setup_rvm if rvm?
         end
@@ -94,13 +94,13 @@ module Travis
 
           def use_ruby_version_file
             sh.fold('rvm') do
-              sh.cmd 'rvm use $(< .ruby-version) --install --binary --fuzzy'
+              sh.cmd 'rvm use $(< .ruby-version) --install --binary --fuzzy', assert: true, echo: true, timing: true
             end
           end
 
           def use_rvm_default_ruby
             sh.fold('rvm') do
-              sh.cmd "rvm use default", timing: true
+              sh.cmd "rvm use default", assert: true, echo: true, timing: true
             end
           end
 
@@ -111,13 +111,13 @@ module Travis
                 sh.if "! $(rvm list | grep ree)" do
                   sh.echo "Installing REE from source. This may take a few minutes.", ansi: :yellow
                   sh.cmd "sed -i 's|^\\(ree_1.8.7_url\\)=.*$|\\1=https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/rubyenterpriseedition|' $HOME/.rvm/config/db"
-                  sh.cmd "rvm use #{ruby_version} --install --fuzzy"
+                  sh.cmd "rvm use #{ruby_version} --install --fuzzy", assert: true, echo: true, timing: true
                 end
                 sh.else do
-                  sh.cmd "rvm use #{ruby_version} --install --binary --fuzzy"
+                  sh.cmd "rvm use #{ruby_version} --install --binary --fuzzy", assert: true, echo: true, timing: true
                 end
               else
-                sh.cmd "rvm use #{ruby_version} --install --binary --fuzzy"
+                sh.cmd "rvm use #{ruby_version} --install --binary --fuzzy", assert: true, echo: true, timing: true
               end
             end
           end
@@ -127,7 +127,7 @@ module Travis
           end
 
           def skip_deps_install
-            sh.cmd "rvm autolibs disable", echo: false, timing: false
+            sh.cmd "rvm autolibs disable", assert: true
           end
 
           def write_default_gems
@@ -144,7 +144,7 @@ module Travis
             RVM_VERSION_ALIASES.select {|k,v| k == version}.each do |alias_version, real_version|
               grep_str = alias_version.gsub('.', '\\\\\\.')
               sh.if "-z $(rvm alias list | grep ^#{grep_str})" do
-                sh.cmd "rvm alias create #{alias_version} ruby-#{real_version}", echo: true, assert: true
+                sh.cmd "rvm alias create #{alias_version} ruby-#{real_version}", echo: true, assert: true, timing: true
               end
             end
           end


### PR DESCRIPTION
RVM resets certain environment variables to ensure that it can
set up Ruby environment correctly.
One such environment variable is $BUNDLE_PATH. If `.travis.yml`
attempts to set $BUNDLE_PATH in env, this is no longer effective
in the subsequent portions of the build. This is confusing.

We resolve this by moving `rvm …` commands to configure, so that
`export` is effective.