### PR TITLE
Run `rebar3` if it is found

### DIFF
--- a/lib/travis/build/script/erlang.rb
+++ b/lib/travis/build/script/erlang.rb
@@ -35,7 +35,7 @@ module Travis
             sh.cmd './rebar compile && ./rebar skip_deps=true eunit'
           end
           sh.elif rebar_configured do
-            sh.if "command -v rebar3" do
+            sh.if "-n $(command -v rebar3)" do
               sh.cmd 'rebar3 eunit'
             end
             sh.else do

--- a/lib/travis/build/script/erlang.rb
+++ b/lib/travis/build/script/erlang.rb
@@ -24,7 +24,12 @@ module Travis
             sh.cmd './rebar get-deps', fold: 'install', retry: true
           end
           sh.elif rebar_configured do
-            sh.cmd 'rebar get-deps', fold: 'install', retry: true
+            sh.if "command -v rebar3" do
+              sh.cmd 'rebar3 get-deps', fold: 'install', retry: true
+            end
+            sh.else do
+              sh.cmd 'rebar get-deps', fold: 'install', retry: true
+            end
           end
         end
 
@@ -33,7 +38,12 @@ module Travis
             sh.cmd './rebar compile && ./rebar skip_deps=true eunit'
           end
           sh.elif rebar_configured do
-            sh.cmd 'rebar compile && rebar skip_deps=true eunit'
+            sh.if "command -v rebar3" do
+              sh.cmd 'rebar3 compile && rebar3 skip_deps=true eunit'
+            end
+            sh.else do
+              sh.cmd 'rebar compile && rebar skip_deps=true eunit'
+            end
           end
           sh.else do
             sh.cmd 'make test'

--- a/lib/travis/build/script/erlang.rb
+++ b/lib/travis/build/script/erlang.rb
@@ -24,7 +24,7 @@ module Travis
             sh.cmd './rebar get-deps', fold: 'install', retry: true
           end
           sh.elif rebar_configured do
-            sh.if "!(command -v rebar3)" do
+            sh.if "-z $(command -v rebar3)" do
               sh.cmd 'rebar get-deps', fold: 'install', retry: true
             end
           end

--- a/lib/travis/build/script/erlang.rb
+++ b/lib/travis/build/script/erlang.rb
@@ -36,7 +36,7 @@ module Travis
           end
           sh.elif rebar_configured do
             sh.if "command -v rebar3" do
-              sh.cmd 'rebar3 compile && rebar3 eunit'
+              sh.cmd 'rebar3 eunit'
             end
             sh.else do
               sh.cmd 'rebar compile && rebar skip_deps=true eunit'

--- a/lib/travis/build/script/erlang.rb
+++ b/lib/travis/build/script/erlang.rb
@@ -24,10 +24,7 @@ module Travis
             sh.cmd './rebar get-deps', fold: 'install', retry: true
           end
           sh.elif rebar_configured do
-            sh.if "command -v rebar3" do
-              sh.cmd 'rebar3 get-deps', fold: 'install', retry: true
-            end
-            sh.else do
+            sh.if "!(command -v rebar3)" do
               sh.cmd 'rebar get-deps', fold: 'install', retry: true
             end
           end
@@ -39,7 +36,7 @@ module Travis
           end
           sh.elif rebar_configured do
             sh.if "command -v rebar3" do
-              sh.cmd 'rebar3 compile && rebar3 skip_deps=true eunit'
+              sh.cmd 'rebar3 compile && rebar3 eunit'
             end
             sh.else do
               sh.cmd 'rebar compile && rebar skip_deps=true eunit'

--- a/spec/build/script/erlang_spec.rb
+++ b/spec/build/script/erlang_spec.rb
@@ -39,7 +39,7 @@ describe Travis::Build::Script::Erlang, :sexp do
 
     it 'runs appropriate rebar command if rebar config exists, but ./rebar does not and rebar3 is not found' do
       branch = sexp_find(sexp, [:elif, '(-f rebar.config || -f Rebar.config)'])
-      rebar_branch = sexp_find(branch, [:if, '!(command -v rebar3)'])
+      rebar_branch = sexp_find(branch, [:if, '-z $(command -v rebar3)'])
       expect(rebar_branch).to  include_sexp [:cmd, 'rebar get-deps', assert: true, echo: true, retry: true, timing: true]
     end
   end

--- a/spec/build/script/erlang_spec.rb
+++ b/spec/build/script/erlang_spec.rb
@@ -55,7 +55,7 @@ describe Travis::Build::Script::Erlang, :sexp do
 
     it 'runs appropriate rebar/rebar3 command if rebar config exists, but ./rebar does not' do
       branch = sexp_find(sexp, [:elif, '(-f rebar.config || -f Rebar.config)'])
-      rebar3_branch = sexp_find(branch, [:if, 'command -v rebar3'])
+      rebar3_branch = sexp_find(branch, [:if, '-n $(command -v rebar3)'])
       rebar_branch  = sexp_find(branch, [:else])
       expect(rebar3_branch).to include_sexp [:cmd, 'rebar3 eunit', echo: true, timing: true]
       expect(rebar_branch).to  include_sexp [:cmd, 'rebar compile && rebar skip_deps=true eunit',  echo: true, timing: true]

--- a/spec/build/script/erlang_spec.rb
+++ b/spec/build/script/erlang_spec.rb
@@ -54,11 +54,14 @@ describe Travis::Build::Script::Erlang, :sexp do
 
     it 'runs `rebar compile && rebar skip_deps=true eunit` if rebar config exists, but ./rebar does not' do
       branch = sexp_find(sexp, [:elif, '(-f rebar.config || -f Rebar.config)'])
-      expect(branch).to include_sexp [:cmd, 'rebar compile && rebar skip_deps=true eunit', echo: true, timing: true]
+      rebar3_branch = sexp_find(branch, [:if, 'command -v rebar3'])
+      rebar_branch  = sexp_find(branch, [:else])
+      expect(rebar3_branch).to include_sexp [:cmd, 'rebar3 compile && rebar3 skip_deps=true eunit', echo: true, timing: true]
+      expect(rebar_branch).to include_sexp  [:cmd, 'rebar compile && rebar skip_deps=true eunit',  echo: true, timing: true]
     end
 
     it 'runs `make test` if rebar config does not exist' do
-      branch = sexp_find(sexp, [:else])
+      branch = sexp_filter(sexp, [:else])[1] # the first 'else' occurs in sh.if "command -v rebar3"
       expect(branch).to include_sexp [:cmd, "make test", echo: true, timing: true]
     end
   end

--- a/spec/build/script/erlang_spec.rb
+++ b/spec/build/script/erlang_spec.rb
@@ -37,9 +37,10 @@ describe Travis::Build::Script::Erlang, :sexp do
       expect(branch).to include_sexp [:cmd, './rebar get-deps', assert: true, echo: true, retry: true, timing: true]
     end
 
-    it 'runs `rebar get-deps` if rebar config exists, but ./rebar does not' do
+    it 'runs appropriate rebar command if rebar config exists, but ./rebar does not and rebar3 is not found' do
       branch = sexp_find(sexp, [:elif, '(-f rebar.config || -f Rebar.config)'])
-      expect(branch).to include_sexp [:cmd, 'rebar get-deps', assert: true, echo: true, retry: true, timing: true]
+      rebar_branch = sexp_find(branch, [:if, '!(command -v rebar3)'])
+      expect(rebar_branch).to  include_sexp [:cmd, 'rebar get-deps', assert: true, echo: true, retry: true, timing: true]
     end
   end
 
@@ -52,12 +53,12 @@ describe Travis::Build::Script::Erlang, :sexp do
       expect(branch).to include_sexp [:cmd, './rebar compile && ./rebar skip_deps=true eunit', echo: true, timing: true]
     end
 
-    it 'runs `rebar compile && rebar skip_deps=true eunit` if rebar config exists, but ./rebar does not' do
+    it 'runs appropriate rebar/rebar3 command if rebar config exists, but ./rebar does not' do
       branch = sexp_find(sexp, [:elif, '(-f rebar.config || -f Rebar.config)'])
       rebar3_branch = sexp_find(branch, [:if, 'command -v rebar3'])
       rebar_branch  = sexp_find(branch, [:else])
-      expect(rebar3_branch).to include_sexp [:cmd, 'rebar3 compile && rebar3 skip_deps=true eunit', echo: true, timing: true]
-      expect(rebar_branch).to include_sexp  [:cmd, 'rebar compile && rebar skip_deps=true eunit',  echo: true, timing: true]
+      expect(rebar3_branch).to include_sexp [:cmd, 'rebar3 compile && rebar3 eunit', echo: true, timing: true]
+      expect(rebar_branch).to  include_sexp [:cmd, 'rebar compile && rebar skip_deps=true eunit',  echo: true, timing: true]
     end
 
     it 'runs `make test` if rebar config does not exist' do

--- a/spec/build/script/erlang_spec.rb
+++ b/spec/build/script/erlang_spec.rb
@@ -57,7 +57,7 @@ describe Travis::Build::Script::Erlang, :sexp do
       branch = sexp_find(sexp, [:elif, '(-f rebar.config || -f Rebar.config)'])
       rebar3_branch = sexp_find(branch, [:if, 'command -v rebar3'])
       rebar_branch  = sexp_find(branch, [:else])
-      expect(rebar3_branch).to include_sexp [:cmd, 'rebar3 compile && rebar3 eunit', echo: true, timing: true]
+      expect(rebar3_branch).to include_sexp [:cmd, 'rebar3 eunit', echo: true, timing: true]
       expect(rebar_branch).to  include_sexp [:cmd, 'rebar compile && rebar skip_deps=true eunit',  echo: true, timing: true]
     end
 


### PR DESCRIPTION
Otherwise, run `rebar`.

This effectively resolves https://github.com/travis-ci/travis-ci/issues/6506.

On Trusty images, `rebar3` is pre-installed, and it should be preferred to `rebar`.