### PR TITLE
Skip update_static_files Rake task during the required jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
       dist: trusty
       env:
       script: ./script/validate-example-payloads-with-docker
-    - stage: "test rake"
+    - stage: "test update_static_files Rake task"
       script: "bundle exec rake update_static_files"
     - stage: ":ship: it to Quay.io"
       sudo: required
@@ -38,7 +38,9 @@ jobs:
       env:
       script: ./script/docker-build-and-push
 
-script: bundle exec rake spec && ./script/validate-bash-syntax
+script:
+  - mkdir -p public/files && touch public/files/nvm.sh
+  - bundle exec rake lib/travis/build/addons/sauce_connect/sauce_connect.sh spec && ./script/validate-bash-syntax
 
 after_success: bundle exec codeclimate-test-reporter
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,19 +23,22 @@ stages:
 jobs:
   allow_failures:
     - script: ./script/docker-build-and-push
+    - script: "bundle exec rake update_static_files"
   include:
     - stage: "test"
       sudo: required
       dist: trusty
       env:
       script: ./script/validate-example-payloads-with-docker
+    - stage: "test rake"
+      script: "bundle exec rake update_static_files"
     - stage: ":ship: it to Quay.io"
       sudo: required
       dist: trusty
       env:
       script: ./script/docker-build-and-push
 
-script: bundle exec rake && ./script/validate-bash-syntax
+script: bundle exec rake spec && ./script/validate-bash-syntax
 
 after_success: bundle exec codeclimate-test-reporter
 


### PR DESCRIPTION
This task is sensitive to GitHub API rate limit, and often fails
during the external PR builds because of it.

We move it to a separate job, which is allowed to fail. This has
an added benefit of not running the Docker build stage during the
external PR builds, because the new "test rake" stage will fail
then.