### PR TITLE
Map lang 'minimal' to the Generic script

### DIFF
--- a/lib/travis/build.rb
+++ b/lib/travis/build.rb
@@ -38,7 +38,7 @@ module Travis
           Script::Cpp
         when 'objective-c', 'swift' then
           Script::ObjectiveC
-        when 'bash', 'sh', 'shell' then
+        when 'bash', 'sh', 'shell', 'minimal' then
           Script::Generic
         else
           name = lang.split('_').map { |w| w.capitalize }.join

--- a/spec/build_spec.rb
+++ b/spec/build_spec.rb
@@ -13,7 +13,7 @@ describe Travis::Build do
       D: ['d'],
       Dart: ['dart'],
       Erlang: ['erlang'],
-      Generic: ['generic', 'bash', 'sh', 'shell'],
+      Generic: ['generic', 'bash', 'sh', 'shell', 'minimal'],
       Go: ['go'],
       Groovy: ['groovy'],
       Haskell: ['haskell'],

--- a/spec/build_spec.rb
+++ b/spec/build_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe Travis::Build do
+  describe '.by_lang' do
+
+    {
+      Android: ['android'],
+      C: ['c'],
+      Clojure: ['clojure'],
+      Cpp: ['cpp', 'c++', 'cplusplus'],
+      Crystal: ['crystal'],
+      Csharp: ['csharp'],
+      D: ['d'],
+      Dart: ['dart'],
+      Erlang: ['erlang'],
+      Generic: ['generic', 'bash', 'sh', 'shell'],
+      Go: ['go'],
+      Groovy: ['groovy'],
+      Haskell: ['haskell'],
+      Haxe: ['haxe'],
+      Julia: ['julia'],
+      Nix: ['nix'],
+      NodeJs: ['node_js'],
+      ObjectiveC: ['objective_c', 'objective-c', 'swift'],
+      Perl6: ['perl6'],
+      Perl: ['perl'],
+      Php: ['php'],
+      PureJava: ['java', 'java-anything'],
+      Python: ['python'],
+      R: ['r'],
+      Ruby: ['ruby'],
+      Rust: ['rust'],
+      Scala: ['scala'],
+      Smalltalk: ['smalltalk'],
+    }.each do |script_type, langs|
+      langs.each do |lang|
+        it "returns #{script_type} for #{lang}" do
+          expect(described_class.by_lang(lang)).to eq(Travis::Build::Script.const_get(script_type))
+        end
+      end
+    end
+
+    it 'returns Ruby for unknown languages' do
+      expect(described_class.by_lang('foo')).to eq(Travis::Build::Script::Ruby)
+    end
+
+  end
+end


### PR DESCRIPTION
Previously it returned the fallback of Ruby.
See travis-ci/docs-travis-ci-com#1267.

Also adds specs for Travis::Build.by_lang(), since the previous specs were removed in #320 (presumably unintentionally).