### PR TITLE
Assert all commands in the `script` step, and warn if the second (and later) command fails

### DIFF
--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -106,6 +106,8 @@ module Travis
       def define_stage(type, name)
         sh.raw "cat <<'EOFUNC_#{name.upcase}' >>$HOME/.travis/job_stages"
         sh.raw "function travis_run_#{name}() {"
+        sh.raw "  travis_build_step=\"#{name}\""
+        sh.raw "  travis_func_index=0"
         commands = run_stage(type, name)
         close = (commands.nil? || commands.empty?) ? ":\n}" : "}"
         sh.raw close

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -46,7 +46,7 @@ module Travis
         before_install: { assert: true,  echo: true,  timing: true  },
         install:        { assert: true,  echo: true,  timing: true  },
         before_script:  { assert: true,  echo: true,  timing: true  },
-        script:         { assert: false, echo: true,  timing: true  },
+        script:         { assert: true,  echo: true,  timing: true  },
         after_success:  { assert: false, echo: true,  timing: true  },
         after_failure:  { assert: false, echo: true,  timing: true  },
         after_script:   { assert: false, echo: true,  timing: true  },

--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -83,6 +83,11 @@ ${ANSI_RED}For more information, see https://docs.travis-ci.com/user/encryption-
   fi
 
   if [[ -n "$assert" ]]; then
+    if [[ $travis_build_step = script && $travis_func_index > 0 ]]; then
+      echo -e "${ANSI_RED} We show an error message because this is the second (or later) command in 'script' and it failed.${ANSI_CLEAR}"
+      echo -e "${ANSI_RED} This is new behavior, and it should be notified.${ANSI_CLEAR}"
+    fi
+
     travis_assert $result
   fi
   ((travis_func_index += 1))

--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -85,6 +85,7 @@ ${ANSI_RED}For more information, see https://docs.travis-ci.com/user/encryption-
   if [[ -n "$assert" ]]; then
     travis_assert $result
   fi
+  ((travis_func_index += 1))
 
   return $result
 }

--- a/spec/build/script/android_spec.rb
+++ b/spec/build/script/android_spec.rb
@@ -60,10 +60,10 @@ describe Travis::Build::Script::Android, :sexp do
   describe 'script' do
     let(:sexp) { sexp_find(subject, [:if, '-f gradlew']) }
 
-    let(:gradlew_connected_check) { [:cmd, './gradlew build connectedCheck', echo: true, timing: true] }
-    let(:gradle_connected_check)  { [:cmd, 'gradle build connectedCheck', echo: true, timing: true] }
-    let(:mvn_install_b)           { [:cmd, 'mvn install -B', echo: true, timing: true] }
-    let(:ant_install_test)        { [:cmd, 'ant debug install test', echo: true, timing: true] }
+    let(:gradlew_connected_check) { [:cmd, './gradlew build connectedCheck', echo: true, timing: true, assert: true] }
+    let(:gradle_connected_check)  { [:cmd, 'gradle build connectedCheck', echo: true, timing: true, assert: true] }
+    let(:mvn_install_b)           { [:cmd, 'mvn install -B', echo: true, timing: true, assert: true] }
+    let(:ant_install_test)        { [:cmd, 'ant debug install test', echo: true, timing: true, assert: true] }
 
     it 'runs ./gradlew build connectedCheck if ./gradlew exists' do
       branch = sexp_find(sexp, [:then])

--- a/spec/build/script/c_spec.rb
+++ b/spec/build/script/c_spec.rb
@@ -22,7 +22,7 @@ describe Travis::Build::Script::C, :sexp do
   end
 
   it 'runs ./configure && make && make test' do
-    should include_sexp [:cmd, './configure && make && make test', echo: true, timing: true]
+    should include_sexp [:cmd, './configure && make && make test', echo: true, timing: true, assert: true]
   end
 
   describe '#cache_slug' do

--- a/spec/build/script/clojure_spec.rb
+++ b/spec/build/script/clojure_spec.rb
@@ -27,7 +27,7 @@ describe Travis::Build::Script::Clojure, :sexp do
     end
 
     it 'runs lein test' do
-      should include_sexp [:cmd, 'lein test', echo: true, timing: true]
+      should include_sexp [:cmd, 'lein test', echo: true, timing: true, assert: true]
     end
   end
 
@@ -45,7 +45,7 @@ describe Travis::Build::Script::Clojure, :sexp do
     end
 
     it 'runs lein2 test if lein: lein2 given' do
-      should include_sexp [:cmd, 'lein2 test', echo: true, timing: true]
+      should include_sexp [:cmd, 'lein2 test', echo: true, timing: true, assert: true]
     end
   end
 

--- a/spec/build/script/cpp_spec.rb
+++ b/spec/build/script/cpp_spec.rb
@@ -89,7 +89,7 @@ describe Travis::Build::Script::Cpp, :sexp do
   end
 
   it 'runs ./configure && make && make test' do
-    should include_sexp [:cmd, './configure && make && make test', echo: true, timing: true]
+    should include_sexp [:cmd, './configure && make && make test', echo: true, timing: true, assert: true]
   end
 
   describe '#cache_slug' do

--- a/spec/build/script/crystal_spec.rb
+++ b/spec/build/script/crystal_spec.rb
@@ -19,7 +19,7 @@ describe Travis::Build::Script::Crystal, :sexp do
   it "runs tests by default" do
     should include_sexp [:cmd,
       "crystal spec",
-      echo: true, timing: true]
+      echo: true, timing: true, assert: true]
   end
 
   context "versions" do

--- a/spec/build/script/csharp_spec.rb
+++ b/spec/build/script/csharp_spec.rb
@@ -175,7 +175,7 @@ describe Travis::Build::Script::Csharp, :sexp do
 
     it 'builds specified solution' do
       data[:config][:solution] = 'foo.sln'
-      should include_sexp [:cmd, 'xbuild /p:Configuration=Release foo.sln', echo: true, timing: true]
+      should include_sexp [:cmd, 'xbuild /p:Configuration=Release foo.sln', echo: true, timing: true, assert: true]
     end
   end
 

--- a/spec/build/script/d_spec.rb
+++ b/spec/build/script/d_spec.rb
@@ -28,7 +28,7 @@ describe Travis::Build::Script::D, :sexp do
   end
 
   it 'runs dub test with DC' do
-    should include_sexp [:cmd, 'dub test --compiler=$DC', echo: true, timing: true]
+    should include_sexp [:cmd, 'dub test --compiler=$DC', echo: true, timing: true, assert: true]
   end
 
   context 'when an old dmd version is configured' do

--- a/spec/build/script/dart_spec.rb
+++ b/spec/build/script/dart_spec.rb
@@ -32,7 +32,7 @@ describe Travis::Build::Script::Dart, :sexp do
   it "runs tests by default" do
     should include_sexp [:cmd,
       "pub global run test_runner --disable-ansi --skip-browser-tests",
-      echo: true, timing: true]
+      echo: true, timing: true, assert: true]
   end
 
   describe 'installs content_shell if config has a :with_content_shell key set with true' do
@@ -159,11 +159,11 @@ describe Travis::Build::Script::Dart, :sexp do
         end
 
         it 'starts xvfb' do
-          expect(sexp).to include_sexp [:cmd, 'sh -e /etc/init.d/xvfb start', echo: true, timing: true]
+          expect(sexp).to include_sexp [:cmd, 'sh -e /etc/init.d/xvfb start', echo: true, timing: true, assert: true]
         end
 
         it 'runs pub run test -p vm -p content-shell -p firefox' do
-          expect(sexp).to include_sexp [:cmd, 'pub run test -p vm -p content-shell -p firefox', echo: true, timing: true]
+          expect(sexp).to include_sexp [:cmd, 'pub run test -p vm -p content-shell -p firefox', echo: true, timing: true, assert: true]
         end
       end
 
@@ -171,7 +171,7 @@ describe Travis::Build::Script::Dart, :sexp do
         let(:sexp) { sexp_filter(super(), [:then]) }
 
         it 'runs pub run test with XVFB' do
-          expect(sexp).to include_sexp [:cmd, 'xvfb-run -s "-screen 0 1024x768x24" pub run test', echo: true, timing: true]
+          expect(sexp).to include_sexp [:cmd, 'xvfb-run -s "-screen 0 1024x768x24" pub run test', echo: true, timing: true, assert: true]
         end
 
         describe 'with test args' do
@@ -184,7 +184,7 @@ describe Travis::Build::Script::Dart, :sexp do
         describe 'with xvfb being false' do
           before { data[:config][:xvfb] = false }
           it "runs pub run test without XVFB" do
-            expect(sexp).to include_sexp [:cmd, 'pub run test', echo: true, timing: true]
+            expect(sexp).to include_sexp [:cmd, 'pub run test', echo: true, timing: true, assert: true]
           end
         end
 
@@ -206,20 +206,20 @@ describe Travis::Build::Script::Dart, :sexp do
       end
 
       it 'installs the test runner' do
-        expect(sexp).to include_sexp [:cmd, 'pub global activate test_runner', echo: true, timing: true]
+        expect(sexp).to include_sexp [:cmd, 'pub global activate test_runner', echo: true, timing: true, assert: true]
       end
 
       describe 'with with_content_shell being true' do
         before { data[:config][:with_content_shell] = true }
 
         it 'runs pub global run test_runner via xvfb-run' do
-          expect(sexp).to include_sexp [:cmd, 'xvfb-run -s "-screen 0 1024x768x24" pub global run test_runner --disable-ansi', echo: true, timing: true]
+          expect(sexp).to include_sexp [:cmd, 'xvfb-run -s "-screen 0 1024x768x24" pub global run test_runner --disable-ansi', echo: true, timing: true, assert: true]
         end
       end
 
       describe 'with with_content_shell being nil' do
         it 'runs pub run test' do
-          expect(sexp).to include_sexp [:cmd, 'pub global run test_runner --disable-ansi --skip-browser-tests', echo: true, timing: true]
+          expect(sexp).to include_sexp [:cmd, 'pub global run test_runner --disable-ansi --skip-browser-tests', echo: true, timing: true, assert: true]
         end
       end
     end
@@ -228,14 +228,14 @@ describe Travis::Build::Script::Dart, :sexp do
       before { data[:config][:dart_task] = 'dartanalyzer' }
 
       it "runs dartanalyzer on the whole package" do
-        should include_sexp [:cmd, 'dartanalyzer .', echo: true, timing: true]
+        should include_sexp [:cmd, 'dartanalyzer .', echo: true, timing: true, assert: true]
       end
 
       describe 'with arguments' do
         before { data[:config][:dart_task] = {dartanalyzer: '--fatal-warnings lib'} }
 
         it "runs dartanalyzer with those arguments" do
-          should include_sexp [:cmd, 'dartanalyzer --fatal-warnings lib', echo: true, timing: true]
+          should include_sexp [:cmd, 'dartanalyzer --fatal-warnings lib', echo: true, timing: true, assert: true]
         end
       end
     end
@@ -246,7 +246,7 @@ describe Travis::Build::Script::Dart, :sexp do
       describe 'when dart_style is installed but dartfmt: sdk is not specified' do
         let(:sexp) { sexp_find(subject, [:elif, "[[ -f pubspec.yaml ]] && (pub deps | grep -q \"^[|']-- dart_style \")"]) }
         it "runs the installed version of dartfmt" do
-          should include_sexp [:raw, 'function dartfmt() { pub run dart_style:format "$@"; }']
+          should include_sexp [:raw, 'function dartfmt() { pub run dart_style:format "$@"; }', assert: true]
         end
       end
 

--- a/spec/build/script/elixir_spec.rb
+++ b/spec/build/script/elixir_spec.rb
@@ -35,7 +35,7 @@ describe Travis::Build::Script::Elixir, :sexp do
 
   describe 'script' do
     it 'runs "mix test"' do
-      should include_sexp [:cmd, 'mix test', echo: true, timing: true]
+      should include_sexp [:cmd, 'mix test', echo: true, timing: true, assert: true]
     end
   end
 

--- a/spec/build/script/erlang_spec.rb
+++ b/spec/build/script/erlang_spec.rb
@@ -49,17 +49,17 @@ describe Travis::Build::Script::Erlang, :sexp do
 
     it 'runs `./rebar compile && ./rebar skip_deps=true eunit` if both rebar config and ./rebar exist' do
       branch = sexp_find(sexp, [:then])
-      expect(branch).to include_sexp [:cmd, './rebar compile && ./rebar skip_deps=true eunit', echo: true, timing: true]
+      expect(branch).to include_sexp [:cmd, './rebar compile && ./rebar skip_deps=true eunit', echo: true, timing: true, assert: true]
     end
 
     it 'runs `rebar compile && rebar skip_deps=true eunit` if rebar config exists, but ./rebar does not' do
       branch = sexp_find(sexp, [:elif, '(-f rebar.config || -f Rebar.config)'])
-      expect(branch).to include_sexp [:cmd, 'rebar compile && rebar skip_deps=true eunit', echo: true, timing: true]
+      expect(branch).to include_sexp [:cmd, 'rebar compile && rebar skip_deps=true eunit', echo: true, timing: true, assert: true]
     end
 
     it 'runs `make test` if rebar config does not exist' do
       branch = sexp_find(sexp, [:else])
-      expect(branch).to include_sexp [:cmd, "make test", echo: true, timing: true]
+      expect(branch).to include_sexp [:cmd, "make test", echo: true, timing: true, assert: true]
     end
   end
 

--- a/spec/build/script/go_spec.rb
+++ b/spec/build/script/go_spec.rb
@@ -154,7 +154,7 @@ describe Travis::Build::Script::Go, :sexp do
       end
 
       it 'runs make' do
-        expect(sexp).to include_sexp [:cmd, 'make', echo: true, timing: true]
+        expect(sexp).to include_sexp [:cmd, 'make', echo: true, timing: true, assert: true]
       end
     end
   end

--- a/spec/build/script/haskell_spec.rb
+++ b/spec/build/script/haskell_spec.rb
@@ -39,7 +39,7 @@ describe Travis::Build::Script::Haskell, :sexp do
   end
 
   it 'runs cabal configure --enable-tests && cabal build && cabal test' do
-    should include_sexp [:cmd, 'cabal configure --enable-tests && cabal build && cabal test', echo: true, timing: true]
+    should include_sexp [:cmd, 'cabal configure --enable-tests && cabal build && cabal test', echo: true, timing: true, assert: true]
   end
 
   [

--- a/spec/build/script/node_js_spec.rb
+++ b/spec/build/script/node_js_spec.rb
@@ -97,12 +97,12 @@ describe Travis::Build::Script::NodeJs, :sexp do
 
     it 'runs npm test if package.json exists' do
       branch = sexp_find(sexp, [:then])
-      expect(sexp).to include_sexp [:cmd, 'npm test', echo: true, timing: true]
+      expect(sexp).to include_sexp [:cmd, 'npm test', echo: true, timing: true, assert: true]
     end
 
     it 'runs make test if no package.json exists' do
       branch = sexp_find(sexp, [:else])
-      expect(sexp).to include_sexp [:cmd, 'make test', echo: true, timing: true]
+      expect(sexp).to include_sexp [:cmd, 'make test', echo: true, timing: true, assert: true]
     end
   end
 

--- a/spec/build/script/objective_c_spec.rb
+++ b/spec/build/script/objective_c_spec.rb
@@ -93,12 +93,12 @@ describe Travis::Build::Script::ObjectiveC, :sexp do
     describe 'if the project is a RubyMotion project' do
       it 'runs `rake spec`' do
         branch = sexp_find(sexp, [:then])
-        expect(branch).to include_sexp [:cmd, 'bundle exec rake spec', echo: true, timing: true]
+        expect(branch).to include_sexp [:cmd, 'bundle exec rake spec', echo: true, timing: true, assert: true]
       end
 
       it 'runs `bundle exec rake spec` if there is a Gemfile' do
         branch = sexp_find(sexp, [:elif, is_ruby_motion])
-        expect(branch).to include_sexp [:cmd, 'rake spec', echo: true, timing: true]
+        expect(branch).to include_sexp [:cmd, 'rake spec', echo: true, timing: true, assert: true]
       end
     end
 
@@ -110,7 +110,7 @@ describe Travis::Build::Script::ObjectiveC, :sexp do
 
       it 'runs xctool' do
         branch = sexp_find(sexp, [:else])
-        expect(branch).to include_sexp [:cmd, 'xctool -workspace YourWorkspace.xcworkspace -scheme YourScheme build test', echo: true, timing: true]
+        expect(branch).to include_sexp [:cmd, 'xctool -workspace YourWorkspace.xcworkspace -scheme YourScheme build test', echo: true, timing: true, assert: true]
       end
     end
 
@@ -123,12 +123,12 @@ describe Travis::Build::Script::ObjectiveC, :sexp do
       end
 
       it 'runs xctool' do
-        expect(branch).to include_sexp [:cmd, 'xctool -project YourProject.xcodeproj -scheme YourScheme build test', echo: true, timing: true]
+        expect(branch).to include_sexp [:cmd, 'xctool -project YourProject.xcodeproj -scheme YourScheme build test', echo: true, timing: true, assert: true]
       end
 
       it 'passes an SDK version to xctool' do
         data[:config][:xcode_sdk] = '7.0'
-        expect(branch).to include_sexp [:cmd, 'xctool -project YourProject.xcodeproj -scheme YourScheme -sdk 7.0 build test', echo: true, timing: true]
+        expect(branch).to include_sexp [:cmd, 'xctool -project YourProject.xcodeproj -scheme YourScheme -sdk 7.0 build test', echo: true, timing: true, assert: true]
       end
     end
 

--- a/spec/build/script/perl_spec.rb
+++ b/spec/build/script/perl_spec.rb
@@ -48,17 +48,17 @@ describe Travis::Build::Script::Perl, :sexp do
 
     it 'runs perl Build.PL && ./Build test if Build.PL exists' do
       branch = sexp_find(sexp, [:then])
-      expect(branch).to include_sexp [:cmd, 'perl Build.PL && ./Build && ./Build test', echo: true, timing: true]
+      expect(branch).to include_sexp [:cmd, 'perl Build.PL && ./Build && ./Build test', echo: true, timing: true, assert: true]
     end
 
     it 'runs perl Makefile.PL && make test if Makefile.PL exists' do
       branch = sexp_find(sexp, [:elif, '-f Makefile.PL'])
-      expect(branch).to include_sexp [:cmd, 'perl Makefile.PL && make test', echo: true, timing: true]
+      expect(branch).to include_sexp [:cmd, 'perl Makefile.PL && make test', echo: true, timing: true, assert: true]
     end
 
     it 'runs make test if no Build.PL or Makefile.PL exists' do
       branch = sexp_find(sexp, [:else])
-      expect(branch).to include_sexp [:cmd, 'make test', echo: true, timing: true]
+      expect(branch).to include_sexp [:cmd, 'make test', echo: true, timing: true, assert: true]
     end
   end
 end

--- a/spec/build/script/php_spec.rb
+++ b/spec/build/script/php_spec.rb
@@ -31,7 +31,7 @@ describe Travis::Build::Script::Php, :sexp do
   end
 
   it 'runs phpunit' do
-    should include_sexp [:cmd, 'phpunit', echo: true, timing: true]
+    should include_sexp [:cmd, 'phpunit', echo: true, timing: true, assert: true]
   end
 
   describe 'installs php nightly' do

--- a/spec/build/script/ruby_spec.rb
+++ b/spec/build/script/ruby_spec.rb
@@ -95,12 +95,12 @@ describe Travis::Build::Script::Ruby, :sexp do
   describe 'script' do
     it 'runs bundle exec rake if a gemfile exists' do
       sexp = sexp_find(subject, [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}"], [:then])
-      should include_sexp [:cmd, 'bundle exec rake', echo: true, timing: true]
+      should include_sexp [:cmd, 'bundle exec rake', echo: true, timing: true, assert: true]
     end
 
     it 'runs rake if a gemfile does not exist' do
       sexp = sexp_find(subject, [:if, "-f ${BUNDLE_GEMFILE:-Gemfile}"], [:else])
-      should include_sexp [:cmd, 'rake', echo: true, timing: true]
+      should include_sexp [:cmd, 'rake', echo: true, timing: true, assert: true]
     end
   end
 

--- a/spec/build/script/rust_spec.rb
+++ b/spec/build/script/rust_spec.rb
@@ -27,15 +27,15 @@ describe Travis::Build::Script::Rust, :sexp do
   end
 
   it 'runs cargo test' do
-    should include_sexp [:cmd, 'cargo test --verbose', echo: true, timing: true]
+    should include_sexp [:cmd, 'cargo test --verbose', echo: true, timing: true, assert: true]
   end
 
   it 'runs cargo build' do
-    should include_sexp [:cmd, 'cargo build --verbose', echo: true, timing: true]
+    should include_sexp [:cmd, 'cargo build --verbose', echo: true, timing: true, assert: true]
   end
 
   it 'runs cargo test' do
-    should include_sexp [:cmd, 'cargo test --verbose', echo: true, timing: true]
+    should include_sexp [:cmd, 'cargo test --verbose', echo: true, timing: true, assert: true]
   end
 
   context "when cache is configured" do

--- a/spec/build/script/scala_spec.rb
+++ b/spec/build/script/scala_spec.rb
@@ -55,12 +55,12 @@ describe Travis::Build::Script::Scala, :sexp do
       let(:sexp) { sexp_find(sexp_filter(subject, [:if, '-d project || -f build.sbt'])[1], [:then]) }
 
       it 'runs sbt with default arguments' do
-        expect(sexp).to include_sexp [:cmd, 'sbt ++2.10.4 test', echo: true, timing: true]
+        expect(sexp).to include_sexp [:cmd, 'sbt ++2.10.4 test', echo: true, timing: true, assert: true]
       end
 
       it 'runs sbt with additional arguments' do
         data[:config][:sbt_args] = '-Dsbt.log.noformat=true'
-        expect(sexp).to include_sexp [:cmd, 'sbt -Dsbt.log.noformat=true ++2.10.4 test', echo: true, timing: true]
+        expect(sexp).to include_sexp [:cmd, 'sbt -Dsbt.log.noformat=true ++2.10.4 test', echo: true, timing: true, assert: true]
       end
     end
   end

--- a/spec/build/script/shared/appliances/stages.rb
+++ b/spec/build/script/shared/appliances/stages.rb
@@ -1,6 +1,6 @@
 shared_examples_for 'build script stages' do
   def assert_stage?(stage)
-    %w(before_install install before_script).include?(stage)
+    %w(before_install install before_script script).include?(stage)
   end
 
   %w(before_install install before_script script after_script after_success).each do |stage|

--- a/spec/build/script/shared/appliances/validate.rb
+++ b/spec/build/script/shared/appliances/validate.rb
@@ -2,7 +2,7 @@ shared_examples_for 'validates config' do
   let(:fetch_error)    { [:echo, 'Could not fetch .travis.yml from GitHub.', ansi: :red] }
   let(:missing_config) { [:echo, 'Could not find .travis.yml, using standard configuration.', ansi: :red] }
   let(:terminate)      { [:raw, 'travis_terminate 2'] }
-  let(:run_script)     { [:cmd, './the_script', echo: true, timing: true] }
+  let(:run_script)     { [:cmd, './the_script', echo: true, timing: true, assert: true] }
 
   before do
     data[:config][:'.result'] = result

--- a/spec/build/script/shared/jvm.rb
+++ b/spec/build/script/shared/jvm.rb
@@ -27,7 +27,7 @@ shared_examples_for 'a jvm build sexp' do
   end
 
   describe 'script' do
-    let(:options) { { echo: true, timing: true } }
+    let(:options) { { echo: true, timing: true, assert: true } }
     let(:sexp)    { sexp_filter(subject, [:if, '-f gradlew'])[1] }
 
     it 'runs `./gradlew check` if gradlew exists' do

--- a/spec/build/script/shared/script.rb
+++ b/spec/build/script/shared/script.rb
@@ -62,7 +62,7 @@ shared_examples_for 'a build script sexp' do
   it_behaves_like 'rvm use'
 
   it 'calls travis_result' do
-    should include_sexp [:raw, 'travis_result $?']
+    should include_sexp [:raw, 'travis_result $?', assert: true]
   end
 end
 


### PR DESCRIPTION
Users often find it confusing that the first failure in the `script` step does not stop the build. This PR changes this.