### PR TITLE
Add support for smalltalk_vm key

### DIFF
--- a/lib/travis/build/script/smalltalk.rb
+++ b/lib/travis/build/script/smalltalk.rb
@@ -1,5 +1,5 @@
-# Copyright (c) 2015-2016 Software Architecture Group (Hasso Plattner Institute)
-# Copyright (c) 2015-2016 Fabio Niephaus, Google Inc.
+# Copyright (c) 2015-2017 Software Architecture Group (Hasso Plattner Institute)
+# Copyright (c) 2015-2017 Fabio Niephaus, Google Inc.
 
 module Travis
   module Build
@@ -43,15 +43,16 @@ module Travis
 
         def export
           super
-          sh.export 'TRAVIS_SMALLTALK_VERSION', smalltalk_version, echo: false
           sh.export 'TRAVIS_SMALLTALK_CONFIG', smalltalk_config, echo: false
+          sh.export 'TRAVIS_SMALLTALK_VERSION', smalltalk_version, echo: false
+          sh.export 'TRAVIS_SMALLTALK_VM', smalltalk_vm, echo: false
         end
 
         def setup
           super
 
-          sh.echo 'Smalltalk for Travis-CI is not officially supported, ' \
-            'but is community maintained.', ansi: :green
+          sh.echo 'Smalltalk for Travis CI is not officially supported, ' \
+            'but is community-maintained.', ansi: :green
           sh.echo 'Please file any issues using the following link', ansi: :green
           sh.echo '  https://github.com/hpi-swa/smalltalkCI/issues', ansi: :green
 
@@ -82,12 +83,16 @@ module Travis
             config.fetch(:smalltalk_edge, {}).fetch(:branch, "master")
           end
 
+          def smalltalk_config
+            config[:smalltalk_config].to_s
+          end
+
           def smalltalk_version
             config[:smalltalk].to_s
           end
 
-          def smalltalk_config
-            config[:smalltalk_config].to_s
+          def smalltalk_vm
+            config[:smalltalk_vm].to_s
           end
 
           def is_squeak?

--- a/lib/travis/build/script/smalltalk.rb
+++ b/lib/travis/build/script/smalltalk.rb
@@ -6,26 +6,27 @@ module Travis
     class Script
       class Smalltalk < Script
         DEFAULTS = {}
+        DEFAULT_REPOSITORY = 'hpi-swa/smalltalkCI'
+        DEFAULT_BRANCH = 'master'
         HOSTS_FILE = '/etc/hosts'
         TEMP_HOSTS_FILE = '/tmp/hosts'
         SYSCTL_FILE = '/etc/sysctl.conf'
         TEMP_SYSCTL_FILE = '/tmp/sysctl.conf'
-        DEFAULT_DEPS = 'libc6:i386 libuuid1:i386 libfreetype6:i386 libssl1.0.0:i386'
-        PHARO_DEPS = DEFAULT_DEPS + ' libcairo2:i386'
+        DEFAULT_32BIT_DEPS = 'libc6:i386 libuuid1:i386 libfreetype6:i386 libssl1.0.0:i386'
+        PHARO_32BIT_DEPS = "#{DEFAULT_32BIT_DEPS} libcairo2:i386"
+        X64_REGEXP = /^[a-zA-Z]*64\-/
 
         def configure
           super
 
           if is_squeak? or is_etoys?
-            install_dependencies(DEFAULT_DEPS)
+            install_dependencies(DEFAULT_32BIT_DEPS)
           elsif is_pharo? or is_moose?
-            install_dependencies(PHARO_DEPS)
+            install_dependencies(PHARO_32BIT_DEPS)
           elsif is_gemstone?
-
             sh.fold 'gemstone_prepare_dependencies' do
               sh.echo 'Preparing build for GemStone', ansi: :yellow
               gemstone_configure_hosts
-
               case config[:os]
               when 'linux'
                 gemstone_prepare_linux_shared_memory
@@ -33,11 +34,9 @@ module Travis
               when 'osx'
                 gemstone_prepare_osx_shared_memory
               end
-
               gemstone_prepare_netldi
               gemstone_prepare_directories
             end
-
           end
         end
 
@@ -56,14 +55,14 @@ module Travis
           sh.echo 'Please file any issues using the following link', ansi: :green
           sh.echo '  https://github.com/hpi-swa/smalltalkCI/issues', ansi: :green
 
-          sh.cmd "pushd $HOME > /dev/null", echo: false
+          sh.cmd 'pushd $HOME > /dev/null', echo: false
           sh.fold 'download_smalltalkci' do
             sh.echo 'Downloading and extracting smalltalkCI', ansi: :yellow
-            sh.cmd "wget -q -O smalltalkCI.zip https://github.com/" + smalltalk_ci_repo + "/archive/" + smalltalk_ci_branch + ".zip"
-            sh.cmd "unzip -q -o smalltalkCI.zip"
-            sh.cmd "pushd smalltalkCI-* > /dev/null", echo: false
-            sh.cmd "source env_vars"
-            sh.cmd "popd > /dev/null; popd > /dev/null", echo: false
+            sh.cmd "wget -q -O smalltalkCI.zip #{download_url}"
+            sh.cmd 'unzip -q -o smalltalkCI.zip'
+            sh.cmd 'pushd smalltalkCI-* > /dev/null', echo: false
+            sh.cmd 'source env_vars'
+            sh.cmd 'popd > /dev/null; popd > /dev/null', echo: false
           end
         end
 
@@ -76,11 +75,11 @@ module Travis
         private
 
           def smalltalk_ci_repo
-            config.fetch(:smalltalk_edge, {}).fetch(:source, "hpi-swa/smalltalkCI")
+            config.fetch(:smalltalk_edge, {}).fetch(:source, DEFAULT_REPOSITORY)
           end
 
           def smalltalk_ci_branch
-            config.fetch(:smalltalk_edge, {}).fetch(:branch, "master")
+            config.fetch(:smalltalk_edge, {}).fetch(:branch, DEFAULT_BRANCH)
           end
 
           def smalltalk_config
@@ -93,6 +92,10 @@ module Travis
 
           def smalltalk_vm
             config[:smalltalk_vm].to_s
+          end
+
+          def download_url
+            "https://github.com/#{smalltalk_ci_repo}/archive/#{smalltalk_ci_branch}.zip"
           end
 
           def is_squeak?
@@ -116,11 +119,19 @@ module Travis
           end
 
           def is_platform?(name)
-            config[:smalltalk].to_s.downcase.start_with?(name)
+            smalltalk_version.downcase.start_with?(name)
           end
 
-          def install_dependencies(deps)
-            return if config[:os] != 'linux'
+          def is_linux?
+            config[:os] == 'linux'
+          end
+
+          def is_64bit?
+            smalltalk_version =~ X64_REGEXP || smalltalk_vm =~ X64_REGEXP
+          end
+
+          def install_dependencies(deps_32bit)
+            return if !is_linux? || is_64bit?
             sh.fold 'install_packages' do
               sh.echo 'Installing dependencies', ansi: :yellow
 
@@ -129,7 +140,7 @@ module Travis
               end
 
               sh.cmd 'sudo apt-get update -qq', retry: true
-              sh.cmd 'sudo apt-get install -y --no-install-recommends ' + deps, retry: true
+              sh.cmd "sudo apt-get install -y --no-install-recommends #{deps_32bit}", retry: true
             end
           end
 

--- a/spec/build/script/smalltalk_spec.rb
+++ b/spec/build/script/smalltalk_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Travis::Build::Script::Smalltalk, :sexp do
+  APT_GET_BASE = 'sudo apt-get install -y --no-install-recommends libc6:i386 libuuid1:i386 libfreetype6:i386 libssl1.0.0:i386'
+
   let(:data)      { payload_for(:push, :smalltalk) }
   let(:script)    { described_class.new(data) }
   let(:defaults)  { described_class::DEFAULTS }
@@ -12,12 +14,12 @@ describe Travis::Build::Script::Smalltalk, :sexp do
     let(:cmds) { ['$SMALLTALK_CI_HOME/run.sh'] }
   end
 
-  it "downloads and extracts correct script" do
-    should include_sexp [:cmd, "wget -q -O smalltalkCI.zip https://github.com/hpi-swa/smalltalkCI/archive/master.zip", assert: true, echo: true, timing: true]
-    should include_sexp [:cmd, "unzip -q -o smalltalkCI.zip", assert: true, echo: true, timing: true]
-    should include_sexp [:cmd, "pushd smalltalkCI-* > /dev/null", assert: true, timing: true]
-    should include_sexp [:cmd, "source env_vars", assert: true, echo: true, timing: true]
-    should include_sexp [:cmd, "popd > /dev/null; popd > /dev/null", assert: true, timing: true]
+  it 'downloads and extracts correct script' do
+    should include_sexp [:cmd, 'wget -q -O smalltalkCI.zip https://github.com/hpi-swa/smalltalkCI/archive/master.zip', assert: true, echo: true, timing: true]
+    should include_sexp [:cmd, 'unzip -q -o smalltalkCI.zip', assert: true, echo: true, timing: true]
+    should include_sexp [:cmd, 'pushd smalltalkCI-* > /dev/null', assert: true, timing: true]
+    should include_sexp [:cmd, 'source env_vars', assert: true, echo: true, timing: true]
+    should include_sexp [:cmd, 'popd > /dev/null; popd > /dev/null', assert: true, timing: true]
   end
 
   describe 'using edge versions' do
@@ -27,27 +29,58 @@ describe Travis::Build::Script::Smalltalk, :sexp do
       data[:config][:smalltalk_edge][:branch] = 'dev'
     end
     it 'installs the correct script' do
-      should include_sexp [:cmd, "wget -q -O smalltalkCI.zip https://github.com/HPI-BP2015H/smalltalkCI/archive/dev.zip", assert: true, echo: true, timing: true]
+      should include_sexp [:cmd, 'wget -q -O smalltalkCI.zip https://github.com/HPI-BP2015H/smalltalkCI/archive/dev.zip', assert: true, echo: true, timing: true]
     end
   end
 
-  describe 'Squeak on Linux' do
+  describe 'Squeak-5.0 on Linux' do
     before do
       data[:config][:smalltalk] = 'Squeak-5.0'
       data[:config][:os] = 'linux'
     end
     it 'installs default dependencies' do
-      should include_sexp [:cmd, "sudo apt-get install -y --no-install-recommends libc6:i386 libuuid1:i386 libfreetype6:i386 libssl1.0.0:i386", retry: true]
+      should include_sexp [:cmd, APT_GET_BASE, retry: true]
     end
   end
 
-  describe 'Pharo on Linux' do
+  describe 'Squeak64-5.0 on Linux' do
+    before do
+      data[:config][:smalltalk] = 'Squeak64-5.0'
+      data[:config][:os] = 'linux'
+    end
+    it 'does not try to call apt-get' do
+      should_not include_sexp [:cmd, APT_GET_BASE, retry: true]
+    end
+  end
+
+  describe 'Squeak-5.0 with Squeak64-5.0 vm on Linux' do
+    before do
+      data[:config][:smalltalk] = 'Squeak-5.0'
+      data[:config][:smalltalk_vm] = 'Squeak64-5.0'
+      data[:config][:os] = 'linux'
+    end
+    it 'does not try to call apt-get' do
+      should_not include_sexp [:cmd, APT_GET_BASE, retry: true]
+    end
+  end
+
+  describe 'Pharo-5.0 on Linux' do
     before do
       data[:config][:smalltalk] = 'Pharo-5.0'
       data[:config][:os] = 'linux'
     end
     it 'installs Pharo dependencies' do
-      should include_sexp [:cmd, "sudo apt-get install -y --no-install-recommends libc6:i386 libuuid1:i386 libfreetype6:i386 libssl1.0.0:i386 libcairo2:i386", retry: true]
+      should include_sexp [:cmd, "#{APT_GET_BASE} libcairo2:i386", retry: true]
+    end
+  end
+
+  describe 'Pharo64-6.0 on Linux' do
+    before do
+      data[:config][:smalltalk] = 'Pharo64-6.0'
+      data[:config][:os] = 'linux'
+    end
+    it 'installs Pharo dependencies' do
+      should_not include_sexp [:cmd, "#{APT_GET_BASE} libcairo2:i386", retry: true]
     end
   end
 
@@ -57,7 +90,7 @@ describe Travis::Build::Script::Smalltalk, :sexp do
       data[:config][:os] = 'osx'
     end
     it 'does not try to call apt-get' do
-      should_not include_sexp [:cmd, "sudo apt-get install -y --no-install-recommends libc6:i386 libuuid1:i386 libfreetype6:i386 libssl1.0.0:i386", retry: true]
+      should_not include_sexp [:cmd, APT_GET_BASE, retry: true]
     end
   end
 
@@ -70,7 +103,7 @@ describe Travis::Build::Script::Smalltalk, :sexp do
 
     it 'set hostname' do
       should include_sexp [:cmd, "sed -e \"s/^\\(127\\.0\\.0\\.1.*\\)$/\\1 $(hostname)/\" /etc/hosts | sed -e \"s/^\\(::1.*\\)$/\\1 $(hostname)/\" > /tmp/hosts"]
-      should include_sexp [:cmd, "cat /tmp/hosts | sudo tee /etc/hosts > /dev/null"]
+      should include_sexp [:cmd, 'cat /tmp/hosts | sudo tee /etc/hosts > /dev/null']
     end
 
     it 'prepare shared memory' do
@@ -83,9 +116,9 @@ describe Travis::Build::Script::Smalltalk, :sexp do
     end
 
     it 'installs the dependencies' do
-      should include_sexp [:cmd, "sudo apt-get install -y --no-install-recommends " +
-                     "libpam0g:i386 libssl1.0.0:i386 gcc-multilib libstdc++6:i386 " +
-                     "libfreetype6:i386 pstack libgl1-mesa-glx:i386 libxcb-dri2-0:i386", retry: true]
+      should include_sexp [:cmd, 'sudo apt-get install -y --no-install-recommends ' +
+                     'libpam0g:i386 libssl1.0.0:i386 gcc-multilib libstdc++6:i386 ' +
+                     'libfreetype6:i386 pstack libgl1-mesa-glx:i386 libxcb-dri2-0:i386', retry: true]
     end
   end
 
@@ -111,7 +144,7 @@ describe Travis::Build::Script::Smalltalk, :sexp do
     end
 
     it 'does not try to call apt-get' do
-      should_not include_sexp [:cmd, "apt-get", retry: true]
+      should_not include_sexp [:cmd, 'apt-get', retry: true]
     end
   end
 

--- a/spec/build/script/smalltalk_spec.rb
+++ b/spec/build/script/smalltalk_spec.rb
@@ -135,4 +135,14 @@ describe Travis::Build::Script::Smalltalk, :sexp do
     end
   end
 
+  describe 'set smalltalk vm' do
+    before do
+      data[:config][:smalltalk_vm] = 'Pharo-vmLatest70'
+    end
+
+    it 'sets TRAVIS_SMALLTALK_VM' do
+      should include_sexp [:export, ['TRAVIS_SMALLTALK_VM', 'Pharo-vmLatest70']]
+    end
+  end
+
 end


### PR DESCRIPTION
This will allow our users to choose a specific virtual machine for their Smalltalk builds on Travis.

Related PR for `travis-core`: https://github.com/travis-ci/travis-core/issues/567.