### PR TITLE
nix: silence and retry curl

### DIFF
--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -19,6 +19,8 @@ module Travis
         def configure
           super
 
+          sh.cmd "echo '-sS --retry 3' > ~/.curlrc"
+
           # Nix needs to be able to exec on /tmp on Linux
           # This will emit an error in the container but
           # it's still needed for "trusty" Linux.


### PR DESCRIPTION
This will setup curl to automatically silence itself and also retry when something fails. This is just a small tweak to the Nix script that tries to fix a problem we've been having lately with Nix projects.