### PR TITLE
Allow backtick in the middle of env var value

### DIFF
--- a/lib/travis/build/env/var.rb
+++ b/lib/travis/build/env/var.rb
@@ -10,7 +10,7 @@ module Travis
             |
             \$\(.*?\) # $(things)
             |
-            [^"'`\ ]+ # some bare word, not containing ", ', or `
+            [^"'\ ]+ # some bare word, not containing " or '
                       # (this includes many variations of things starting in $)
             |
             (?=\s) # an empty string (look for a space ahead)

--- a/spec/build/env/var_spec.rb
+++ b/spec/build/env/var_spec.rb
@@ -102,6 +102,10 @@ describe Travis::Build::Env::Var do
       expect(parse('APP_URL=http://$APP_HOST:8080 BAR="bar bar"')).to eq([['APP_URL', 'http://$APP_HOST:8080'], ['BAR', '"bar bar"']])
     end
 
+    it 'allow ` in the middle' do
+      expect(parse('PATH=FOO:`pwd`/bin BAR="bar bar"')).to eq([['PATH', 'FOO:`pwd`/bin'], ['BAR', '"bar bar"']])
+    end
+
     it 'handle space after the initial $ in ()' do
       expect(parse('CAT_VERSION=$(cat VERSION)')).to eq([['CAT_VERSION', '$(cat VERSION)']])
     end


### PR DESCRIPTION
Resolves https://github.com/travis-ci/travis-ci/issues/8442.