### PR TITLE
Allow assignment of empty environment variables

### DIFF
--- a/lib/travis/build/env/var.rb
+++ b/lib/travis/build/env/var.rb
@@ -6,7 +6,7 @@ module Travis
         (?:SECURE )? # optionally starts with "SECURE "
         ([\w]+)= # left hand side, var name
           ( # right hand side is one of
-            ("|'|`)([^\3]*?)(\3) # quoted stuff
+            ("|'|`).*?((?<!\\)\3) # quoted stuff
             |
             \$\([^\)]*\) # $(command) output
             |

--- a/lib/travis/build/env/var.rb
+++ b/lib/travis/build/env/var.rb
@@ -2,7 +2,22 @@ module Travis
   module Build
     class Env
       class Var
-        PATTERN = /(?:SECURE )?([\w]+)=(("|')(.*?)(\3)|\$\(.*?\)|[^"' ]+)/
+        PATTERN = /
+        (?:SECURE )? # optionally starts with "SECURE "
+        ([\w]+)= # left hand side, var name
+          ( # right hand side is one of
+            ("|')([^\3]*?)(\3) # quoted stuff
+            |
+            \$\([^\)]*?\) # $(command) output -- this is not especially useful,
+                          # as it is just another case of the next case
+            |
+            [^"'\ ]+ # some bare word
+            |
+            (?=\s) # an empty string
+            |
+            \z # the end of the string
+          )
+        /x
 
         class << self
           def parse(line)

--- a/lib/travis/build/env/var.rb
+++ b/lib/travis/build/env/var.rb
@@ -6,14 +6,17 @@ module Travis
         (?:SECURE )? # optionally starts with "SECURE "
         ([\w]+)= # left hand side, var name
           ( # right hand side is one of
-            ("|')([^\3]*?)(\3) # quoted stuff
+            ("|'|`)([^\3]*?)(\3) # quoted stuff
             |
-            \$\([^\)]*?\) # $(command) output -- this is not especially useful,
-                          # as it is just another case of the next case
+            \$\([^\)]*\) # $(command) output
             |
-            [^"'\ ]+ # some bare word
+            \$\{[^\}]+\} # ${NAME}
             |
-            (?=\s) # an empty string
+            \$\S* # $STUFF or $ (which assigns the value '$')
+            |
+            [^"'`\$\ ]+ # some bare word, not containing ", ', `, or $
+            |
+            (?=\s) # an empty string (look for a space ahead)
             |
             \z # the end of the string
           )

--- a/spec/build/env/var_spec.rb
+++ b/spec/build/env/var_spec.rb
@@ -89,6 +89,10 @@ describe Travis::Build::Env::Var do
     it 'ignores unquoted bare word' do
       expect(parse('FOO=$comm bar BAR="bar bar"')).to eq([['FOO', '$comm'], ['BAR', '"bar bar"']])
     end
+
+    it 'parses quoted string, with escaped end-quote mark inside' do
+      expect(parse('FOO="foo\\"bar" BAR="bar bar"')).to eq([['FOO', '"foo\\"bar"'], ['BAR', '"bar bar"']])
+    end
   end
 
   describe 'secure?' do

--- a/spec/build/env/var_spec.rb
+++ b/spec/build/env/var_spec.rb
@@ -38,7 +38,7 @@ describe Travis::Build::Env::Var do
       expect(parse("FOO= BAR=bar")).to eq([['FOO', ""], ['BAR', 'bar']])
     end
 
-    it "parses FOO= BAR=" do
+    it "assigns empty strings" do
       expect(parse("FOO= BAR=")).to eq([['FOO', ""], ['BAR', '']])
     end
 
@@ -70,8 +70,24 @@ describe Travis::Build::Env::Var do
       expect(parse('FOO=$var BAR="bar bar"')).to eq([['FOO', '$var'], ['BAR', '"bar bar"']])
     end
 
-    it 'parses FOO=$(command) BAR="bar bar"' do
+    it 'preserves $()' do
       expect(parse('FOO=$(command) BAR="bar bar"')).to eq([['FOO', '$(command)'], ['BAR', '"bar bar"']])
+    end
+
+    it 'preserves ${NAME}' do
+      expect(parse('FOO=${NAME} BAR="bar bar"')).to eq([['FOO', '${NAME}'], ['BAR', '"bar bar"']])
+    end
+
+    it 'preserves $' do
+      expect(parse('FOO=$ BAR="bar bar"')).to eq([['FOO', '$'], ['BAR', '"bar bar"']])
+    end
+
+    it 'preserves embedded =' do
+      expect(parse('FOO=comm=bar BAR="bar bar"')).to eq([['FOO', 'comm=bar'], ['BAR', '"bar bar"']])
+    end
+
+    it 'ignores unquoted bare word' do
+      expect(parse('FOO=$comm bar BAR="bar bar"')).to eq([['FOO', '$comm'], ['BAR', '"bar bar"']])
     end
   end
 

--- a/spec/build/env/var_spec.rb
+++ b/spec/build/env/var_spec.rb
@@ -34,6 +34,14 @@ describe Travis::Build::Env::Var do
       expect(parse("FOO='' BAR=bar")).to eq([['FOO', "''"], ['BAR', 'bar']])
     end
 
+    it "parses FOO= BAR=bar" do
+      expect(parse("FOO= BAR=bar")).to eq([['FOO', ""], ['BAR', 'bar']])
+    end
+
+    it "parses FOO= BAR=" do
+      expect(parse("FOO= BAR=")).to eq([['FOO', ""], ['BAR', '']])
+    end
+
     it "parses FOO='foo' BAR=bar" do
       expect(parse("FOO='foo' BAR=bar")).to eq([['FOO', "'foo'"], ['BAR', 'bar']])
     end
@@ -52,6 +60,18 @@ describe Travis::Build::Env::Var do
 
     it 'parses FOO="foo foo" BAR="bar bar"' do
       expect(parse('FOO="foo foo" BAR="bar bar"')).to eq([['FOO', '"foo foo"'], ['BAR', '"bar bar"']])
+    end
+
+    it 'parses FOO="$var" BAR="bar bar"' do
+      expect(parse('FOO="$var" BAR="bar bar"')).to eq([['FOO', '"$var"'], ['BAR', '"bar bar"']])
+    end
+
+    it 'parses FOO=$var BAR="bar bar"' do
+      expect(parse('FOO=$var BAR="bar bar"')).to eq([['FOO', '$var'], ['BAR', '"bar bar"']])
+    end
+
+    it 'parses FOO=$(command) BAR="bar bar"' do
+      expect(parse('FOO=$(command) BAR="bar bar"')).to eq([['FOO', '$(command)'], ['BAR', '"bar bar"']])
     end
   end
 


### PR DESCRIPTION
and increase readability of the regular expression that parses the assignment.

Resolves https://github.com/travis-ci/travis-ci/issues/8387.