### PR TITLE
Remove hhvm repo for images used by enterprise

### DIFF
--- a/lib/travis/build/appliances/fix_hhvm_source.rb
+++ b/lib/travis/build/appliances/fix_hhvm_source.rb
@@ -1,4 +1,3 @@
-
 require 'travis/build/appliances/base'
 
 module Travis
@@ -6,16 +5,17 @@ module Travis
     module Appliances
       class FixHhvmSource < Base
         def apply
-          sh.if "$(command -v lsb_release) && $(lsb_release -cs) != precise" do
-            command = <<-EOF
-            if [[ -d /var/lib/apt/lists && -n $(command -v apt-get) ]]; then
-              grep -l -i -r hhvm /etc/apt/sources.list.d | xargs sudo rm -vf
-            fi
-            EOF
-            sh.cmd command, echo: false
-            sh.cmd "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94", echo: false, assert: false, sudo: true
-            sh.cmd 'add-apt-repository "deb [ arch=amd64 ] https://dl.hhvm.com/ubuntu $(lsb_release -sc) main"', echo: false, assert: false, sudo: true
-          end
+          command = <<-EOF
+            if command -v lsb_release; then
+              grep -l -i -r hhvm /etc/apt/sources.list.d | xargs sudo rm -f
+              sudo sed -i /hhvm/d /etc/apt/sources.list
+              if [[ $(lsb_release -cs) = trusty ]]; then
+                sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94
+                sudo add-apt-repository "deb [arch=amd64] https://dl.hhvm.com/ubuntu $(lsb_release -sc) main"
+              fi
+            fi &>/dev/null
+          EOF
+          sh.cmd command, assert: false
         end
       end
     end


### PR DESCRIPTION
(@bnferguson writing here)

Fixes issue we saw in https://github.com/travis-ci/travis-build/pull/1250#issuecomment-345972929  where Precise images would still have issues after the previous fixes. HHVM doesn't have a precise build anymore, so the solution is to just remove the repo. 