### PR TITLE
Revert "Remove redis server patch for container-based trusty"

### DIFF
--- a/lib/travis/build/appliances/fix_container_based_trusty.rb
+++ b/lib/travis/build/appliances/fix_container_based_trusty.rb
@@ -6,16 +6,19 @@ module Travis
   module Build
     module Appliances
       class FixContainerBasedTrusty < Base
+        REDIS_INIT = '/etc/init.d/redis-server'
+        private_constant :REDIS_INIT
+
         def apply
           sh.if sh_is_linux? do
             sh.if sh_is_trusty? do
-              # NOTE: no fixes currently needed :tada:
+              patch_redis_init
             end
           end
         end
 
         def apply?
-          false
+          true
         end
 
         private
@@ -26,6 +29,15 @@ module Travis
 
         def sh_is_trusty?
           '$(lsb_release -sc 2>/dev/null) = trusty'
+        end
+
+        def patch_redis_init
+          sh.if "-f #{REDIS_INIT}" do
+            sh.echo 'Patching redis-server init script', ansi: :yellow
+            sh.raw(
+              %(sudo sed -i '/ulimit -n/s/ulimit.*/: no ulimit/g' #{REDIS_INIT})
+            )
+          end
         end
       end
     end


### PR DESCRIPTION
Reverts travis-ci/travis-build#1163

Some old images are still in hanging around, so we need to revert this in order to make the `master` branch deployable.