### PR TITLE
Nix: fix macOS install by using 'yes'

### DIFF
--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -27,6 +27,8 @@ module Travis
             sh.cmd "sudo mount -o remount,exec /run/user"
             sh.cmd "sudo mkdir -p -m 0755 /nix/"
             sh.cmd "sudo chown $USER /nix/"
+            # Set nix config dir and make config Hydra compatible
+            sh.cmd "echo 'build-max-jobs = 4' | sudo tee /etc/nix/nix.conf > /dev/null"
           end
         end
 
@@ -37,14 +39,13 @@ module Travis
             sh.cmd "wget --retry-connrefused --waitretry=1 -O /tmp/nix-install https://nixos.org/nix/install"
             sh.cmd "yes | sh /tmp/nix-install"
 
-            # Set nix config dir and make config Hydra compatible
-            sh.cmd "sudo sed -i.bak '/build-max-jobs/d' /etc/nix/nix.conf"
-            sh.cmd "echo 'build-max-jobs = 4' | sudo tee -a /etc/nix/nix.conf > /dev/null"
-
-            # single-user install (linux)
-            sh.cmd '[ -e "$HOME/.nix-profile/etc/profile.d/nix.sh" ] && source $HOME/.nix-profile/etc/profile.d/nix.sh'
-            # multi-user install (macos)
-            sh.cmd '[ -e "/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh" ] && source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
+            if config[:os] == 'linux'
+              # single-user install (linux)
+              sh.cmd 'source $HOME/.nix-profile/etc/profile.d/nix.sh'
+            else
+              # multi-user install (macos)
+              sh.cmd 'source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
+            end
           end
         end
 

--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -36,7 +36,7 @@ module Travis
             sh.cmd "yes | sh /tmp/nix-install"
 
             # Set nix config dir and make config Hydra compatible
-            sh.cmd "sed -i '/build-max-jobs/d' /etc/nix/nix.conf"
+            sh.cmd "sed -i.bak '/build-max-jobs/d' /etc/nix/nix.conf"
             sh.cmd "echo 'build-max-jobs = 4' | sudo tee -a /etc/nix/nix.conf > /dev/null"
 
             # single-user install (linux)

--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -34,11 +34,15 @@ module Travis
           sh.fold 'nix.install' do
             sh.cmd "wget --retry-connrefused --waitretry=1 -O /tmp/nix-install https://nixos.org/nix/install"
             sh.cmd "yes | sh /tmp/nix-install"
-            sh.cmd "source $HOME/.nix-profile/etc/profile.d/nix.sh"
 
             # Set nix config dir and make config Hydra compatible
             sh.cmd "sed -i '/build-max-jobs/d' /etc/nix/nix.conf"
             sh.cmd "echo 'build-max-jobs = 4' | sudo tee -a /etc/nix/nix.conf > /dev/null"
+
+            # single-user install (linux)
+            sh.cmd '[ -e "$HOME/.nix-profile/etc/profile.d/nix.sh"" ] && source $HOME/.nix-profile/etc/profile.d/nix.sh'
+            # multi-user install (macos)
+            sh.cmd '[ -e "/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh" ] && source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
           end
         end
 

--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -19,10 +19,6 @@ module Travis
         def configure
           super
 
-          # Set nix config dir and make config Hydra compatible
-          sh.cmd "sudo mkdir -p /etc/nix"
-          sh.cmd "echo 'build-max-jobs = 4' | sudo tee /etc/nix/nix.conf > /dev/null"
-
           # Nix needs to be able to exec on /tmp on Linux
           # This will emit an error in the container but
           # it's still needed for "trusty" Linux.
@@ -39,6 +35,10 @@ module Travis
             sh.cmd "wget --retry-connrefused --waitretry=1 -O /tmp/nix-install https://nixos.org/nix/install"
             sh.cmd "yes | sh /tmp/nix-install"
             sh.cmd "source $HOME/.nix-profile/etc/profile.d/nix.sh"
+
+            # Set nix config dir and make config Hydra compatible
+            sh.cmd "sed -i '/build-max-jobs/d' /etc/nix/nix.conf"
+            sh.cmd "echo 'build-max-jobs = 4' | sudo tee -a /etc/nix/nix.conf > /dev/null"
           end
         end
 

--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -41,7 +41,7 @@ module Travis
             sh.cmd "yes | sh /tmp/nix-install"
 
             # Set nix config dir and make config Hydra compatible
-            sh.cmd "sed -i.bak '/build-max-jobs/d' /etc/nix/nix.conf"
+            sh.cmd "sudo sed -i.bak '/build-max-jobs/d' /etc/nix/nix.conf"
             sh.cmd "echo 'build-max-jobs = 4' | sudo tee -a /etc/nix/nix.conf > /dev/null"
 
             # single-user install (linux)

--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -25,6 +25,8 @@ module Travis
           if config[:os] == 'linux'
             sh.cmd "sudo mount -o remount,exec /run"
             sh.cmd "sudo mount -o remount,exec /run/user"
+            sh.cmd "sudo mkdir -p -m 0755 /nix/"
+            sh.cmd "sudo chown $USER /nix/"
           end
         end
 
@@ -32,11 +34,6 @@ module Travis
           super
 
           sh.fold 'nix.install' do
-            sh.if "$TRAVIS_OS_NAME = linux" do
-              sh.cmd "sudo mkdir -p -m 0755 /nix/"
-              sh.cmd "sudo chown $USER /nix/"
-            end
-
             sh.cmd "wget --retry-connrefused --waitretry=1 -O /tmp/nix-install https://nixos.org/nix/install"
             sh.cmd "yes | sh /tmp/nix-install"
 
@@ -45,7 +42,7 @@ module Travis
             sh.cmd "echo 'build-max-jobs = 4' | sudo tee -a /etc/nix/nix.conf > /dev/null"
 
             # single-user install (linux)
-            sh.cmd '[ -e "$HOME/.nix-profile/etc/profile.d/nix.sh"" ] && source $HOME/.nix-profile/etc/profile.d/nix.sh'
+            sh.cmd '[ -e "$HOME/.nix-profile/etc/profile.d/nix.sh" ] && source $HOME/.nix-profile/etc/profile.d/nix.sh'
             # multi-user install (macos)
             sh.cmd '[ -e "/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh" ] && source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
           end

--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -32,6 +32,11 @@ module Travis
           super
 
           sh.fold 'nix.install' do
+            sh.if "$TRAVIS_OS_NAME = linux" do
+              sh.cmd "sudo mkdir -p -m 0755 /nix/"
+              sh.cmd "sudo chown $USER /nix/"
+            end
+
             sh.cmd "wget --retry-connrefused --waitretry=1 -O /tmp/nix-install https://nixos.org/nix/install"
             sh.cmd "yes | sh /tmp/nix-install"
 

--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -30,10 +30,6 @@ module Travis
             sh.cmd "sudo mount -o remount,exec /run"
             sh.cmd "sudo mount -o remount,exec /run/user"
           end
-
-          # setup /nix dir for rootless install in setup
-          sh.cmd "sudo mkdir -p -m 0755 /nix/"
-          sh.cmd "sudo chown $USER /nix/"
         end
 
         def setup
@@ -41,7 +37,7 @@ module Travis
 
           sh.fold 'nix.install' do
             sh.cmd "wget --retry-connrefused --waitretry=1 -O /tmp/nix-install https://nixos.org/nix/install"
-            sh.cmd "sh /tmp/nix-install"
+            sh.cmd "yes | sh /tmp/nix-install"
             sh.cmd "source $HOME/.nix-profile/etc/profile.d/nix.sh"
           end
         end


### PR DESCRIPTION
Nix 1.11.12 was released that uses interactive mode for macOS, so this commit fixes that.

I haven't tested this change, so if @BanzaiMan can deploy it to staging I'm happy to give it a spin.

cc @garbas @matthewbauer 