### PR TITLE
Install different versions of dpl based on travis_internal_ruby output

### DIFF
--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -174,7 +174,13 @@ module Travis
 
             def cmd(cmd, *args)
               sh.cmd('type rvm &>/dev/null || source ~/.rvm/scripts/rvm', echo: false, assert: false)
-              sh.cmd("rvm $(travis_internal_ruby) --fuzzy do ruby -S #{cmd}", *args)
+              sh.if("$(travis_internal_ruby) = 1.9*") do
+                sh.raw("_command=\"#{cmd} -v '< 1.9'\"")
+              end
+              sh.else do
+                sh.raw("_command=\"#{cmd}\"")
+              end
+              sh.cmd("rvm $(travis_internal_ruby) --fuzzy do ruby -S $_command", *args)
             end
 
             def options

--- a/spec/spec_helpers/sexp.rb
+++ b/spec/spec_helpers/sexp.rb
@@ -29,6 +29,16 @@ module SpecHelpers
       parts.inject(sexp) { |sexp, part| sexp_filter(sexp, part).first } || []
     end
 
+    def sexp_if_then_else(sexp, condition)
+      # given the `:if` sexp with `condition`, return a hash with keys
+      # :then and :else, each representing `:then` and `:else` s-expressions.
+      # `:else` might be `nil`.
+      # sexp_find(sexp, [:if, condition]) returns s-expression of the form:
+      #   [:if, condition, [:then, []], [:else, []]]
+      # of which we want the second and the third elements
+      [:then, :else].zip(sexp_find(sexp, [:if, condition])[2,2]).to_h
+    end
+
     def sexp_filter(sexp, part, result = [])
       return result unless sexp.is_a?(Array)
       result << sexp if sexp_matches?(sexp[0, part.length], part)


### PR DESCRIPTION
This is the first step in moving `dpl` to a better place, where
we can drop MRI 1.9 support.

We plan to release `dpl` 1.9 in the not-so-distant future, which will
require Ruby >= 2.2.
If `travis_internal_ruby` returns 1.9, then, we need to install
some 1.8.x.

This PR also adds a new helper method for specs, `sexp_if_then_else`,
which looks for the `if` s-expression for the given condition, then
returns the hash naturally mapping to it, with keys `:then` and
`:else`.
This allows a cleaner and more robust search for the s-expression
we want for the specs.