### PR TITLE
Ensure nvm files are executable

### DIFF
--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -151,6 +151,7 @@ module Travis
             sh.raw "mkdir -p #{nvm_dir}"
             sh.raw "curl -s -o #{nvm_dir}/nvm.sh   https://#{app_host}/files/nvm.sh".untaint,   assert: false
             sh.raw "curl -s -o #{nvm_dir}/nvm-exec https://#{app_host}/files/nvm-exec".untaint, assert: false
+            sh.raw "chmod 0755 #{nvm_dir}/nvm.sh #{nvm_dir}/nvm-exec", assert: true
             sh.raw "source #{nvm_dir}/nvm.sh", assert: false
           end
 


### PR DESCRIPTION
This resolves https://github.com/travis-ci/travis-ci/issues/8159

`nvm.sh` exists on the build image with proper permissions, and it already has the execute bit set.