### PR TITLE
Quietly exit when `-v` is passed

### DIFF
--- a/lib/travis/build/appliances/disable_sudo.rb
+++ b/lib/travis/build/appliances/disable_sudo.rb
@@ -11,9 +11,22 @@ if [[ -f \$HOME/.sudo-run ]]; then
   exit 1
 fi
 
+OPTIND=1
+while getopts "v" opt; do
+  case $opt in
+  v)
+    QUIET=1
+    ;;
+  esac
+done
+
+shift "$((OPTIND-1))"
+
+if [[ $QUIET != 1 ]]; then
 echo -e "\\\\033[33;1mThis job is running on container-based infrastructure, which does not allow use of 'sudo', setuid, and setgid executables.\\\\033[0m
 \\\\033[33;1mIf you require sudo, add 'sudo: required' to your .travis.yml\\\\033[0m
 "
+fi
 
 touch \$HOME/.sudo-run
 


### PR DESCRIPTION
So that this can be invoked without drawing attention
on the first invocation.