### PR TITLE
Enforce tag presence on GitHub Releases deployment

### DIFF
--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -28,6 +28,10 @@ module Travis
             smalltalk
           ).map(&:to_sym)
 
+          PROVIDERS_REQUIRING_TAG = %w(
+            releases
+          )
+
           attr_accessor :script, :sh, :data, :config, :allow_failure
 
           def initialize(script, sh, data, config)
@@ -111,7 +115,7 @@ module Travis
             end
 
             def tags_condition
-              if config[:provider] == 'releases'
+              if PROVIDERS_REQUIRING_TAG.any? { |provider| config[:provider].to_s.upcase == provider.to_s.upcase }
                 '"$TRAVIS_TAG" != ""'
               else
                 case on[:tags]

--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -111,9 +111,13 @@ module Travis
             end
 
             def tags_condition
-              case on[:tags]
-              when true  then '"$TRAVIS_TAG" != ""'
-              when false then '"$TRAVIS_TAG" = ""'
+              if config[:provider] == 'releases'
+                '"$TRAVIS_TAG" != ""'
+              else
+                case on[:tags]
+                when true  then '"$TRAVIS_TAG" != ""'
+                when false then '"$TRAVIS_TAG" = ""'
+                end
               end
             end
 

--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -115,13 +115,10 @@ module Travis
             end
 
             def tags_condition
-              if PROVIDERS_REQUIRING_TAG.any? { |provider| config[:provider].to_s.upcase == provider.to_s.upcase }
+              if provider_requires_tag? || on[:tags]
                 '"$TRAVIS_TAG" != ""'
               else
-                case on[:tags]
-                when true  then '"$TRAVIS_TAG" != ""'
-                when false then '"$TRAVIS_TAG" = ""'
-                end
+                '"$TRAVIS_TAG" = ""'
               end
             end
 
@@ -195,6 +192,10 @@ module Travis
 
             def negate_condition(conditions)
               Array(conditions).flatten.compact.map { |condition| " ! (#{condition})" }.join(" && ")
+            end
+
+            def provider_requires_tag?
+              PROVIDERS_REQUIRING_TAG.any? { |provider| config[:provider].to_s.upcase == provider.to_s.upcase }
             end
 
             def build_gem_locally_from(source, branch)

--- a/spec/build/addons/deploy_spec.rb
+++ b/spec/build/addons/deploy_spec.rb
@@ -30,7 +30,7 @@ describe Travis::Build::Addons::Deploy, :sexp do
 
   describe 'deploys if conditions apply' do
     let(:config) { { provider: 'heroku', password: 'foo', email: 'user@host' } }
-    let(:sexp)   { sexp_find(subject, [:if, '($TRAVIS_BRANCH = master)']) }
+    let(:sexp)   { sexp_find(subject, [:if, '($TRAVIS_BRANCH = master) && ("$TRAVIS_TAG" = "")']) }
 
     it { expect(sexp).to include_sexp [:cmd, './before_deploy_1.sh', assert: true, echo: true, timing: true] }
     it { expect(sexp).to include_sexp [:cmd, './before_deploy_2.sh', assert: true, echo: true, timing: true] }
@@ -46,42 +46,42 @@ describe Travis::Build::Addons::Deploy, :sexp do
     let(:data)   { super().merge(branch: 'staging') }
     let(:config) { { provider: 'heroku', on: { branch: { staging: 'foo', production: 'bar' } } } }
 
-    it { should match_sexp [:if, '($TRAVIS_BRANCH = staging || $TRAVIS_BRANCH = production)'] }
+    it { should match_sexp [:if, '($TRAVIS_BRANCH = staging || $TRAVIS_BRANCH = production) && ("$TRAVIS_TAG" = "")'] }
   end
 
   describe 'option specific branch hashes (deprecated)' do
     let(:data)   { super().merge(branch: 'staging') }
     let(:config) { { provider: 'heroku', app: { staging: 'foo', production: 'bar' } } }
 
-    it { should match_sexp [:if, '($TRAVIS_BRANCH = staging || $TRAVIS_BRANCH = production)'] }
+    it { should match_sexp [:if, '($TRAVIS_BRANCH = staging || $TRAVIS_BRANCH = production) && ("$TRAVIS_TAG" = "")'] }
   end
 
   describe 'yields correct branch condition' do
     let(:data)   { super().merge(branch: 'foo') }
     let(:config) { { provider: 'engineyard', app: { foo: 'foo' } } }
 
-    it { should match_sexp [:if, '($TRAVIS_BRANCH = foo)'] }
+    it { should match_sexp [:if, '($TRAVIS_BRANCH = foo) && ("$TRAVIS_TAG" = "")'] }
     it { should_not match_sexp [:if, '($TRAVIS_BRANCH = not_foo)'] }
   end
 
   describe 'option specific Ruby version' do
     let(:config) { { provider: 'heroku', on: { ruby: 'foo' } } }
 
-    it { should match_sexp [:if, '($TRAVIS_BRANCH = master) && ($TRAVIS_RUBY_VERSION = foo)'] }
+    it { should match_sexp [:if, '($TRAVIS_BRANCH = master) && ($TRAVIS_RUBY_VERSION = foo) && ("$TRAVIS_TAG" = "")'] }
   end
 
   describe 'option specific Rust version' do
     let(:data)   { super().merge(language: 'rust') }
     let(:config) { { provider: 'heroku', on: { rust: 'stable', branch: 'bar' } } }
 
-    it { should match_sexp [:if, '($TRAVIS_BRANCH = bar) && ($TRAVIS_RUST_VERSION = stable)'] }
+    it { should match_sexp [:if, '($TRAVIS_BRANCH = bar) && ($TRAVIS_RUST_VERSION = stable) && ("$TRAVIS_TAG" = "")'] }
   end
 
   context 'when edge dpl is tested' do
     let(:data)   { super().merge(branch: 'staging') }
     let(:config) { { provider: 'heroku', edge: { source: 'svenvfuchs/dpl', branch: 'foo' } } }
 
-    it { should match_sexp [:if, '($TRAVIS_BRANCH = master)'] }
+    it { should match_sexp [:if, '($TRAVIS_BRANCH = master) && ("$TRAVIS_TAG" = "")'] }
   end
 
   describe 'on tags' do
@@ -95,10 +95,11 @@ describe Travis::Build::Addons::Deploy, :sexp do
     let(:nodejitsu) { { provider: 'nodejitsu', user: 'foo', api_key: 'bar', on: { condition: '$BAR = bar' } } }
     let(:config)    { [heroku, nodejitsu] }
 
-    it { should match_sexp [:if, '($TRAVIS_BRANCH = master) && ($FOO = foo)'] }
+    it { should match_sexp [:if, '($TRAVIS_BRANCH = master) && ($FOO = foo) && ("$TRAVIS_TAG" = "")'] }
+
     # it { should include_sexp [:cmd, 'rvm $(travis_internal_ruby) --fuzzy do ruby -S dpl --provider=heroku --password=foo --email=user@host --fold', assert: true, timing: true] }
     it { should include_sexp [:cmd, 'rvm $(travis_internal_ruby) --fuzzy do ruby -S dpl --provider="heroku" --password="foo" --email="user@host" --fold; if [ $? -ne 0 ]; then echo "failed to deploy"; travis_terminate 2; fi', timing: true] }
-    it { should match_sexp [:if, '($TRAVIS_BRANCH = master) && ($BAR = bar)'] }
+    it { should match_sexp [:if, '($TRAVIS_BRANCH = master) && ($BAR = bar) && ("$TRAVIS_TAG" = "")'] }
     # it { should include_sexp [:cmd, 'rvm $(travis_internal_ruby) --fuzzy do ruby -S dpl --provider=nodejitsu --user=foo --api_key=bar --fold', assert: true, timing: true] }
     it { should include_sexp [:cmd, 'rvm $(travis_internal_ruby) --fuzzy do ruby -S dpl --provider="nodejitsu" --user="foo" --api_key="bar" --fold; if [ $? -ne 0 ]; then echo "failed to deploy"; travis_terminate 2; fi', timing: true] }
   end
@@ -112,13 +113,13 @@ describe Travis::Build::Addons::Deploy, :sexp do
   describe 'multiple conditions match' do
     let(:config) { { provider: 'heroku', on: { condition: ['$FOO = foo', '$BAR = bar'] } } }
 
-    it { should match_sexp [:if, '($TRAVIS_BRANCH = master) && ($FOO = foo) && ($BAR = bar)'] }
+    it { should match_sexp [:if, '($TRAVIS_BRANCH = master) && ($FOO = foo) && ($BAR = bar) && ("$TRAVIS_TAG" = "")'] }
   end
 
   describe 'deploy condition fails' do
     let(:config) { { provider: 'heroku', on: { condition: '$FOO = foo'} } }
     # let(:sexp)   { sexp_find(subject, [:if, '(-z $TRAVIS_PULL_REQUEST) && ($TRAVIS_BRANCH = master) && ($FOO = foo)'], [:else]) }
-    let(:sexp)   { sexp_find(subject, [:if, '($TRAVIS_BRANCH = master) && ($FOO = foo)'], [:else]) }
+    let(:sexp)   { sexp_find(subject, [:if, '($TRAVIS_BRANCH = master) && ($FOO = foo) && ("$TRAVIS_TAG" = "")'], [:else]) }
 
     let(:is_pull_request)  { [:echo, 'Skipping a deployment with the heroku provider because the current build is a pull request.', ansi: :yellow] }
     let(:not_permitted)    { [:echo, 'Skipping a deployment with the heroku provider because this branch is not permitted', ansi: :yellow] }
@@ -133,7 +134,7 @@ describe Travis::Build::Addons::Deploy, :sexp do
 
   describe 'deploy with compound condition fails' do
     let(:config) { { provider: 'heroku', on: { condition: '$FOO = foo && $BAR = bar'} } }
-    let(:sexp)   { sexp_find(subject, [:if, '($TRAVIS_BRANCH = master) && ($FOO = foo && $BAR = bar)'], [:else]) }
+    let(:sexp)   { sexp_find(subject, [:if, '($TRAVIS_BRANCH = master) && ($FOO = foo && $BAR = bar) && ("$TRAVIS_TAG" = "")'], [:else]) }
 
     let(:custom_condition) { [:echo, 'Skipping a deployment with the heroku provider because a custom condition was not met', ansi: :yellow] }
 

--- a/spec/build/addons/deploy_spec.rb
+++ b/spec/build/addons/deploy_spec.rb
@@ -149,5 +149,16 @@ describe Travis::Build::Addons::Deploy, :sexp do
 
     it { expect(sexp_find(sexp, [:if, ' ! ("$TRAVIS_TAG" != "")'])).to include_sexp not_tag }
   end
+
+  context 'when deploying with "releases" provider' do
+    let(:config) { { provider: 'releases' } }
+    let(:sexp)   { sexp_find(subject, [:if, ' ! ("$TRAVIS_TAG" != "")']) }
+
+    let(:not_tag) { [:echo, "Skipping a deployment with the releases provider because this is not a tagged commit", ansi: :yellow] }
+
+    it "implicitly requires a tag" do
+      expect(sexp_find(sexp, [])).to include_sexp not_tag
+    end
+  end
 end
 


### PR DESCRIPTION
In the documentation, we state that the GitHub Releases deployment
requires a tag build, but this is not true.

We happily oblige, and in the process, creates an unwanted release,
based on an unexpected tag name (untagged-HEX); this results in
https://github.com/travis-ci/travis-ci/issues/8185.

This commit resolves that issue by triggering the tags condition
when the deployment provider is `release`.

----

This resolves https://github.com/travis-ci/travis-ci/issues/8185.