### PR TITLE
Allow quoting rules (with ``,'',"", or $()) to be preceded by other chars

### DIFF
--- a/lib/travis/build/env/var.rb
+++ b/lib/travis/build/env/var.rb
@@ -6,9 +6,9 @@ module Travis
         (?:SECURE\ )? # optionally starts with "SECURE "
         ([\w]+)= # left hand side, var name
           ( # right hand side is one of
-            ("|'|`).*?((?<!\\)\3) # quoted stuff
+            (?:[^"'`\ ]?("|'|`).*?((?<!\\)\3))+ # things quoted by ',",`, optionally preceded, one or more times
             |
-            \$\(.*?\) # $(things)
+            (?:[^\$]?\$\(.*?\))+ # $(things), optionally preceded by non-$, one or more times
             |
             [^"'\ ]+ # some bare word, not containing " or '
                       # (this includes many variations of things starting in $)

--- a/spec/build/env/var_spec.rb
+++ b/spec/build/env/var_spec.rb
@@ -106,6 +106,22 @@ describe Travis::Build::Env::Var do
       expect(parse('PATH=FOO:`pwd`/bin BAR="bar bar"')).to eq([['PATH', 'FOO:`pwd`/bin'], ['BAR', '"bar bar"']])
     end
 
+    it '`` with a space inside' do
+      expect(parse('KERNEL=`uname -r` BAR="bar bar"')).to eq([['KERNEL', '`uname -r`'], ['BAR', '"bar bar"']])
+    end
+
+    it 'some stuff, followed by `` with a space inside' do
+      expect(parse('KERNEL=a`uname -r` BAR="bar bar"')).to eq([['KERNEL', 'a`uname -r`'], ['BAR', '"bar bar"']])
+    end
+
+    it 'some stuff, followed by $() with a space inside' do
+      expect(parse('KERNEL=a$(uname -r) BAR="bar bar"')).to eq([['KERNEL', 'a$(uname -r)'], ['BAR', '"bar bar"']])
+    end
+
+    it 'some stuff, followed by "" with a space inside' do
+      expect(parse('KERNEL=a"$(find \"$HOME\" {} \;)" BAR="bar bar"')).to eq([['KERNEL', 'a"$(find \\"$HOME\\" {} \\;)"'], ['BAR', '"bar bar"']])
+    end
+
     it 'handle space after the initial $ in ()' do
       expect(parse('CAT_VERSION=$(cat VERSION)')).to eq([['CAT_VERSION', '$(cat VERSION)']])
     end


### PR DESCRIPTION
And allow repetitions of such things