### PR TITLE
Allow skipping conditional stages

### DIFF
--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -124,7 +124,7 @@ module Travis
       end
 
       def skip?(type, name)
-        type == :custom && SKIP_KEYWORDS.any? { |word| config[name] == word }
+        type != :builtin && SKIP_KEYWORDS.any? { |word| config[name] == word }
       end
     end
   end


### PR DESCRIPTION
Can be reproduced with:

```
rvm:
  - '2.2'
  - '2.3'
script: echo script
after_success: echo after_success
jobs:
  include:
    - stage: w00t!
      script: echo script
      after_success: skip
```

Before this fix:

https://staging.travis-ci.org/svenfuchs/test-2/jobs/619792

![image](https://user-images.githubusercontent.com/2208/29871696-07bb75aa-8d8d-11e7-8099-94adeac2cae6.png)

With this fix:

https://staging.travis-ci.org/svenfuchs/test-2/jobs/619796

![image](https://user-images.githubusercontent.com/2208/29871684-fc427c82-8d8c-11e7-8c4f-49d7a0a4d058.png)
