### PR TITLE
Install RVM hook to update RubyGems

### DIFF
--- a/lib/travis/build/appliances.rb
+++ b/lib/travis/build/appliances.rb
@@ -28,6 +28,7 @@ require 'travis/build/appliances/show_system_info'
 require 'travis/build/appliances/setup_filter'
 require 'travis/build/appliances/validate'
 require 'travis/build/appliances/npm_registry'
+require 'travis/build/appliances/update_rubygems'
 
 module Travis
   module Build

--- a/lib/travis/build/appliances/update_rubygems.rb
+++ b/lib/travis/build/appliances/update_rubygems.rb
@@ -1,0 +1,24 @@
+require 'travis/build/appliances/base'
+
+module Travis
+  module Build
+    module Appliances
+      class UpdateRubygems < Base
+        RUBYGEMS_BASELINE_VERSION='2.6.13'
+        def apply
+          sh.cmd "cat >$HOME/.rvm/hooks/after_use <<EORVMHOOK
+vers2int() {
+  printf '1%03d%03d%03d%03d' $(echo \"$1\" | tr '.' ' ')
+}
+
+if [[ $(vers2int `gem --version`) -lt $(vers2int \"#{RUBYGEMS_BASELINE_VERSION}\") ]]; then
+  gem update --system
+fi
+EORVMHOOK
+"
+          sh.cmd "chmod +x $HOME/.rvm/hooks/after_use"
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/build/appliances/update_rubygems.rb
+++ b/lib/travis/build/appliances/update_rubygems.rb
@@ -7,6 +7,8 @@ module Travis
         RUBYGEMS_BASELINE_VERSION='2.6.13'
         def apply
           sh.cmd "cat >$HOME/.rvm/hooks/after_use <<EORVMHOOK
+gem >&/dev/null || return 0
+
 vers2int() {
   printf '1%03d%03d%03d%03d' $(echo \"$1\" | tr '.' ' ')
 }

--- a/lib/travis/build/appliances/update_rubygems.rb
+++ b/lib/travis/build/appliances/update_rubygems.rb
@@ -7,7 +7,7 @@ module Travis
         RUBYGEMS_BASELINE_VERSION='2.6.13'
         def apply
           sh.cmd "cat >$HOME/.rvm/hooks/after_use <<EORVMHOOK
-gem >&/dev/null || return 0
+gem --help >&/dev/null || return 0
 
 vers2int() {
   printf '1%03d%03d%03d%03d' $(echo \"$1\" | tr '.' ' ')

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -180,6 +180,7 @@ module Travis
           apply :rvm_use
           apply :rm_oraclejdk8_symlink
           apply :enable_i386
+          apply :update_rubygems
         end
 
         def setup_filter


### PR DESCRIPTION
Install the `after_use` hook, so that when RVM is used to switch Rubies, we update RubyGems to 2.6.13 (http://blog.rubygems.org/2017/08/27/2.6.13-released.html)

This leaves non-Ruby builds, but I think we'd bear this risk.