### PR TITLE
Elixir fixes

### DIFF
--- a/lib/travis/build/script/elixir.rb
+++ b/lib/travis/build/script/elixir.rb
@@ -67,6 +67,8 @@ export MIX_ARCHIVES=#{KIEX_MIX_HOME}elixir-#{elixir_version}' > #{KIEX_ELIXIR_HO
         def otp_release_requirement_satisfied?
           !( elixir_1_0_x? &&  otp_release_18_0_or_higher?) &&
           !( elixir_1_2_0_or_higher? && !otp_release_18_0_or_higher?)
+        rescue
+          false
         end
 
         def method_missing(m, *args, &block)

--- a/lib/travis/build/script/elixir.rb
+++ b/lib/travis/build/script/elixir.rb
@@ -74,6 +74,9 @@ export MIX_ARCHIVES=#{KIEX_MIX_HOME}elixir-#{elixir_version}' > #{KIEX_ELIXIR_HO
           when /\Aelixir_(\d+)_(\d+)_(\d+)_or_higher\?\z/
             x, y, z = $~[1,3].map(&:to_i)
             Gem::Version.new(elixir_version) > Gem::Version.new("#{x}.#{y-1}.999")
+          when /\Aotp_release_(\d+)_(\d+)_or_higher\?\z/
+            x, y = $~[1,2].map(&:to_i)
+            Gem::Version.new(otp_release) > Gem::Version.new("#{x-1}.999")
           else
             super
           end
@@ -82,14 +85,6 @@ export MIX_ARCHIVES=#{KIEX_MIX_HOME}elixir-#{elixir_version}' > #{KIEX_ELIXIR_HO
         def elixir_1_0_x?
           Gem::Version.new(elixir_version) < Gem::Version.new('1.1') &&
           Gem::Version.new(elixir_version) >= Gem::Version.new('1.0.0')
-        end
-
-        def otp_release_18_0_or_higher?
-          Gem::Version.new(otp_release) > Gem::Version.new('17.999')
-        end
-
-        def otp_release_19_0_or_higher?
-          Gem::Version.new(otp_release) > Gem::Version.new('18.999')
         end
 
         def required_otp_version

--- a/lib/travis/build/script/elixir.rb
+++ b/lib/travis/build/script/elixir.rb
@@ -88,7 +88,13 @@ export MIX_ARCHIVES=#{KIEX_MIX_HOME}elixir-#{elixir_version}' > #{KIEX_ELIXIR_HO
         end
 
         def required_otp_version
-          elixir_1_2_0_or_higher? ? '18.0' : '17.4'
+          if elixir_1_6_0_or_higher?
+            '19.0'
+          elsif elixir_1_2_0_or_higher?
+            '18.0'
+          else
+            '17.4'
+          end
         end
 
         def elixir_archive_name(elixir_version, otp_release)

--- a/lib/travis/build/script/elixir.rb
+++ b/lib/travis/build/script/elixir.rb
@@ -69,16 +69,14 @@ export MIX_ARCHIVES=#{KIEX_MIX_HOME}elixir-#{elixir_version}' > #{KIEX_ELIXIR_HO
           !( elixir_1_2_0_or_higher? && !otp_release_18_0_or_higher?)
         end
 
-        def elixir_1_2_0_or_higher?
-          Gem::Version.new(elixir_version) > Gem::Version.new('1.1.999') # use this for pre-release 1.2.0
-        end
-
-        def elixir_1_3_0_or_higher?
-          Gem::Version.new(elixir_version) > Gem::Version.new('1.2.999') # use this for pre-release 1.3.0
-        end
-
-        def elixir_1_4_0_or_higher?
-          Gem::Version.new(elixir_version) > Gem::Version.new('1.3.999')
+        def method_missing(m, *args, &block)
+          case m
+          when /\Aelixir_(\d+)_(\d+)_(\d+)_or_higher\?\z/
+            x, y, z = $~[1,3].map(&:to_i)
+            Gem::Version.new(elixir_version) > Gem::Version.new("#{x}.#{y-1}.999")
+          else
+            super
+          end
         end
 
         def elixir_1_0_x?

--- a/spec/build/script/elixir_spec.rb
+++ b/spec/build/script/elixir_spec.rb
@@ -57,18 +57,18 @@ describe Travis::Build::Script::Elixir, :sexp do
 
         if otp_release_wanted == otp_release_required
           describe "wanted OTP release #{otp_release_wanted}" do
-            xit "is installed" do
+            it "is installed" do
               sexp = sexp_find(subject, [:if, "! -f #{Travis::Build::HOME_DIR}/otp/#{otp_release_wanted}/activate"], [:then])
-              expect(sexp).to include_sexp([:raw, "archive_url=https://s3.amazonaws.com/travis-otp-releases/ubuntu/$(lsb_release -rs)/erlang-#{otp_release_wanted}-x86_64.tar.bz2"])
-              expect(sexp).to include_sexp([:cmd, "wget $archive_url", assert: true, echo: true, timing: true])
+              expect(sexp).to include_sexp([:raw, "archive_url=https://s3.amazonaws.com/travis-otp-releases/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/erlang-#{otp_release_wanted}-nonroot.tar.bz2", assert: true])
+              expect(sexp).to include_sexp([:cmd, "wget -o $HOME/erlang.tar.bz2 ${archive_url}", assert: true, echo: true, timing: true])
             end
           end
         else
           describe "required OTP release #{otp_release_required}" do
-            xit "is installed" do
+            it "is installed" do
               sexp = sexp_find(subject, [:if, "! -f #{Travis::Build::HOME_DIR}/otp/#{otp_release_required}/activate"], [:then])
-              expect(sexp).to include_sexp([:raw, "archive_url=https://s3.amazonaws.com/travis-otp-releases/ubuntu/$(lsb_release -rs)/erlang-#{otp_release_required}-x86_64.tar.bz2"])
-              expect(sexp).to include_sexp([:cmd, "wget $archive_url", assert: true, echo: true, timing: true])
+              expect(sexp).to include_sexp([:raw, "archive_url=https://s3.amazonaws.com/travis-otp-releases/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/erlang-#{otp_release_required}-nonroot.tar.bz2", assert: true])
+              expect(sexp).to include_sexp([:cmd, "wget -o $HOME/erlang.tar.bz2 ${archive_url}", assert: true, echo: true, timing: true])
             end
           end
         end

--- a/spec/build/script/elixir_spec.rb
+++ b/spec/build/script/elixir_spec.rb
@@ -85,5 +85,6 @@ describe Travis::Build::Script::Elixir, :sexp do
   installs_required_otp_release('1.2.0', '17.3', '18.0')
   installs_required_otp_release('1.2.0-dev', '17.4', '18.0')
   installs_required_otp_release('1.0.5', '18.0', '17.4')
+  installs_required_otp_release('1.0.5', 'R16B03-1', '17.4')
 end
 


### PR DESCRIPTION
This PR

1. Adds requirement of OTP Release 19.0 and later for the anticipated Elixir 1.6
1. Reinstates many Elixir specs which were previously skipped
1. Fixes an `ArgumentError` that arises when OTP versions older than 17.0 (such as `R16B03-1`) is specified.