### PR TITLE
Add steps to include private auth steps hex.pm

### DIFF
--- a/spec/build/script/elixir_spec.rb
+++ b/spec/build/script/elixir_spec.rb
@@ -31,6 +31,23 @@ describe Travis::Build::Script::Elixir, :sexp do
     it 'runs "mix deps.get"' do
       should include_sexp [:cmd, 'mix deps.get',  assert: true, echo: true, timing: true]
     end
+
+    context "when hex_org_key is not given" do
+      it "does not authenticate with mix server" do
+        should_not include_sexp [:cmd, 'mix hex.organization auth acme --key 126d49fb3014bd26457471ebae97c625', assert: true, echo: true, timing: true]
+      end
+    end
+
+    context "when hex_org_keys is given" do
+      before :each do
+        data[:config][:hex_org_keys] = ['126d49fb3014bd26457471ebae97c625']
+      end
+
+      it "authenticates with mix server" do
+        should include_sexp [:cmd, 'mix hex.organization auth acme --key 126d49fb3014bd26457471ebae97c625', assert: true, echo: true, timing: true]
+        store_example "hex_org_keys"
+      end
+    end
   end
 
   describe 'script' do


### PR DESCRIPTION
This PR adds a step to run `mix hex.organization auth acme` commands with the auth keys given in `hex_org_keys`.

`hex_org_keys` is either a scalar or an array of auth keys.