### PR TITLE
Catch all runtime errors in deploy config

### DIFF
--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -39,10 +39,8 @@ module Travis
 
             @allow_failure = config.delete(:allow_failure)
 
-          rescue TypeError => e
-            if e.message =~ /no implicit conversion of Symbol into String/
-              raise Travis::Build::DeployConfigError.new
-            end
+          rescue
+            raise Travis::Build::DeployConfigError.new
           end
 
           def deploy


### PR DESCRIPTION
All exceptions we see here should be due to errors in `deploy` value, and giving
a broad error message makes sense.