### PR TITLE
    Change Dockerfile in order to make it generic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,25 @@
-FROM ruby:2.3.4
+FROM ubuntu:latest
+#FROM armv7/armhf-ubuntu
+#FROM ppc64le/ubuntu:latest
 
 LABEL maintainer Travis CI GmbH <support+travis-app-docker-images@travis-ci.com>
 
-# throw errors if Gemfile has been modified since Gemfile.lock
+RUN apt-get -qq update && apt-get -qq upgrade -y && apt-get -qq install apt-utils
+
+RUN apt-get -qq install -y wget git ruby ruby-dev build-essential clang libffi-dev
+
+RUN gem install ffi
+
+RUN gem install bundler
+
 RUN bundle config --global frozen 1
 
 RUN mkdir -p /usr/src/app
+
 WORKDIR /usr/src/app
 
 COPY Gemfile      /usr/src/app
+
 COPY Gemfile.lock /usr/src/app
 
 RUN bundle install


### PR DESCRIPTION
    This commits adds the required packages which need to
    be installed for building travis-build. It brings flexilibily
    for other architectures, requiring only the change of the name
    of Docker image.

Signed-off-by: Rafael Peria de Sene <rpsene@br.ibm.com>