### PR TITLE
Kill processes owned by $USER which were started during the build

### DIFF
--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -171,6 +171,9 @@ travis_terminate() {
       && sync \
       && command exec 1>&9 2>&9 9>&- \
       && sync
+  TMPDIR=$(mktemp -d)
+  pgrep -u $USER | grep -v -w $$ > $TMPDIR/pids
+  pkill -9 -F $TMPDIR/pids
   pkill -9 -P $$ &> /dev/null || true
   exit $1
 }

--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -175,7 +175,6 @@ travis_terminate() {
       && sync \
       && command exec 1>&9 2>&9 9>&- \
       && sync
-  TMPDIR=$(mktemp -d)
   pgrep -u $USER | grep -v -w $$ > $TRAVIS_TMPDIR/pids_after
   diff --unchanged-line-format='' --new-line-format="%L" \
     --old-line-format='' $TRAVIS_TMPDIR/pids_before $TRAVIS_TMPDIR/pids_after > $TRAVIS_TMPDIR/pids

--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -176,7 +176,7 @@ travis_terminate() {
       && command exec 1>&9 2>&9 9>&- \
       && sync
   pgrep -u $USER | grep -v -w $$ > $TRAVIS_TMPDIR/pids_after
-  kill -9 $(awk 'NR==FNR{a[$1]++;next};!($1 in a)' <$TRAVIS_TMPDIR/pids_{before,after})
+  kill -9 $(awk 'NR==FNR{a[$1]++;next};!($1 in a)' $TRAVIS_TMPDIR/pids_{before,after}) || true
   pkill -9 -P $$ &> /dev/null || true
   exit $1
 }

--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -176,9 +176,7 @@ travis_terminate() {
       && command exec 1>&9 2>&9 9>&- \
       && sync
   pgrep -u $USER | grep -v -w $$ > $TRAVIS_TMPDIR/pids_after
-  diff --unchanged-line-format='' --new-line-format="%L" \
-    --old-line-format='' $TRAVIS_TMPDIR/pids_before $TRAVIS_TMPDIR/pids_after > $TRAVIS_TMPDIR/pids
-  pkill -9 -F $TRAVIS_TMPDIR/pids &> /dev/null
+  kill -9 $(awk 'NR==FNR{a[$1]++;next};!($1 in a)' <$TRAVIS_TMPDIR/pids_{before,after})
   pkill -9 -P $$ &> /dev/null || true
   exit $1
 }

--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -33,7 +33,7 @@ TRAVIS_CMD=
 
 if [ -f /.dockerenv ]; then
   TRAVIS_TMPDIR=$(mktemp -d)
-  pgrep -u $USER | grep -v -w $$ > $TRAVIS_TMPDIR/pids_before
+  pgrep -u $USER > $TRAVIS_TMPDIR/pids_before
 fi
 
 travis_cmd() {

--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -31,6 +31,10 @@ export USER
 TRAVIS_TEST_RESULT=
 TRAVIS_CMD=
 
+TRAVIS_TMPDIR=$(mktemp -d)
+
+pgrep -u $USER | grep -v -w $$ > $TRAVIS_TMPDIR/pids_before
+
 travis_cmd() {
   local assert output display retry timing cmd result secure
 
@@ -172,8 +176,10 @@ travis_terminate() {
       && command exec 1>&9 2>&9 9>&- \
       && sync
   TMPDIR=$(mktemp -d)
-  pgrep -u $USER | grep -v -w $$ > $TMPDIR/pids
-  pkill -9 -F $TMPDIR/pids
+  pgrep -u $USER | grep -v -w $$ > $TRAVIS_TMPDIR/pids_after
+  diff --unchanged-line-format='' --new-line-format="%L" \
+    --old-line-format='' $TRAVIS_TMPDIR/pids_before $TRAVIS_TMPDIR/pids_after > $TRAVIS_TMPDIR/pids
+  pkill -9 -F $TRAVIS_TMPDIR/pids &> /dev/null
   pkill -9 -P $$ &> /dev/null || true
   exit $1
 }

--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -33,7 +33,7 @@ TRAVIS_CMD=
 
 if [ -f /.dockerenv ]; then
   TRAVIS_TMPDIR=$(mktemp -d)
-  pgrep -u $USER > $TRAVIS_TMPDIR/pids_before
+  pgrep -u $USER | grep -v -w $$ > $TRAVIS_TMPDIR/pids_before
 fi
 
 travis_cmd() {


### PR DESCRIPTION
https://github.com/travis-ci/travis-ci/issues/8082 describes an issue where jobs do not get terminated by the Docker host when the filter is in play and background processes are still running.

This PR aims to resolve this by comparing the processes owned by `$USER` before and after the build.