### PR TITLE
Escape the required ' ' after SECURE in EXTENDED Regexp

### DIFF
--- a/lib/travis/build/env/var.rb
+++ b/lib/travis/build/env/var.rb
@@ -3,7 +3,7 @@ module Travis
     class Env
       class Var
         PATTERN = /
-        (?:SECURE )? # optionally starts with "SECURE "
+        (?:SECURE\ )? # optionally starts with "SECURE "
         ([\w]+)= # left hand side, var name
           ( # right hand side is one of
             ("|'|`).*?((?<!\\)\3) # quoted stuff

--- a/spec/build/env/var_spec.rb
+++ b/spec/build/env/var_spec.rb
@@ -101,6 +101,10 @@ describe Travis::Build::Env::Var do
     it 'allow $ in the middle' do
       expect(parse('APP_URL=http://$APP_HOST:8080 BAR="bar bar"')).to eq([['APP_URL', 'http://$APP_HOST:8080'], ['BAR', '"bar bar"']])
     end
+
+    it 'env var can start with SECURE' do
+      expect(parse('SECURE_VAR=value BAR="bar bar"')).to eq([['SECURE_VAR', 'value'], ['BAR', '"bar bar"']])
+    end
   end
 
   describe 'secure?' do


### PR DESCRIPTION
Since the pattern is now extended //x, all spaces now
requires a backslash.