### PR TITLE
Wrap `brew` command with `do_brew()` function

### DIFF
--- a/lib/travis/build/appliances/debug_tools.rb
+++ b/lib/travis/build/appliances/debug_tools.rb
@@ -28,8 +28,8 @@ module Travis
               end
               sh.else do
                 sh.echo "We are setting up the debug environment. This may take a while..."
-                sh.cmd "brew update &> /dev/null", echo: false, retry: true
-                sh.cmd "brew install tmate &> /dev/null", echo: false, retry: true
+                sh.cmd "do_brew update &> /dev/null", echo: false, retry: true
+                sh.cmd "do_brew install tmate &> /dev/null", echo: false, retry: true
               end
             end
 

--- a/lib/travis/build/script/crystal.rb
+++ b/lib/travis/build/script/crystal.rb
@@ -27,8 +27,8 @@ module Travis
               if config[:crystal] && config[:crystal] != "latest"
                 sh.failure %Q(Specifying Crystal version is not yet supported by the macOS environment)
               end
-              sh.cmd %q(brew update)
-              sh.cmd %q(brew install crystal-lang)
+              sh.cmd %q(do_brew update)
+              sh.cmd %q(do_brew install crystal-lang)
             else
               sh.failure %Q(Operating system not supported: "#{config[:os]}")
             end

--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -152,8 +152,8 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
                 sh.failure "The version of this operating system is not supported by .NET Core. View valid versions at https://docs.travis-ci.com/user/languages/csharp/"
               end
               if !is_dotnet_after_2_0_prev_2?
-                sh.cmd 'brew update', timing: true, assert: true
-                sh.cmd 'brew install openssl', timing: true, assert: true
+                sh.cmd 'do_brew update', timing: true, assert: true
+                sh.cmd 'do_brew install openssl', timing: true, assert: true
                 sh.cmd 'mkdir -p /usr/local/lib', timing: false, assert: true
                 sh.cmd 'ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/', timing: false, assert: true
                 sh.cmd 'ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/', timing: false, assert: true
@@ -226,7 +226,7 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
             return "https://dotnetcli.azureedge.net/dotnet/Sdk/#{config_dotnet}/dotnet-#{dotnet_package_prefix}-#{config_dotnet}-osx-x64.pkg"
           end
         end
-	
+
         def dotnet_is_preview?
           return config_dotnet.include? "-preview"
         end

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -111,7 +111,7 @@ module Travis
               when 'osx'
                 # We want to update, but we don't need the 800+ lines of
                 # output.
-                sh.cmd 'brew update >/dev/null', retry: true
+                sh.cmd 'do_brew update >/dev/null', retry: true
 
                 # R-devel builds available at research.att.com
                 if r_version == 'devel'
@@ -363,7 +363,7 @@ module Travis
           return unless (config[:os] == 'osx')
           pkg_arg = packages.join(' ')
           sh.echo "Installing brew packages: #{packages.join(', ')}"
-          sh.cmd "brew install #{pkg_arg}", retry: true
+          sh.cmd "do_brew install #{pkg_arg}", retry: true
         end
 
         def install_deps

--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -273,6 +273,22 @@ vers2int() {
   printf '1%03d%03d%03d%03d' $(echo "$1" | tr '.' ' ')
 }
 
+_ensure_ruby_23() {
+  if ! (rvm list | grep 2\.[3-9] 2>&1 >/dev/null); then
+    echo "${ANSI_YELLOW}Homebrew requires Ruby 2.3 or later.${ANSI_RESET}"
+    rvm install 2.3 --binary --fuzzy
+  fi
+}
+
+do_brew() {
+  if [[ $(vers2int $(ruby -e 'puts RUBY_VERSION')) -lt $(vers2int 2.3) ]]; then
+    _ensure_ruby_23
+    rvm 2.3 do brew "$@"
+  else
+    brew "$@"
+  fi
+}
+
 <%# based on http://stackoverflow.com/a/30576368 by gniourf_gniourf :heart_eyes_cat: %>
 bash_qsort_numeric() {
    local pivot i smaller=() larger=()

--- a/spec/build/script/crystal_spec.rb
+++ b/spec/build/script/crystal_spec.rb
@@ -30,7 +30,7 @@ describe Travis::Build::Script::Crystal, :sexp do
 
     it "installs latest macOS release by default" do
       data[:config][:os] = "osx"
-      should include_sexp [:cmd, "brew install crystal-lang"]
+      should include_sexp [:cmd, "do_brew install crystal-lang"]
     end
 
     it "installs latest linux release when explicitly asked for" do

--- a/spec/build/script/csharp_spec.rb
+++ b/spec/build/script/csharp_spec.rb
@@ -204,7 +204,7 @@ describe Travis::Build::Script::Csharp, :sexp do
     it 'installs dotnet 1.0' do
       data[:config][:os] = 'osx'
       data[:config][:dotnet] = '1.0.0-preview2-003121'
-      should include_sexp [:cmd, "brew install openssl", timing: true, assert: true]
+      should include_sexp [:cmd, "do_brew install openssl", timing: true, assert: true]
       should include_sexp [:cmd, "mkdir -p /usr/local/lib", assert: true]
       should include_sexp [:cmd, "ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/", assert: true]
       should include_sexp [:cmd, "ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/", assert: true]
@@ -216,7 +216,7 @@ describe Travis::Build::Script::Csharp, :sexp do
     it 'installs dotnet 2.0 preview 1' do
       data[:config][:os] = 'osx'
       data[:config][:dotnet] = '2.0.0-preview1-005977'
-      should include_sexp [:cmd, "brew install openssl", timing: true, assert: true]
+      should include_sexp [:cmd, "do_brew install openssl", timing: true, assert: true]
       should include_sexp [:cmd, "mkdir -p /usr/local/lib", assert: true]
       should include_sexp [:cmd, "ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/", assert: true]
       should include_sexp [:cmd, "ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/", assert: true]
@@ -228,7 +228,7 @@ describe Travis::Build::Script::Csharp, :sexp do
     it 'installs dotnet 2.0 preview 2 and above' do
       data[:config][:os] = 'osx'
       data[:config][:dotnet] = '2.0.0-preview2-006497'
-      should_not include_sexp [:cmd, "brew install openssl", timing: true, assert: true]
+      should_not include_sexp [:cmd, "do_brew install openssl", timing: true, assert: true]
       should include_sexp [:cmd, "wget --retry-connrefused --waitretry=1 -O /tmp/dotnet.pkg https://dotnetcli.azureedge.net/dotnet/Sdk/2.0.0-preview2-006497/dotnet-sdk-2.0.0-preview2-006497-osx-x64.pkg", timing: true, assert: true, echo: true]
       should include_sexp [:cmd, "sudo installer -package \"/tmp/dotnet.pkg\" -target \"/\" -verboseR", timing: true, assert: true]
       should include_sexp [:cmd, "eval $(/usr/libexec/path_helper -s)", assert: true]


### PR DESCRIPTION
To ensure that `brew` commands are run with Ruby 2.3 or later