### PR TITLE
Append to PATH whether or not /etc/profile.d/pyenv.sh exists

### DIFF
--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -11,7 +11,6 @@ module Travis
         SCRIPT_MISSING       = 'Please override the script: key in your .travis.yml to run tests.'
 
         PYENV_PATH_FILE      = '/etc/profile.d/pyenv.sh'
-        TEMP_PYENV_PATH_FILE = '/tmp/pyenv.sh'
 
         def export
           super
@@ -116,10 +115,7 @@ module Travis
           end
 
           def setup_path(version = 'nightly')
-            sh.if "-f #{PYENV_PATH_FILE}" do
-              sh.cmd "sed -e 's|export PATH=\\(.*\\)$|export PATH=/opt/python/#{version}/bin:\\1|' #{PYENV_PATH_FILE} > #{TEMP_PYENV_PATH_FILE}"
-              sh.cmd "cat #{TEMP_PYENV_PATH_FILE} | sudo tee #{PYENV_PATH_FILE} > /dev/null"
-            end
+            sh.cmd "echo 'export PATH=/opt/python/#{version}/bin:$PATH' | sudo tee -a #{PYENV_PATH_FILE}"
           end
       end
     end

--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -115,7 +115,7 @@ module Travis
           end
 
           def setup_path(version = 'nightly')
-            sh.cmd "echo 'export PATH=/opt/python/#{version}/bin:$PATH' | sudo tee -a #{PYENV_PATH_FILE}"
+            sh.cmd "echo 'export PATH=/opt/python/#{version}/bin:$PATH' | sudo tee -a #{PYENV_PATH_FILE} &>/dev/null"
           end
       end
     end

--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -116,8 +116,10 @@ module Travis
           end
 
           def setup_path(version = 'nightly')
-            sh.cmd "sed -e 's|export PATH=\\(.*\\)$|export PATH=/opt/python/#{version}/bin:\\1|' #{PYENV_PATH_FILE} > #{TEMP_PYENV_PATH_FILE}"
-            sh.cmd "cat #{TEMP_PYENV_PATH_FILE} | sudo tee #{PYENV_PATH_FILE} > /dev/null"
+            sh.if "-f #{PYENV_PATH_FILE}" do
+              sh.cmd "sed -e 's|export PATH=\\(.*\\)$|export PATH=/opt/python/#{version}/bin:\\1|' #{PYENV_PATH_FILE} > #{TEMP_PYENV_PATH_FILE}"
+              sh.cmd "cat #{TEMP_PYENV_PATH_FILE} | sudo tee #{PYENV_PATH_FILE} > /dev/null"
+            end
           end
       end
     end


### PR DESCRIPTION
Removes an error that is visible in job output as:

```
sed: can't read /etc/profile.d/pyenv.sh: No such file or directory
```