### PR TITLE
Remove the option to check reverse dependencies

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -21,7 +21,6 @@ module Travis
           # Build/test options
           r_build_args: '',
           r_check_args: '--as-cran',
-          r_check_revdep: false,
           # Heavy dependencies
           pandoc: true,
           latex: true,
@@ -252,20 +251,6 @@ module Travis
               dump_error_logs
               sh.failure "Found warnings, treating as errors (as requested)."
             end
-          end
-
-          # Check revdeps, if requested.
-          if @devtools_installed and config[:r_check_revdep]
-            sh.echo "Checking reverse dependencies"
-            revdep_script =
-              'library("devtools");' \
-              'res <- revdep_check();' \
-              'if (length(res) > 0) {' \
-              ' revdep_check_summary(res);' \
-              ' revdep_check_save_logs(res);' \
-              ' q(status = 1, save = "no");' \
-              '}'
-            sh.cmd "Rscript -e '#{revdep_script}'", assert: true
           end
 
         end


### PR DESCRIPTION
This can potentially use a lot of resources and it is usually better to
run them locally rather than on travis.

associated doc PR is https://github.com/travis-ci/docs-travis-ci-com/pull/1501