### PR TITLE
Allow space inside $()

### DIFF
--- a/lib/travis/build/env/var.rb
+++ b/lib/travis/build/env/var.rb
@@ -8,9 +8,10 @@ module Travis
           ( # right hand side is one of
             ("|'|`).*?((?<!\\)\3) # quoted stuff
             |
-            \$\S* # $STUFF or $ (which assigns the value '$')
+            \$\(.*?\) # $(things)
             |
             [^"'`\ ]+ # some bare word, not containing ", ', or `
+                      # (this includes many variations of things starting in $)
             |
             (?=\s) # an empty string (look for a space ahead)
             |

--- a/spec/build/env/var_spec.rb
+++ b/spec/build/env/var_spec.rb
@@ -102,6 +102,10 @@ describe Travis::Build::Env::Var do
       expect(parse('APP_URL=http://$APP_HOST:8080 BAR="bar bar"')).to eq([['APP_URL', 'http://$APP_HOST:8080'], ['BAR', '"bar bar"']])
     end
 
+    it 'handle space after the initial $ in ()' do
+      expect(parse('CAT_VERSION=$(cat VERSION)')).to eq([['CAT_VERSION', '$(cat VERSION)']])
+    end
+
     it 'env var can start with SECURE' do
       expect(parse('SECURE_VAR=value BAR="bar bar"')).to eq([['SECURE_VAR', 'value'], ['BAR', '"bar bar"']])
     end


### PR DESCRIPTION
Instead of demanding non-spaces after the initial `$`, we
let users decide what comes in between parentheses.