### PR TITLE
Use Dart SDK's formatter by default, not custom.

### DIFF
--- a/lib/travis/build/script/dart.rb
+++ b/lib/travis/build/script/dart.rb
@@ -230,11 +230,10 @@ MESSAGE
           def dartfmt
             args = task[:dartfmt]
 
-            if args.is_a?(String)
-              sh.echo "dartfmt arguments aren't supported.", ansi: :red
-            end
-
-            sh.if package_direct_dependency?('dart_style'), raw: true do
+            # If specified `-dartfmt: custom` and there is a dependency on `dart_style` we
+            # will use the custom (pinned) version of dart_style to run formatting checks
+            # instead of the SDK.
+            sh.if args == 'custom' and package_direct_dependency?('dart_style'), raw: true do
               sh.raw 'function dartfmt() { pub run dart_style:format "$@"; }'
             end
 

--- a/lib/travis/build/script/dart.rb
+++ b/lib/travis/build/script/dart.rb
@@ -234,7 +234,7 @@ MESSAGE
             # will use the SDK version of dart_style to run formatting checks instead of
             # the custom pinned version.
             if args != 'sdk'
-              if args.is_a?(String)
+              if !args.nil?
                 sh.echo "dartfmt only supports 'sdk' as an optional argument value.", ansi: :red
               end
               sh.if package_direct_dependency?('dart_style'), raw: true do

--- a/lib/travis/build/script/dart.rb
+++ b/lib/travis/build/script/dart.rb
@@ -233,8 +233,15 @@ MESSAGE
             # If specified `-dartfmt: custom` and there is a dependency on `dart_style` we
             # will use the custom (pinned) version of dart_style to run formatting checks
             # instead of the SDK.
-            sh.if args == 'custom' and package_direct_dependency?('dart_style'), raw: true do
-              sh.raw 'function dartfmt() { pub run dart_style:format "$@"; }'
+            if args == 'custom'
+              sh.if package_direct_dependency?('dart_style'), raw: true do
+                sh.raw 'function dartfmt() { pub run dart_style:format "$@"; }'
+              end
+              sh.else do
+                sh.failure "Since 'custom' was used as the dartfmt argument, you should directly depend on dart_style in pubspec.yaml"
+              end
+            elsif args.is_a?(String)
+              sh.echo "dartfmt only supports 'custom' as an optional argument value.", ansi: :red
             end
 
             sh.cmd 'unformatted=`dartfmt -n .`'

--- a/lib/travis/build/script/dart.rb
+++ b/lib/travis/build/script/dart.rb
@@ -230,15 +230,14 @@ MESSAGE
           def dartfmt
             args = task[:dartfmt]
 
-            # If specified `-dartfmt: custom` and there is a dependency on `dart_style` we
-            # will use the custom (pinned) version of dart_style to run formatting checks
-            # instead of the SDK.
-            if args == 'custom'
+            # If specified `-dartfmt: sdk` and there is a dependency on `dart_style` we
+            # will use the SDK version of dart_style to run formatting checks instead of
+            # the custom pinned version.
+            if args != 'sdk'
               sh.if package_direct_dependency?('dart_style'), raw: true do
+                sh.echo 'Using the provided dart_style package to run format instead of the SDK.'
+                sh.echo "You may specify '- dartfmt: sdk' in order to use the SDK version instead"
                 sh.raw 'function dartfmt() { pub run dart_style:format "$@"; }'
-              end
-              sh.else do
-                sh.failure "Since 'custom' was used as the dartfmt argument, you should directly depend on dart_style in pubspec.yaml"
               end
             elsif args.is_a?(String)
               sh.echo "dartfmt only supports 'custom' as an optional argument value.", ansi: :red

--- a/lib/travis/build/script/dart.rb
+++ b/lib/travis/build/script/dart.rb
@@ -240,7 +240,7 @@ MESSAGE
                 sh.raw 'function dartfmt() { pub run dart_style:format "$@"; }'
               end
             elsif args.is_a?(String)
-              sh.echo "dartfmt only supports 'custom' as an optional argument value.", ansi: :red
+              sh.echo "dartfmt only supports 'sdk' as an optional argument value.", ansi: :red
             end
 
             sh.cmd 'unformatted=`dartfmt -n .`'

--- a/lib/travis/build/script/dart.rb
+++ b/lib/travis/build/script/dart.rb
@@ -234,13 +234,14 @@ MESSAGE
             # will use the SDK version of dart_style to run formatting checks instead of
             # the custom pinned version.
             if args != 'sdk'
+              if args.is_a?(String)
+                sh.echo "dartfmt only supports 'sdk' as an optional argument value.", ansi: :red
+              end
               sh.if package_direct_dependency?('dart_style'), raw: true do
                 sh.echo 'Using the provided dart_style package to run format instead of the SDK.'
                 sh.echo "You may specify '- dartfmt: sdk' in order to use the SDK version instead"
                 sh.raw 'function dartfmt() { pub run dart_style:format "$@"; }'
               end
-            elsif args.is_a?(String)
-              sh.echo "dartfmt only supports 'sdk' as an optional argument value.", ansi: :red
             end
 
             sh.cmd 'unformatted=`dartfmt -n .`'

--- a/spec/build/script/dart_spec.rb
+++ b/spec/build/script/dart_spec.rb
@@ -243,7 +243,9 @@ describe Travis::Build::Script::Dart, :sexp do
     describe 'with dartfmt' do
       before { data[:config][:dart_task] = 'dartfmt' }
 
-      describe 'when dart_style is installed' do
+      describe 'when dart_style is installed and dartfmt: custom' do
+        before { data[:config][:dart_task] - {dartfmt: 'custom'} }
+
         let(:sexp) { sexp_find(subject, [:elif, "[[ -f pubspec.yaml ]] && (pub deps | grep -q \"^[|']-- dart_style \")"]) }
         it "runs the installed version of dartfmt" do
           should include_sexp [:raw, 'function dartfmt() { pub run dart_style:format "$@"; }']

--- a/spec/build/script/dart_spec.rb
+++ b/spec/build/script/dart_spec.rb
@@ -244,7 +244,7 @@ describe Travis::Build::Script::Dart, :sexp do
       before { data[:config][:dart_task] = 'dartfmt' }
 
       describe 'when dart_style is installed and dartfmt: custom' do
-        before { data[:config][:dart_task] - {dartfmt: 'custom'} }
+        before { data[:config][:dart_task] = {dartfmt: 'custom'} }
 
         let(:sexp) { sexp_find(subject, [:elif, "[[ -f pubspec.yaml ]] && (pub deps | grep -q \"^[|']-- dart_style \")"]) }
         it "runs the installed version of dartfmt" do

--- a/spec/build/script/dart_spec.rb
+++ b/spec/build/script/dart_spec.rb
@@ -251,7 +251,7 @@ describe Travis::Build::Script::Dart, :sexp do
       end
 
       describe 'when dart_style is installed but darfmt: sdk is specified' do
-        before { data[:config][:dart_task] = {dartfmt: 'custom'} }
+        before { data[:config][:dart_task] = {dartfmt: 'sdk'} }
         let(:sexp) { sexp_find(subject, [:elif, "[[ -f pubspec.yaml ]] && (pub deps | grep -q \"^[|']-- dart_style \")"]) }
         it "runs the SDK version of dartfmt" do
           should match_sexp [:cmd, /dartfmt -n \./]

--- a/spec/build/script/dart_spec.rb
+++ b/spec/build/script/dart_spec.rb
@@ -243,12 +243,18 @@ describe Travis::Build::Script::Dart, :sexp do
     describe 'with dartfmt' do
       before { data[:config][:dart_task] = 'dartfmt' }
 
-      describe 'when dart_style is installed and dartfmt: custom' do
-        before { data[:config][:dart_task] = {dartfmt: 'custom'} }
-
+      describe 'when dart_style is installed but dartfmt: sdk is not specified' do
         let(:sexp) { sexp_find(subject, [:elif, "[[ -f pubspec.yaml ]] && (pub deps | grep -q \"^[|']-- dart_style \")"]) }
         it "runs the installed version of dartfmt" do
           should include_sexp [:raw, 'function dartfmt() { pub run dart_style:format "$@"; }']
+        end
+      end
+
+      describe 'when dart_style is installed but darfmt: sdk is specified' do
+        before { data[:config][:dart_task] = {dartfmt: 'custom'} }
+        let(:sexp) { sexp_find(subject, [:elif, "[[ -f pubspec.yaml ]] && (pub deps | grep -q \"^[|']-- dart_style \")"]) }
+        it "runs the SDK version of dartfmt" do
+          should match_sexp [:cmd, /dartfmt -n \./]
         end
       end
 


### PR DESCRIPTION
As discussed on https://github.com/dart-lang/dart_style/issues/643.

The previous behavior meant if you depended on the dart formatter package (`dart_style`) you automatically ran formatter checks using the version you pinned to. This is not the behavior any user expects.

To get this behavior, you can add the following to `.travis.yml`:

```yaml
- dartfmt: custom
```