### PR TITLE
C#: update Mono repositories to new layout, don't install openssl for .NET Core 2.0

### DIFF
--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -130,7 +130,9 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
               sh.cmd 'sudo apt-get update -qq', timing: true, assert: true
               sh.cmd "sudo apt-get install -qq dotnet-#{dotnet_package_prefix}-#{config[:dotnet]}", timing: true, assert: true
             when 'osx'
-              sh.if '$(sw_vers -productVersion | cut -d . -f 2) -lt 11' do
+              min_osx_minor = 11
+              min_osx_minor = 12 if is_dotnet_after_2_0_prev_2?
+              sh.if "$(sw_vers -productVersion | cut -d . -f 2) -lt #{min_osx_minor}" do
                 sh.failure "The version of this operating system is not supported by .NET Core. View valid versions at https://docs.travis-ci.com/user/languages/csharp/"
               end
               sh.cmd 'brew update', timing: true, assert: true

--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -135,11 +135,13 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
               sh.if "$(sw_vers -productVersion | cut -d . -f 2) -lt #{min_osx_minor}" do
                 sh.failure "The version of this operating system is not supported by .NET Core. View valid versions at https://docs.travis-ci.com/user/languages/csharp/"
               end
-              sh.cmd 'brew update', timing: true, assert: true
-              sh.cmd 'brew install openssl', timing: true, assert: true
-              sh.cmd 'mkdir -p /usr/local/lib', timing: false, assert: true
-              sh.cmd 'ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/', timing: false, assert: true
-              sh.cmd 'ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/', timing: false, assert: true
+              if !is_dotnet_after_2_0_prev_2?
+                sh.cmd 'brew update', timing: true, assert: true
+                sh.cmd 'brew install openssl', timing: true, assert: true
+                sh.cmd 'mkdir -p /usr/local/lib', timing: false, assert: true
+                sh.cmd 'ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/', timing: false, assert: true
+                sh.cmd 'ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/', timing: false, assert: true
+              end
               sh.cmd "wget --retry-connrefused --waitretry=1 -O /tmp/dotnet.pkg #{dotnet_osx_url}", timing: true, assert: true, echo: true
               sh.cmd 'sudo installer -package "/tmp/dotnet.pkg" -target "/" -verboseR', timing: true, assert: true
               sh.cmd 'eval $(/usr/libexec/path_helper -s)', timing: false, assert: true

--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -48,7 +48,7 @@ View valid versions of \"mono\" at https://docs.travis-ci.com/user/languages/csh
 
                 if is_mono_after_5_0
                   # new Mono repo layout
-                  repo_prefix = 'alpha-' if config[:mono] == 'alpha'
+                  repo_prefix = 'alpha-' if config[:mono] == 'alpha' || config[:mono] == 'nightly' || config[:mono] == 'weekly'
                   repo_prefix = 'beta-'  if config[:mono] == 'beta'
                   repo_suffix = "/snapshots/#{config[:mono]}" if !is_mono_version_keyword?
 

--- a/spec/build/script/csharp_spec.rb
+++ b/spec/build/script/csharp_spec.rb
@@ -66,9 +66,19 @@ describe Travis::Build::Script::Csharp, :sexp do
       should include_sexp [:echo, "\"foo\" is either an invalid version of \"mono\" or unsupported on this operating system.\nView valid versions of \"mono\" at https://docs.travis-ci.com/user/languages/csharp/"]
     end
 
+    it 'throws a error with an invalid Mono version as float' do
+      data[:config][:mono] = 5.2
+      should include_sexp [:echo, "\"5.2\" is either an invalid version of \"mono\" or unsupported on this operating system.\nView valid versions of \"mono\" at https://docs.travis-ci.com/user/languages/csharp/"]
+    end
+
     it 'throws a error with an invalid .NET Core version' do
       data[:config][:dotnet] = 'foo'
       should include_sexp [:echo, "\"foo\" is either an invalid version of \"dotnet\" or unsupported on this operating system.\nView valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/csharp/"]
+    end
+
+    it 'throws a error with an invalid .NET Core version as float' do
+      data[:config][:dotnet] = 2.0
+      should include_sexp [:echo, "\"2.0\" is either an invalid version of \"dotnet\" or unsupported on this operating system.\nView valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/csharp/"]
     end
 
     it 'throws a error with an invalid version' do

--- a/spec/build/script/csharp_spec.rb
+++ b/spec/build/script/csharp_spec.rb
@@ -15,8 +15,7 @@ describe Travis::Build::Script::Csharp, :sexp do
   describe 'configure' do
     it 'sets up package repository for mono' do
       should include_sexp [:cmd, 'sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF', assert: true]
-      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian wheezy main' >> /etc/apt/sources.list.d/mono-xamarin.list\"", assert: true]
-      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian wheezy-libtiff-compat main' >> /etc/apt/sources.list.d/mono-xamarin.list\"", assert: true]
+      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu trusty main' > /etc/apt/sources.list.d/mono-official.list\"", assert: true]
       should include_sexp [:cmd, 'sudo apt-get update -qq', timing: true, assert: true]
     end
 
@@ -103,32 +102,37 @@ describe Travis::Build::Script::Csharp, :sexp do
     end
 
     it 'selects latest version by default' do
-      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian wheezy main' >> /etc/apt/sources.list.d/mono-xamarin.list\"", assert: true]
+      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu trusty main' > /etc/apt/sources.list.d/mono-official.list\"", assert: true]
     end
 
     it 'selects correct version' do
       data[:config][:mono] = '3.12.0'
-      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian wheezy/snapshots/3.12.0 main' >> /etc/apt/sources.list.d/mono-xamarin.list\"", assert: true]
+      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian wheezy/snapshots/3.12.0 main' >> /etc/apt/sources.list.d/mono-official.list\"", assert: true]
+    end
+
+    it 'selects correct version on new repo' do
+      data[:config][:mono] = '5.2.0'
+      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu trusty/snapshots/5.2.0 main' > /etc/apt/sources.list.d/mono-official.list\"", assert: true]
     end
 
     it 'selects alpha version when specified' do
       data[:config][:mono] = 'alpha'
-      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu alpha-trusty main' > /etc/apt/sources.list.d/mono-official-alpha.list\"", assert: true]
+      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu alpha-trusty main' > /etc/apt/sources.list.d/mono-official.list\"", assert: true]
     end
 
     it 'selects beta version when specified' do
       data[:config][:mono] = 'beta'
-      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian beta main' >> /etc/apt/sources.list.d/mono-xamarin.list\"", assert: true]
+      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu beta-trusty main' > /etc/apt/sources.list.d/mono-official.list\"", assert: true]
     end
 
     it 'selects nightly (which really is weekly, but kept to avoid breaking existing scripts) version when specified' do
       data[:config][:mono] = 'nightly'
-      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian nightly main' >> /etc/apt/sources.list.d/mono-xamarin.list\"", assert: true]
+      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu nightly main' >> /etc/apt/sources.list.d/mono-official.list\"", assert: true]
     end
 
     it 'selects weekly version when specified' do
       data[:config][:mono] = 'weekly'
-      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian nightly main' >> /etc/apt/sources.list.d/mono-xamarin.list\"", assert: true]
+      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu nightly main' >> /etc/apt/sources.list.d/mono-official.list\"", assert: true]
     end
 
     it 'selects no version of Mono when specified' do

--- a/spec/build/script/csharp_spec.rb
+++ b/spec/build/script/csharp_spec.rb
@@ -218,10 +218,7 @@ describe Travis::Build::Script::Csharp, :sexp do
     it 'installs dotnet 2.0 preview 2 and above' do
       data[:config][:os] = 'osx'
       data[:config][:dotnet] = '2.0.0-preview2-006497'
-      should include_sexp [:cmd, "brew install openssl", timing: true, assert: true]
-      should include_sexp [:cmd, "mkdir -p /usr/local/lib", assert: true]
-      should include_sexp [:cmd, "ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/", assert: true]
-      should include_sexp [:cmd, "ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/", assert: true]
+      should_not include_sexp [:cmd, "brew install openssl", timing: true, assert: true]
       should include_sexp [:cmd, "wget --retry-connrefused --waitretry=1 -O /tmp/dotnet.pkg https://dotnetcli.azureedge.net/dotnet/Sdk/2.0.0-preview2-006497/dotnet-sdk-2.0.0-preview2-006497-osx-x64.pkg", timing: true, assert: true, echo: true]
       should include_sexp [:cmd, "sudo installer -package \"/tmp/dotnet.pkg\" -target \"/\" -verboseR", timing: true, assert: true]
       should include_sexp [:cmd, "eval $(/usr/libexec/path_helper -s)", assert: true]


### PR DESCRIPTION
The new repo layout was already there for alpha, but we need it for beta and stable as well.

We can also skip installing openssl on .NET Core 2.0 on OSX since it's no longer required.

@BanzaiMan would be great to get a staging deploy for this so I can test it :)