### PR TITLE
Install libmariadbclient-dev only on Precise

### DIFF
--- a/lib/travis/build/addons/mariadb.rb
+++ b/lib/travis/build/addons/mariadb.rb
@@ -17,7 +17,9 @@ module Travis
             sh.cmd "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 #{MARIADB_GPG_KEY}", sudo: true
             sh.cmd 'add-apt-repository "deb http://%p/mariadb/repo/%p/ubuntu $(lsb_release -cs) main"' % [MARIADB_MIRROR, mariadb_version], sudo: true
             sh.cmd "apt-get update -qq", assert: false, sudo: true
-            sh.cmd "apt-get install -y -o Dpkg::Options::='--force-confnew' mariadb-server mariadb-server-#{mariadb_version} libmariadbclient-dev", sudo: true, echo: true, timing: true
+            sh.cmd "PACKAGES='mariadb-server mariadb-server-#{mariadb_version}'", echo: true
+            sh.cmd "if [[ $(lsb_release -cs) = 'precise' ]]; then PACKAGES=\"${PACKAGES} libmariadbclient-dev\"; fi", echo: true
+            sh.cmd "apt-get install -y -o Dpkg::Options::='--force-confnew' $PACKAGES", sudo: true, echo: true, timing: true
             sh.echo "Starting MariaDB v#{mariadb_version}", ansi: :yellow
             sh.cmd "service mysql start", sudo: true, assert: false, echo: true, timing: true
             sh.export 'TRAVIS_MARIADB_VERSION', mariadb_version, echo: false

--- a/spec/build/addons/mariadb_spec.rb
+++ b/spec/build/addons/mariadb_spec.rb
@@ -23,7 +23,8 @@ describe Travis::Build::Addons::Mariadb, :sexp do
   it { should include_sexp [:cmd, "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 #{Travis::Build::Addons::Mariadb::MARIADB_GPG_KEY}", sudo: true] }
   it { should include_sexp [:cmd, 'add-apt-repository "deb http://%p/mariadb/repo/%p/ubuntu $(lsb_release -cs) main"' % [Travis::Build::Addons::Mariadb::MARIADB_MIRROR, config], sudo: true] }
   it { should include_sexp [:cmd, "apt-get update -qq", sudo: true] }
-  it { should include_sexp [:cmd, "apt-get install -y -o Dpkg::Options::='--force-confnew' mariadb-server mariadb-server-10.0 libmariadbclient-dev", sudo: true, echo: true, timing: true] }
+  it { should include_sexp [:cmd, "PACKAGES='mariadb-server mariadb-server-10.0'", echo: true] }
+  it { should include_sexp [:cmd, "apt-get install -y -o Dpkg::Options::='--force-confnew' $PACKAGES", sudo: true, echo: true, timing: true] }
   it { should include_sexp [:cmd, "service mysql start", sudo: true, echo: true, timing: true] }
   it { should include_sexp [:cmd, "mysql --version", echo: true] }
 end


### PR DESCRIPTION
It appears that the package requirements changed with Trusty,
which no longer requires this.

Resolves https://github.com/travis-ci/travis-ci/issues/8255