### PR TITLE
Fix on-demand installation archive names

### DIFF
--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -102,7 +102,7 @@ module Travis
       end
 
       def archive_url_for(bucket, version, lang = self.class.name.split('::').last.downcase, ext = 'bz2')
-        file_name = "#{[version, lang].compact.join("-")}.tar.#{ext}"
+        file_name = "#{[lang, version].compact.join("-")}.tar.#{ext}"
         sh.if "$(uname) = 'Linux'" do
           sh.raw "travis_host_os=$(lsb_release -is | tr 'A-Z' 'a-z')"
           sh.raw "travis_rel_version=$(lsb_release -rs)"

--- a/spec/build/script/erlang_spec.rb
+++ b/spec/build/script/erlang_spec.rb
@@ -22,9 +22,10 @@ describe Travis::Build::Script::Erlang, :sexp do
       should include_sexp [:cmd, 'source $HOME/otp/R14B04/activate', assert: true, echo: true, timing: true]
     end
 
-    xit 'downloads OTP archive on demand when the desired release is not pre-installed' do
+    it 'downloads OTP archive on demand when the desired release is not pre-installed' do
       branch = sexp_find(subject, [:if, '! -f $HOME/otp/R14B04/activate'])
-      expect(branch).to include_sexp [:cmd, 'wget https://s3.amazonaws.com/travis-otp-releases/ubuntu/$(lsb_release -rs)/erlang-R14B04-x86_64.tar.bz2', assert: true, echo: true, timing: true]
+      expect(branch).to include_sexp [:raw, 'archive_url=https://s3.amazonaws.com/travis-otp-releases/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/erlang-R14B04-nonroot.tar.bz2', assert: true]
+      expect(branch).to include_sexp [:cmd, 'wget -o $HOME/erlang.tar.bz2 ${archive_url}', assert: true, echo: true, timing: true]
     end
   end
 

--- a/spec/build/script/php_spec.rb
+++ b/spec/build/script/php_spec.rb
@@ -71,11 +71,12 @@ describe Travis::Build::Script::Php, :sexp do
   describe 'when desired PHP version is not found' do
     let(:version) { '7.0.0beta2' }
     let(:data) { payload_for(:push, :php, config: { php: version }) }
-    let(:sexp) { sexp_find(subject, [:if, "$? -ne 0"], [:then]) }
+    let(:sexp) { sexp_find(sexp_filter(subject, [:if, "$? -ne 0"])[1], [:then]) }
 
-    xit 'installs PHP version on demand' do
-      expect(sexp).to include_sexp [:raw, "archive_url=https://s3.amazonaws.com/travis-php-archives/php-#{version}-archive.tar.bz2"]
-      expect(sexp).to include_sexp [:cmd, "curl -s -o archive.tar.bz2 $archive_url && tar xjf archive.tar.bz2 --directory /", timing: true]
+    it 'installs PHP version on demand' do
+      # puts sexp
+      expect(sexp).to include_sexp [:raw, "archive_url=https://s3.amazonaws.com/travis-php-archives/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/php-#{version}.tar.bz2", assert: true]
+      expect(sexp).to include_sexp [:cmd, "curl -s -o archive.tar.bz2 $archive_url && tar xjf archive.tar.bz2 --directory /", echo: true, timing: true]
     end
   end
 

--- a/spec/build/script/php_spec.rb
+++ b/spec/build/script/php_spec.rb
@@ -74,7 +74,6 @@ describe Travis::Build::Script::Php, :sexp do
     let(:sexp) { sexp_find(sexp_filter(subject, [:if, "$? -ne 0"])[1], [:then]) }
 
     it 'installs PHP version on demand' do
-      # puts sexp
       expect(sexp).to include_sexp [:raw, "archive_url=https://s3.amazonaws.com/travis-php-archives/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/php-#{version}.tar.bz2", assert: true]
       expect(sexp).to include_sexp [:cmd, "curl -s -o archive.tar.bz2 $archive_url && tar xjf archive.tar.bz2 --directory /", echo: true, timing: true]
     end

--- a/spec/build/script/python_spec.rb
+++ b/spec/build/script/python_spec.rb
@@ -45,6 +45,7 @@ describe Travis::Build::Script::Python, :sexp do
 
   it 'sets up the python version (pypy3)' do
     data[:config][:python] = 'pypy3'
+    should include_sexp [:cmd,  "curl -s -o pypy3.tar.bz2 ${archive_url}", assert: true]
     should include_sexp [:cmd,  'source ~/virtualenv/pypy3/bin/activate', assert: true, echo: true, timing: true]
   end
 
@@ -56,6 +57,16 @@ describe Travis::Build::Script::Python, :sexp do
     data[:config][:python] = 'nightly'
     should include_sexp [:cmd,  'sudo tar xjf python-nightly.tar.bz2 --directory /', echo: true, assert: true]
     should include_sexp [:cmd,  'source ~/virtualenv/pythonnightly/bin/activate', assert: true, echo: true, timing: true]
+  end
+
+  context 'when specified Python is not pre-installed' do
+    let(:version) { '2.7' }
+    let(:sexp) { sexp_find(subject, [:if, "! -f ~/virtualenv/python#{version}/bin/activate"]) }
+
+    it "downloads archive" do
+      branch = sexp_find(sexp, [:then])
+      expect(branch).to include_sexp [:raw, "archive_url=https://s3.amazonaws.com/travis-python-archives/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/python-#{version}.tar.bz2"]
+    end
   end
 
   it 'announces python --version' do


### PR DESCRIPTION
https://github.com/travis-ci/travis-build/pull/1088 broke the names of the archives used by on-demand installation. This adds specs for just such a breakage, and fixes it.