### PR TITLE
Fix last fold in R scripts

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -258,6 +258,10 @@ module Travis
           # information.
           dump_log("out")
 
+          # If a fold (like dump log) is the last command it is not folded, so
+          # add a dummy command
+          sh.cmd 'TRUE', echo: false
+
           # Check revdeps, if requested.
           if @devtools_installed and config[:r_check_revdep]
             sh.echo "Checking reverse dependencies"


### PR DESCRIPTION
If the last command is in a fold the fold will be expanded. In the
common case dumping the output logs is the last command, but we don't
want the fold expanded. So simply add a dummy command after dumping the
fold.