### PR TITLE
Fix RVM hook for updating RubyGems

### DIFF
--- a/lib/travis/build/appliances/update_rubygems.rb
+++ b/lib/travis/build/appliances/update_rubygems.rb
@@ -14,6 +14,10 @@ vers2int() {
 }
 
 if [[ \$(vers2int \`gem --version\`) -lt \$(vers2int "%s") ]]; then
+  echo ""
+  echo "** Updating RubyGems to the latest version for security reasons. **"
+  echo "** If you need an older version, you can downgrade with 'gem update --system OLD_VERSION'. **"
+  echo ""
   gem update --system
 fi
 EORVMHOOK

--- a/lib/travis/build/appliances/update_rubygems.rb
+++ b/lib/travis/build/appliances/update_rubygems.rb
@@ -6,18 +6,18 @@ module Travis
       class UpdateRubygems < Base
         RUBYGEMS_BASELINE_VERSION='2.6.13'
         def apply
-          sh.cmd "cat >$HOME/.rvm/hooks/after_use <<EORVMHOOK
+          sh.cmd %q:cat >$HOME/.rvm/hooks/after_use <<EORVMHOOK
 gem --help >&/dev/null || return 0
 
 vers2int() {
-  printf '1%03d%03d%03d%03d' $(echo \"$1\" | tr '.' ' ')
+  printf '1%%03d%%03d%%03d%%03d' \$(echo "\$1" | tr '.' ' ')
 }
 
-if [[ $(vers2int `gem --version`) -lt $(vers2int \"#{RUBYGEMS_BASELINE_VERSION}\") ]]; then
+if [[ \$(vers2int \`gem --version\`) -lt \$(vers2int "%s") ]]; then
   gem update --system
 fi
 EORVMHOOK
-"
+: % RUBYGEMS_BASELINE_VERSION
           sh.cmd "chmod +x $HOME/.rvm/hooks/after_use"
         end
       end


### PR DESCRIPTION
The previous hook was faulty, resuling in alway attempting to
update RubyGems.

This commit fixes the quoting rule, so that the hook checks
RubyGems version correctly.