### PR TITLE
Update Bundler if it is old and RubyGems is also updated

### DIFF
--- a/lib/travis/build/appliances/update_rubygems.rb
+++ b/lib/travis/build/appliances/update_rubygems.rb
@@ -4,6 +4,7 @@ module Travis
   module Build
     module Appliances
       class UpdateRubygems < Base
+        BUNDLER_BASELINE_VERSION='1.15.4'
         RUBYGEMS_BASELINE_VERSION='2.6.13'
         def apply
           sh.cmd %q:cat >$HOME/.rvm/hooks/after_use <<EORVMHOOK
@@ -19,9 +20,17 @@ if [[ \$(vers2int \`gem --version\`) -lt \$(vers2int "%s") ]]; then
   echo "** If you need an older version, you can downgrade with 'gem update --system OLD_VERSION'. **"
   echo ""
   gem update --system
+
+  if [[ \$(vers2int \`bundle --version | awk '{print \$NF}'\`) -lt \$(vers2int "%s") ]]; then
+    echo ""
+    echo "** Updating Bundler to coincide with RubyGems update. **"
+    echo "** If you need an older version, you can downgrade with 'gem uninstall -ax bundler; gem install bundler -v OLD_VERSION'. **"
+    echo ""
+    gem update bundler
+  fi
 fi
 EORVMHOOK
-: % RUBYGEMS_BASELINE_VERSION
+: % [RUBYGEMS_BASELINE_VERSION, BUNDLER_BASELINE_VERSION]
           sh.cmd "chmod +x $HOME/.rvm/hooks/after_use"
         end
       end


### PR DESCRIPTION
With a recent version of RubyGems and an old version of Bundler,
`bundle install` could die with
a NoMethodError:

	NoMethodError: undefined method `spec' for nil:NilClass
	Installing builder 3.2.3
	An error occurred while installing asciidoctor (1.5.7.dev), and Bundler cannot
	continue.
	Make sure that `gem install asciidoctor -v '1.5.7.dev'` succeeds before
	bundling.

We avoid this situation by updating Bundler.

Resolves https://github.com/travis-ci/travis-ci/issues/8355