### PR TITLE
Add shebang line to /usr/bin/sudo replacement script

### DIFF
--- a/lib/travis/build/appliances/disable_sudo.rb
+++ b/lib/travis/build/appliances/disable_sudo.rb
@@ -6,6 +6,7 @@ module Travis
       class DisableSudo < Base
         WRITE_SUDO = <<-EOC
 cat <<-'EOF' > _sudo
+#!/bin/bash
 if [[ -f \$HOME/.sudo-run ]]; then
   exit 1
 fi


### PR DESCRIPTION
So that when it is invoked directly no syntax error is shown