### PR TITLE
apply hhvm fix not for precise

### DIFF
--- a/lib/travis/build/appliances/fix_hhvm_source.rb
+++ b/lib/travis/build/appliances/fix_hhvm_source.rb
@@ -6,7 +6,7 @@ module Travis
     module Appliances
       class FixHhvmSource < Base
         def apply
-          sh.if "$(command -v lsb_release)" do
+          sh.if "$(command -v lsb_release) && $(lsb_release -cs) != precise" do
             command = <<-EOF
             if [[ -d /var/lib/apt/lists && -n $(command -v apt-get) ]]; then
               grep -l -i -r hhvm /etc/apt/sources.list.d | xargs sudo rm -vf
@@ -14,7 +14,7 @@ module Travis
             EOF
             sh.cmd command, echo: false
             sh.cmd "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94", echo: false, assert: false, sudo: true
-            sh.cmd 'add-apt-repository "deb [ arch=amd64 ] http://dl.hhvm.com/ubuntu $(lsb_release -sc) main"', echo: false, assert: false, sudo: true
+            sh.cmd 'add-apt-repository "deb [ arch=amd64 ] https://dl.hhvm.com/ubuntu $(lsb_release -sc) main"', echo: false, assert: false, sudo: true
           end
         end
       end


### PR DESCRIPTION
On Precise builds, the following error:
`Error: 'deb [ arch=amd64 ] http://dl.hhvm.com/ubuntu precise main' invalid`

As HHVM is not targeting precise anymore, the apt-repository only needs to be updated when the dist is not precise, see https://github.com/travis-ci/travis-ci/issues/7827

This works as expected:
https://staging.travis-ci.org/travis-ci/travis_staging_test/builds/656494