### PR TITLE
Reorder appliances

### DIFF
--- a/lib/travis/build/appliances.rb
+++ b/lib/travis/build/appliances.rb
@@ -32,6 +32,7 @@ require 'travis/build/appliances/setup_filter'
 require 'travis/build/appliances/validate'
 require 'travis/build/appliances/npm_registry'
 require 'travis/build/appliances/update_rubygems'
+require 'travis/build/appliances/apt_get_update'
 
 module Travis
   module Build

--- a/lib/travis/build/appliances/apt_get_update.rb
+++ b/lib/travis/build/appliances/apt_get_update.rb
@@ -3,14 +3,12 @@ require 'travis/build/appliances/base'
 module Travis
   module Build
     module Appliances
-      class FixRwkyRedis < Base
+      class AptGetUpdate < Base
         def apply
           command = <<-EOF
           if [[ -d /var/lib/apt/lists && -n $(command -v apt-get) ]]; then
-            for f in $(grep -l rwky/redis /etc/apt/sources.list.d/*); do
-              sed 's,rwky/redis,rwky/ppa,g' $f > /tmp/${f##**/}
-              sudo mv /tmp/${f##**/} /etc/apt/sources.list.d
-            done
+            sudo rm -rf /var/lib/apt/lists/*
+            sudo apt-get update -qq 2>&1 >/dev/null
           fi
           EOF
           sh.cmd command, echo: false

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -161,6 +161,7 @@ module Travis
           apply :show_system_info
           apply :rm_riak_source
           apply :fix_rwky_redis
+          apply :update_mongodb32_key
           apply :apt_get_update
           apply :fix_container_based_trusty
           apply :fix_sudo_enabled_trusty
@@ -181,7 +182,6 @@ module Travis
           apply :debug_tools
           apply :npm_registry
           apply :rvm_use
-          apply :update_mongodb32_key
           apply :rm_oraclejdk8_symlink
           apply :enable_i386
           apply :update_rubygems

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -161,6 +161,7 @@ module Travis
           apply :show_system_info
           apply :rm_riak_source
           apply :fix_rwky_redis
+          apply :apt_get_update
           apply :fix_container_based_trusty
           apply :fix_sudo_enabled_trusty
           apply :update_glibc


### PR DESCRIPTION
Separate the execution of `apt-get update` and remove MongoDB 3.2 key before the first invocation of `apt-get update`.