### PR TITLE
Introduce hide_secrets_in_debug config

### DIFF
--- a/lib/travis/build/config.rb
+++ b/lib/travis/build/config.rb
@@ -47,6 +47,7 @@ module Travis
           )
         },
         go_version: ENV.fetch('TRAVIS_BUILD_GO_VERSION', '1.8.3'),
+        hide_secrets_in_debug: ENV.fetch('TRAVIS_BUILD_HIDE_SECRETS_IN_DEBUG', ''),
         internal_ruby_regex: ENV.fetch(
           'TRAVIS_BUILD_INTERNAL_RUBY_REGEX',
           '^ruby-(2\.[0-2]\.[0-9]|1\.9\.3)'


### PR DESCRIPTION
If set (in public setting), skip secure env vars when running in
debug mode, so that the log can be public.