### PR TITLE
Allow `$` to appear in the middle of the env var value

### DIFF
--- a/lib/travis/build/env/var.rb
+++ b/lib/travis/build/env/var.rb
@@ -14,7 +14,7 @@ module Travis
             |
             \$\S* # $STUFF or $ (which assigns the value '$')
             |
-            [^"'`\$\ ]+ # some bare word, not containing ", ', `, or $
+            [^"'`\ ]+ # some bare word, not containing ", ', or `
             |
             (?=\s) # an empty string (look for a space ahead)
             |

--- a/spec/build/env/var_spec.rb
+++ b/spec/build/env/var_spec.rb
@@ -93,6 +93,10 @@ describe Travis::Build::Env::Var do
     it 'parses quoted string, with escaped end-quote mark inside' do
       expect(parse('FOO="foo\\"bar" BAR="bar bar"')).to eq([['FOO', '"foo\\"bar"'], ['BAR', '"bar bar"']])
     end
+
+    it 'allow $ in the middle' do
+      expect(parse('APP_URL=http://$APP_HOST:8080 BAR="bar bar"')).to eq([['APP_URL', 'http://$APP_HOST:8080'], ['BAR', '"bar bar"']])
+    end
   end
 
   describe 'secure?' do


### PR DESCRIPTION
Resolves https://github.com/travis-ci/travis-ci/issues/8404