### PR TITLE
Disable Gradle daemon for user

### DIFF
--- a/lib/travis/build/script/shared/jdk.rb
+++ b/lib/travis/build/script/shared/jdk.rb
@@ -17,6 +17,9 @@ module Travis
           sh.if '-f build.gradle || -f build.gradle.kts' do
             sh.export 'TERM', 'dumb'
           end
+
+          sh.echo "Disabling Gradle daemon", ansi: :yellow
+          sh.cmd 'mkdir -p ~/.gradle && echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties', echo: true
         end
 
         def announce


### PR DESCRIPTION
In CI environment, Gradle daemons are discouraged.

See https://docs.gradle.org/current/userguide/gradle_daemon.html#sec:ways_to_disable_gradle_daemon

This resolves https://github.com/travis-ci/travis-ci/issues/8205