### PR TITLE
Keep `rvm current` STDOUT

### DIFF
--- a/lib/travis/build/script/shared/directory_cache/base.rb
+++ b/lib/travis/build/script/shared/directory_cache/base.rb
@@ -102,7 +102,7 @@ module Travis
           end
 
           def run_rvm_use
-            sh.raw "rvm use $(rvm current >&/dev/null) >&/dev/null"
+            sh.raw "rvm use $(rvm current 2>/dev/null) >&/dev/null"
           end
 
           def install


### PR DESCRIPTION
When setting up `casher`, ensure that we retain the output from `rvm
current`. If we sent it to `/dev/null`, we effectively run `rvm use`,
which will respect `.ruby-version` if it is present, and if this
version is pre-installed, that version is selected, even though we had
previously switched to a different version.

This resolves https://github.com/travis-ci/travis-ci/issues/8069