### PR TITLE
Update naming scheme for Julia binaries

### DIFF
--- a/lib/travis/build/script/julia.rb
+++ b/lib/travis/build/script/julia.rb
@@ -94,14 +94,14 @@ module Travis
               ext = 'linux-x86_64.tar.gz'
               nightlyext = 'linux64.tar.gz'
             when 'osx'
-              osarch = 'osx/x64'
-              ext = 'osx10.7+.dmg'
-              nightlyext = 'osx.dmg'
+              osarch = 'mac/x64'
+              ext = 'mac64.dmg'
+              nightlyext = ext
             end
             case config[:julia].to_s
             when 'release'
               # CHANGEME on new minor releases (once or twice a year)
-              url = "julialang-s3.julialang.org/bin/#{osarch}/0.5/julia-0.5-latest-#{ext}"
+              url = "julialang-s3.julialang.org/bin/#{osarch}/0.6/julia-0.6-latest-#{ext}"
             when 'nightly'
               url = "julialangnightlies-s3.julialang.org/bin/#{osarch}/julia-latest-#{nightlyext}"
             when /^(\d+\.\d+)\.\d+$/


### PR DESCRIPTION
The naming scheme changed recently, which broke Travis builds on macOS for Julia nightly. This PR also bumps 'release' to point to 0.6 instead of 0.5.

Fixes https://github.com/JuliaLang/julia/issues/24308

cc @staticfloat