### PR TITLE
Fix nix.rb issue

### DIFF
--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -19,7 +19,9 @@ module Travis
         def configure
           super
 
-          sh.cmd "echo '-sS --retry 3' > ~/.curlrc"
+          sh.cmd "echo '-s' >> ~/.curlrc"
+          sh.cmd "echo '-S' >> ~/.curlrc"
+          sh.cmd "echo '--retry 3' >> ~/.curlrc"
 
           # Nix needs to be able to exec on /tmp on Linux
           # This will emit an error in the container but


### PR DESCRIPTION
Curl gives this warning with 739b37caf8b312a62b254e551cd4760f3e6de697,

Warning: .curlrc:1: warning: '-sS' uses unquoted white space in 
Warning: the line that may cause side-effects!

Hadn't realized there was a special syntax for curlrc. It needs everything on a separate line.

Apologies for the mistake!
Thanks