### PR TITLE
Alias :on to :if (in Deploy::Script)

### DIFF
--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -79,7 +79,7 @@ module Travis
 
             def on
               @on ||= begin
-                on = config.delete(:on) || config.delete(true) || config.delete(:true) || {}
+                on = config.delete(:if) || config.delete(:on) || config.delete(true) || config.delete(:true) || {}
                 on = { branch: on.to_str } if on.respond_to? :to_str
                 on[:ruby] ||= on[:rvm] if on.include? :rvm
                 on[:node] ||= on[:node_js] if on.include? :node_js

--- a/spec/build/addons/deploy_spec.rb
+++ b/spec/build/addons/deploy_spec.rb
@@ -42,7 +42,14 @@ describe Travis::Build::Addons::Deploy, :sexp do
     it { expect(sexp).to include_sexp [:cmd, './after_deploy_2.sh', echo: true, timing: true] }
   end
 
-  describe 'branch specific option hashes' do
+  describe 'branch specific option hashes (using :if)' do
+    let(:data)   { super().merge(branch: 'staging') }
+    let(:config) { { provider: 'heroku', if: { branch: { staging: 'foo', production: 'bar' } } } }
+
+    it { should match_sexp [:if, '($TRAVIS_BRANCH = staging || $TRAVIS_BRANCH = production)'] }
+  end
+
+  describe 'branch specific option hashes (using :on)' do
     let(:data)   { super().merge(branch: 'staging') }
     let(:config) { { provider: 'heroku', on: { branch: { staging: 'foo', production: 'bar' } } } }
 
@@ -64,7 +71,13 @@ describe Travis::Build::Addons::Deploy, :sexp do
     it { should_not match_sexp [:if, '($TRAVIS_BRANCH = not_foo)'] }
   end
 
-  describe 'option specific Ruby version' do
+  describe 'option specific Ruby version (using :if)' do
+    let(:config) { { provider: 'heroku', if: { ruby: 'foo' } } }
+
+    it { should match_sexp [:if, '($TRAVIS_BRANCH = master) && ($TRAVIS_RUBY_VERSION = foo)'] }
+  end
+
+  describe 'option specific Ruby version (using :on)' do
     let(:config) { { provider: 'heroku', on: { ruby: 'foo' } } }
 
     it { should match_sexp [:if, '($TRAVIS_BRANCH = master) && ($TRAVIS_RUBY_VERSION = foo)'] }


### PR DESCRIPTION
It seems the previous change doesn't do anything because the class changed (`Deploy::Config`) is not even being used?

In addition to the unit tests I have tested this change here by modifying `play/compile.rb`

```
  config: {
    rvm: 'ruby-head',
    addons: {
      deploy: {
        provider: 'script',
        script: 'foo',
        if: {
          all_branches: true
        }
      }
    }
```

which then included:

```
EOFUNC_RESET_STATE
cat <<'EOFUNC_AFTER_SUCCESS' >>$HOME/.travis/job_stages
function travis_run_after_success() {

if [[ $TRAVIS_TEST_RESULT = 0 ]]; then
  if [[ $- = *e* ]]; then
    ERREXIT_SET=true
  fi
  set +e
  travis_fold start dpl.0
    type rvm &>/dev/null || source ~/.rvm/scripts/rvm
    travis_cmd rvm\ \$\(travis_internal_ruby\)\ --fuzzy\ do\ ruby\ -S\ gem\ install\ dpl --assert --timing
    rm -f dpl-*.gem
  travis_fold end dpl.0
  type rvm &>/dev/null || source ~/.rvm/scripts/rvm
  travis_cmd rvm\ \$\(travis_internal_ruby\)\ --fuzzy\ do\ ruby\ -S\ dpl\ --provider\=\"script\"\ --script\=\"foo\"\ --fold\;\ if\ \[\ \$\?\ -ne\ 0\ \]\;\ then\ echo\ \"failed\ to\ deploy\"\;\ travis_terminate\ 2\;\ fi --timing
  if [[ -n $ERREXIT_SET ]]; then
    set -e
  fi
fi

}
```