### PR TITLE
haxe: set default version to 3.4.3

### DIFF
--- a/lib/travis/build/script/haxe.rb
+++ b/lib/travis/build/script/haxe.rb
@@ -17,7 +17,7 @@ module Travis
     class Script
       class Haxe < Script
         DEFAULTS = {
-          haxe: '3.4.2',
+          haxe: '3.4.3',
           neko: '2.1.0'
         }
 


### PR DESCRIPTION
Haxe 3.4.3 was released: https://github.com/HaxeFoundation/haxe/releases/tag/3.4.3
It is a bugfix release with no breaking changes.