### PR TITLE
Allow any character combination after the initial $

### DIFF
--- a/lib/travis/build/env/var.rb
+++ b/lib/travis/build/env/var.rb
@@ -8,10 +8,6 @@ module Travis
           ( # right hand side is one of
             ("|'|`).*?((?<!\\)\3) # quoted stuff
             |
-            \$\([^\)]*\) # $(command) output
-            |
-            \$\{[^\}]+\} # ${NAME}
-            |
             \$\S* # $STUFF or $ (which assigns the value '$')
             |
             [^"'`\ ]+ # some bare word, not containing ", ', or `

--- a/spec/build/env/var_spec.rb
+++ b/spec/build/env/var_spec.rb
@@ -78,6 +78,10 @@ describe Travis::Build::Env::Var do
       expect(parse('FOO=${NAME} BAR="bar bar"')).to eq([['FOO', '${NAME}'], ['BAR', '"bar bar"']])
     end
 
+    it 'preserves ${NAME}STUFF' do
+      expect(parse('FOO=${NAME}STUFF BAR="bar bar"')).to eq([['FOO', '${NAME}STUFF'], ['BAR', '"bar bar"']])
+    end
+
     it 'preserves $' do
       expect(parse('FOO=$ BAR="bar bar"')).to eq([['FOO', '$'], ['BAR', '"bar bar"']])
     end


### PR DESCRIPTION
Do not pair up `()` and `{}`; it is users' responsibility to pass
correct values