### PR TITLE
Fix string quoting

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -450,8 +450,8 @@ module Travis
             mactex = 'BasicTeX.pkg'
             # TODO(craigcitro): Confirm that this will route us to the
             # nearest mirror.
-            sh.cmd 'curl -fLo \"/tmp/#{mactex}\" --retry 3 http://mirror.ctan.org/systems/mac/mactex/'\
-                   '#{mactex}'
+            sh.cmd "curl -fLo \"/tmp/#{mactex}\" --retry 3 http://mirror.ctan.org/systems/mac/mactex/"\
+                   "#{mactex}"
 
             sh.echo 'Installing OS X binary package for MacTeX'
             sh.cmd "sudo installer -pkg \"/tmp/#{mactex}\" -target /"


### PR DESCRIPTION
So that `#{}` is interpolated by Ruby

Resolves https://github.com/travis-ci/travis-ci/issues/8263.