### PR TITLE
update to latest nightly mac build on att research

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -111,7 +111,7 @@ module Travis
 
                 # R-devel builds available at research.att.com
                 if r_version == 'devel'
-                  r_url = "https://r.research.att.com/mavericks/R-devel/R-devel-mavericks-signed.pkg"
+                  r_url = "https://r.research.att.com/el-capitan/R-devel/R-devel-el-capitan.pkg"
 
                 # The latest release is the only one available in /bin/macosx
                 elsif r_version == r_latest


### PR DESCRIPTION
cc @craigcitro @jimhester

It appears that `https://r.research.att.com/el-capitan/R-devel/R-devel-el-capitan.pkg` is now the latest nightly build on att research.

The old `mavericks/` builds seem to stop around 2017-03-23.

In line with this, the latest build from `https://r.research.att.com/mavericks/R-devel/R-devel-mavericks-signed.pkg` now (2017-08-08) now reports to be `R 3.5.0 Under development (unstable) (2017-03-23 r72389)`, which is somewhat behind the curve.

So I'm guessing the latest nightlies are now only build for mavericks.