### PR TITLE
Write `~/.pearrc` for pre-installed PHP runtimes

### DIFF
--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -31,6 +31,13 @@ module Travis
             sh.if "$? -ne 0" do
               install_php_on_demand(version)
             end
+            sh.else do
+              sh.fold "pearrc" do
+                sh.echo "Writing $HOME/.pearrc", ansi: :yellow
+                overwrite_pearrc(version)
+                sh.cmd "pear config-show", echo: true
+              end
+            end
             sh.cmd "phpenv global #{version}", assert: true
           end
           sh.cmd "phpenv rehash", assert: false, echo: false, timing: false
@@ -182,6 +189,32 @@ hhvm.libxml.ext_entity_whitelist=file,http,https
             end
             sh.cmd "composer self-update", assert: false
           end
+        end
+
+        def overwrite_pearrc(version)
+          pear_config = %q(
+            [
+              'preferred_state' => "stable",
+              'temp_dir'     => "/tmp/pear/install",
+              'download_dir' => "/tmp/pear/install",
+              'bin_dir'      => "/home/travis/.phpenv/versions/__VERSION__/bin",
+              'php_dir'      => "/home/travis/.phpenv/versions/__VERSION__/share/pear",
+              'doc_dir'      => "/home/travis/.phpenv/versions/__VERSION__/docs",
+              'data_dir'     => "/home/travis/.phpenv/versions/__VERSION__/data",
+              'cfg_dir'      => "/home/travis/.phpenv/versions/__VERSION__/cfg",
+              'www_dir'      => "/home/travis/.phpenv/versions/__VERSION__/www",
+              'man_dir'      => "/home/travis/.phpenv/versions/__VERSION__/man",
+              'test_dir'     => "/home/travis/.phpenv/versions/__VERSION__/tests",
+              '__channels'   => [
+                '__uri' => [],
+                'doc.php.net' => [],
+                'pecl.php.net' => []
+              ],
+              'auto_discover' => 1
+            ]
+          ).gsub("__VERSION__", version)
+
+          sh.cmd "echo '<?php error_reporting(0); echo serialize(#{pear_config}) ?>' | php > $HOME/.pearrc", echo: false
         end
       end
     end


### PR DESCRIPTION
On-demand PHP archives contain `~/.pearrc`, but the pre-installed
ones may have incorrect content depending on in which order
PHP runtimes were installed during the build image provisioning.

We ensure that `~/.pearrc` is reasonable by dumping pear config.