### PR TITLE
Skip overwriting ~/.pearrc for PHP 5.3 and older

### DIFF
--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -31,8 +31,8 @@ module Travis
             sh.if "$? -ne 0" do
               install_php_on_demand(version)
             end
-            sh.else do
-              unless php_5_3_or_older?
+            unless php_5_3_or_older?
+              sh.else do
                 sh.fold "pearrc" do
                   sh.echo "Writing $HOME/.pearrc", ansi: :yellow
                   overwrite_pearrc(version)

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -32,10 +32,12 @@ module Travis
               install_php_on_demand(version)
             end
             sh.else do
-              sh.fold "pearrc" do
-                sh.echo "Writing $HOME/.pearrc", ansi: :yellow
-                overwrite_pearrc(version)
-                sh.cmd "pear config-show", echo: true
+              unless php_5_3_or_older?
+                sh.fold "pearrc" do
+                  sh.echo "Writing $HOME/.pearrc", ansi: :yellow
+                  overwrite_pearrc(version)
+                  sh.cmd "pear config-show", echo: true
+                end
               end
             end
             sh.cmd "phpenv global #{version}", assert: true
@@ -189,6 +191,10 @@ hhvm.libxml.ext_entity_whitelist=file,http,https
             end
             sh.cmd "composer self-update", assert: false
           end
+        end
+
+        def php_5_3_or_older?
+          !hhvm? && Gem::Version.new(version) < Gem::Version.new('5.4')
         end
 
         def overwrite_pearrc(version)

--- a/spec/build/script/php_spec.rb
+++ b/spec/build/script/php_spec.rb
@@ -40,6 +40,13 @@ describe Travis::Build::Script::Php, :sexp do
     xit { should include_sexp [:cmd, 'curl -s -o archive.tar.bz2 $archive_url && tar xjf archive.tar.bz2 --directory /', timing: true] }
   end
 
+  describe 'installs php nightly' do
+    before { data[:config][:php] = '5.3' }
+    # expect(sexp).to include_sexp [:raw, "archive_url=https://s3.amazonaws.com/travis-php-archives/php-#{version}-archive.tar.bz2"]
+    it { should include_sexp [:cmd, 'curl -s -o archive.tar.bz2 $archive_url && tar xjf archive.tar.bz2 --directory /', echo: true, timing: true] }
+    it { store_example "5.3" }
+  end
+
   describe 'installs php 7' do
     before { data[:config][:php] = '7' }
     it { should include_sexp [:cmd, 'ln -s ~/.phpenv/versions/7.0 ~/.phpenv/versions/7', assert: true, timing: true] }

--- a/spec/build/script/php_spec.rb
+++ b/spec/build/script/php_spec.rb
@@ -40,11 +40,18 @@ describe Travis::Build::Script::Php, :sexp do
     xit { should include_sexp [:cmd, 'curl -s -o archive.tar.bz2 $archive_url && tar xjf archive.tar.bz2 --directory /', timing: true] }
   end
 
-  describe 'installs php nightly' do
-    before { data[:config][:php] = '5.3' }
-    # expect(sexp).to include_sexp [:raw, "archive_url=https://s3.amazonaws.com/travis-php-archives/php-#{version}-archive.tar.bz2"]
-    it { should include_sexp [:cmd, 'curl -s -o archive.tar.bz2 $archive_url && tar xjf archive.tar.bz2 --directory /', echo: true, timing: true] }
-    it { store_example "5.3" }
+  context 'with php 5.4' do
+    describe 'writes ~/.pearrc if necessary' do
+      before { data[:config][:php] = '5.4' }
+      it { should include_sexp [:echo, 'Writing $HOME/.pearrc', ansi: :yellow] }
+    end
+  end
+
+  context 'with php 5.3' do
+    describe 'does not write ~/.pearrc' do
+      before { data[:config][:php] = '5.3' }
+      it { should_not include_sexp [:echo, 'Writing $HOME/.pearrc', ansi: :yellow] }
+    end
   end
 
   describe 'installs php 7' do


### PR DESCRIPTION
PHP 5.3 and older have problems with the `[]` array syntax, so we
need to avoid it.

Resolves https://github.com/travis-ci/travis-ci/issues/8639.