### PR TITLE
Fix Go version check for go get -t

### DIFF
--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -148,7 +148,7 @@ module Travis
           end
 
           def go_get_cmd
-            if go_version == 'go1' || (go_version !~ /tip|master/ && comparable_go_version <= Gem::Version.new('1.2'))
+            if go_version == 'go1' || (go_version[/^[0-9]/] && comparable_go_version <= Gem::Version.new('1.2'))
               'go get'
             else
               'go get -t'


### PR DESCRIPTION
gimme recently added the ability to request 'stable' instead of tip or
master. However, if one requests stable, go get -t is disabled despite
the fact that it would be enabled on the actual version (1.8.3 at time
of writing). Since comparable_go_version returns 0.0.1 if the version
isn't a number, we get the options for < 1.2.

Instead we should treat all non-numbered go versions the same, which
means using go get -t.