### PR TITLE
retry fix to wget for fragile MacTEX downloads

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -450,8 +450,8 @@ module Travis
             mactex = 'BasicTeX.pkg'
             # TODO(craigcitro): Confirm that this will route us to the
             # nearest mirror.
-            sh.cmd 'curl -fLo http://mirror.ctan.org/systems/mac/mactex/'\
-                   "#{mactex} -O \"/tmp/#{mactex}\"", retry: true
+            sh.cmd 'curl -fLo \"/tmp/#{mactex}\" --retry 3 http://mirror.ctan.org/systems/mac/mactex/'\
+                   '#{mactex}'
 
             sh.echo 'Installing OS X binary package for MacTeX'
             sh.cmd "sudo installer -pkg \"/tmp/#{mactex}\" -target /"

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -450,7 +450,7 @@ module Travis
             mactex = 'BasicTeX.pkg'
             # TODO(craigcitro): Confirm that this will route us to the
             # nearest mirror.
-            sh.cmd 'wget http://mirror.ctan.org/systems/mac/mactex/'\
+            sh.cmd 'wget --retry-on-http-error=403 --waitretry=3 --tries=5 http://mirror.ctan.org/systems/mac/mactex/'\
                    "#{mactex} -O \"/tmp/#{mactex}\""
 
             sh.echo 'Installing OS X binary package for MacTeX'

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -450,8 +450,8 @@ module Travis
             mactex = 'BasicTeX.pkg'
             # TODO(craigcitro): Confirm that this will route us to the
             # nearest mirror.
-            sh.cmd 'wget --retry-on-http-error=403 --waitretry=3 --tries=5 http://mirror.ctan.org/systems/mac/mactex/'\
-                   "#{mactex} -O \"/tmp/#{mactex}\""
+            sh.cmd 'curl -fLo http://mirror.ctan.org/systems/mac/mactex/'\
+                   "#{mactex} -O \"/tmp/#{mactex}\"", retry: true
 
             sh.echo 'Installing OS X binary package for MacTeX'
             sh.cmd "sudo installer -pkg \"/tmp/#{mactex}\" -target /"


### PR DESCRIPTION
MacTeX download from CTAN breaks some types of R builds (oldrel on Mac OS X often) about a third of the time. 

Add `wget --retry-on-http-error=403 --waitretry=3 --tries=5` to the command for downloading MacTeX from CTAN to address fragile downloads. See https://github.com/travis-ci/travis-ci/issues/6702 for discussion.

Thanks to @aaronrudkin for the specific code and @BanzaiMan for the place to drop it in.