### PR TITLE
Obtain RethinkDB GPG key directly from https://download.rethinkdb.com/apt/pubkey.gpg

### DIFF
--- a/lib/travis/build/addons/rethinkdb.rb
+++ b/lib/travis/build/addons/rethinkdb.rb
@@ -7,8 +7,6 @@ module Travis
       class Rethinkdb < Base
         SUPER_USER_SAFE = true
 
-        RETHINKDB_GPG_KEY = '0x3A8F2399'
-
         def after_prepare
           sh.fold 'rethinkdb' do
             sh.if "$(uname) != 'Linux'" do
@@ -17,7 +15,7 @@ module Travis
             sh.else do
               sh.echo "Installing RethinkDB version #{rethinkdb_version}", ansi: :yellow
               sh.cmd "service rethinkdb stop", sudo: true
-              sh.cmd "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 #{RETHINKDB_GPG_KEY}", sudo: true
+              sh.cmd "wget -qO- https://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -v -''", echo: true
               sh.cmd 'echo -e "\ndeb http://download.rethinkdb.com/apt $(lsb_release -cs) main" | sudo tee -a /etc/apt/sources.list > /dev/null'
               sh.cmd "apt-get update -qq", assert: false, sudo: true
               sh.cmd "package_version=`apt-cache show rethinkdb | grep -F \"Version: #{rethinkdb_version}\" | sort -r | head -n 1 | awk '{printf $2}'`"

--- a/spec/build/addons/rethinkdb_spec.rb
+++ b/spec/build/addons/rethinkdb_spec.rb
@@ -24,7 +24,7 @@ describe Travis::Build::Addons::Rethinkdb, :sexp do
   end
 
   it { should include_sexp [:cmd, "service rethinkdb stop", sudo: true] }
-  it { should include_sexp [:cmd, "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 #{Travis::Build::Addons::Rethinkdb::RETHINKDB_GPG_KEY}", sudo: true] }
+  it { should include_sexp [:cmd, "wget -qO- https://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -v -''", echo: true] }
   it { should include_sexp [:cmd, 'echo -e "\ndeb http://download.rethinkdb.com/apt $(lsb_release -cs) main" | sudo tee -a /etc/apt/sources.list > /dev/null'] }
   it { should include_sexp [:cmd, "apt-get update -qq", sudo: true] }
   it { should include_sexp [:cmd, "apt-get install -y -o Dpkg::Options::='--force-confnew' rethinkdb=$package_version", sudo: true, echo: true, timing: true] }


### PR DESCRIPTION
As explained in https://rethinkdb.com/docs/install/ubuntu/:

> If you followed the above instructions before July 2017 and want to
> upgrade to a newer version of RethinkDB, you will need to first
> download the new key (0742918E5C8DA04A)

Resolves https://github.com/travis-ci/travis-ci/issues/8122.