### PR TITLE
Update "travis_retry" to work with "set -e"

### DIFF
--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -247,9 +247,7 @@ travis_retry() {
     [ $result -ne 0 ] && {
       echo -e "\n${ANSI_RED}The command \"$@\" failed. Retrying, $count of 3.${ANSI_RESET}\n" >&2
     }
-    "$@"
-    result=$?
-    [ $result -eq 0 ] && break
+    "$@" && { result=0 && break; } || result=$?
     count=$(($count + 1))
     sleep 1
   done


### PR DESCRIPTION
If we rely on `$?` to detect whether the user's command failed, then if the user enabled `set -e` before invoking `travis_retry`, it won't actually retry, and will bail immediately upon the first failure.  If we instead just use `if` or `&&` directly on the user's command, then `set -e` is appeased, and we get the retry logic we're expecting. :smile: :tada: