### PR TITLE
Add TRAVIS_BUILD_APP_HOST env for docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,5 @@ services:
     build: .
     ports:
     - 4000:4000
+    environment:
+      - TRAVIS_BUILD_APP_HOST=build.travis-ci.org


### PR DESCRIPTION
So that when running localy the asset URLs can be configured correctly.