### PR TITLE
Truncate commit message to 32KB

### DIFF
--- a/lib/travis/build/env/builtin.rb
+++ b/lib/travis/build/env/builtin.rb
@@ -40,7 +40,7 @@ module Travis
               TRAVIS_JOB_NUMBER:      job[:number],
               TRAVIS_BRANCH:          job[:branch],
               TRAVIS_COMMIT:          job[:commit],
-              TRAVIS_COMMIT_MESSAGE: '$(git log --format=%B -n 1)',
+              TRAVIS_COMMIT_MESSAGE: '$(git log --format=%B -n 1 | head -c 32768)',
               TRAVIS_COMMIT_RANGE:    job[:commit_range],
               TRAVIS_REPO_SLUG:       repository[:slug],
               TRAVIS_OS_NAME:         config[:os],

--- a/spec/build/script/shared/appliances/env.rb
+++ b/spec/build/script/shared/appliances/env.rb
@@ -10,7 +10,7 @@ shared_examples_for 'a script with travis env vars sexp' do
     should include_sexp [:export, ['TRAVIS_JOB_NUMBER',      '1.1']]
     should include_sexp [:export, ['TRAVIS_BRANCH',          'master']]
     should include_sexp [:export, ['TRAVIS_COMMIT',          '313f61b']]
-    should include_sexp [:export, ['TRAVIS_COMMIT_MESSAGE',  '$(git log --format=%B -n 1)']]
+    should include_sexp [:export, ['TRAVIS_COMMIT_MESSAGE',  '$(git log --format=%B -n 1 | head -c 32768)']]
     should include_sexp [:export, ['TRAVIS_COMMIT_RANGE',    '313f61b..313f61a']]
     should include_sexp [:export, ['TRAVIS_REPO_SLUG',       'travis-ci/travis-ci']]
     should include_sexp [:export, ['TRAVIS_OS_NAME',         'linux']]


### PR DESCRIPTION
When the commit message is too long, the assignment can result in
mysterious runtime errors.

We avoid this by truncating the message to a reasonable length.

We choose 32K because GitHub's web UI limits its display of
git commit message to something around 29K.

This resolves https://github.com/travis-ci/travis-ci/issues/8443.