### PR TITLE
C#: switch .NET Core to new repository

### DIFF
--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -28,8 +28,8 @@ module Travis
           config[:solution].to_s if config[:solution]
         end
 
-        MONO_VERSION_REGEXP = /^(\d{1})\.(\d{1,2})\.\d{1,2}$/
-        DOTNET_VERSION_REGEXP = /^\d{1}\.\d{1,2}\.\d{1,2}(?:-(?:preview|rc)\d+(\.\d+)?(?:-\d)?-\d{6})?$/
+        MONO_VERSION_REGEXP   = /^(\d{1})\.(\d{1,2})\.\d{1,2}$/
+        DOTNET_VERSION_REGEXP = /^(\d{1})\.(\d{1,2})\.\d{1,2}$/
 
         def configure
           super
@@ -133,12 +133,12 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
 
             case config_os
             when 'linux'
-              sh.cmd 'sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 417A0893', assert: true
+              sh.cmd 'sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BE1229CF', assert: true
               sh.if '$(lsb_release -cs) = trusty' do
-                sh.cmd "sudo sh -c \"echo 'deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main' > /etc/apt/sources.list.d/dotnetdev.list\"", assert: true
+                sh.cmd "sudo sh -c \"echo 'deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-trusty-prod trusty main' > /etc/apt/sources.list.d/dotnetdev.list\"", assert: true
               end
               sh.elif '$(lsb_release -cs) = xenial' do
-                sh.cmd "sudo sh -c \"echo 'deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ xenial main' > /etc/apt/sources.list.d/dotnetdev.list\"", assert: true
+                sh.cmd "sudo sh -c \"echo 'deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-xenial-prod xenial main' > /etc/apt/sources.list.d/dotnetdev.list\"", assert: true
               end
               sh.else do
                 sh.failure "The version of this operating system is not supported by .NET Core. View valid versions at https://docs.travis-ci.com/user/languages/csharp/"
@@ -147,11 +147,11 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
               sh.cmd "sudo apt-get install -qq dotnet-#{dotnet_package_prefix}-#{config_dotnet}", timing: true, assert: true
             when 'osx'
               min_osx_minor = 11
-              min_osx_minor = 12 if is_dotnet_after_2_0_prev_2?
+              min_osx_minor = 12 if is_dotnet_after_2_0?
               sh.if "$(sw_vers -productVersion | cut -d . -f 2) -lt #{min_osx_minor}" do
                 sh.failure "The version of this operating system is not supported by .NET Core. View valid versions at https://docs.travis-ci.com/user/languages/csharp/"
               end
-              if !is_dotnet_after_2_0_prev_2?
+              if !is_dotnet_after_2_0?
                 sh.cmd 'brew update', timing: true, assert: true
                 sh.cmd 'brew install openssl', timing: true, assert: true
                 sh.cmd 'mkdir -p /usr/local/lib', timing: false, assert: true
@@ -218,21 +218,15 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
         end
 
         def dotnet_osx_url
-          if is_dotnet_1_0? && dotnet_is_preview?
-            return "https://dotnetcli.azureedge.net/dotnet/preview/Installers/#{config_dotnet}/dotnet-#{dotnet_package_prefix}-osx-x64.#{config_dotnet}.pkg"
-          elsif !is_dotnet_after_2_0_prev_2?
-            return "https://dotnetcli.azureedge.net/dotnet/Sdk/#{config_dotnet}/dotnet-#{dotnet_package_prefix}-osx-x64.#{config_dotnet}.pkg"
-          else
+          if is_dotnet_after_2_0?
             return "https://dotnetcli.azureedge.net/dotnet/Sdk/#{config_dotnet}/dotnet-#{dotnet_package_prefix}-#{config_dotnet}-osx-x64.pkg"
+          else
+            return "https://dotnetcli.azureedge.net/dotnet/Sdk/#{config_dotnet}/dotnet-#{dotnet_package_prefix}-osx-x64.#{config_dotnet}.pkg"
           end
-        end
-	
-        def dotnet_is_preview?
-          return config_dotnet.include? "-preview"
         end
 
         def dotnet_package_prefix
-          return is_dotnet_after_2_0_prev_2? ? "sdk" : "dev"
+          return is_dotnet_after_2_0? ? "sdk" : "dev"
         end
 
         def is_mono_version_valid?
@@ -306,14 +300,12 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
           true
         end
 
-        def is_dotnet_after_2_0_prev_2?
-          return false unless config_dotnet[0].to_i > 1
-          return false if config_dotnet.include? "2.0.0-preview1"
-          true
-        end
+        def is_dotnet_after_2_0?
+          return false unless is_dotnet_version_valid?
 
-        def is_dotnet_1_0?
-          return config_dotnet[0] == '1'
+          return false if DOTNET_VERSION_REGEXP.match(config_dotnet)[1].to_i < 2
+
+          true
         end
       end
     end

--- a/spec/build/script/csharp_spec.rb
+++ b/spec/build/script/csharp_spec.rb
@@ -19,24 +19,17 @@ describe Travis::Build::Script::Csharp, :sexp do
       should include_sexp [:cmd, 'sudo apt-get update -qq', timing: true, assert: true]
     end
 
-    it 'sets up package repository for dotnet 1.0' do
-      data[:config][:dotnet] = '1.0.0-preview2-003121'
-      should include_sexp [:cmd, 'sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 417A0893', assert: true]
-      should include_sexp [:cmd, "sudo sh -c \"echo 'deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main' > /etc/apt/sources.list.d/dotnetdev.list\"", assert: true]
+    it 'sets up package repository for dotnet 1.1.5' do
+      data[:config][:dotnet] = '1.1.5'
+      should include_sexp [:cmd, 'sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BE1229CF', assert: true]
+      should include_sexp [:cmd, "sudo sh -c \"echo 'deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-trusty-prod trusty main' > /etc/apt/sources.list.d/dotnetdev.list\"", assert: true]
       should include_sexp [:cmd, 'sudo apt-get update -qq', timing: true, assert: true]
     end
 
-    it 'sets up package repository for dotnet 2.0 preview 1' do
-      data[:config][:dotnet] = '2.0.0-preview1-005977'
-      should include_sexp [:cmd, 'sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 417A0893', assert: true]
-      should include_sexp [:cmd, "sudo sh -c \"echo 'deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main' > /etc/apt/sources.list.d/dotnetdev.list\"", assert: true]
-      should include_sexp [:cmd, 'sudo apt-get update -qq', timing: true, assert: true]
-    end
-
-    it 'sets up package repository for dotnet 2.0 preview 2 and above' do
-      data[:config][:dotnet] = '2.0.0-preview2-006497'
-      should include_sexp [:cmd, 'sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 417A0893', assert: true]
-      should include_sexp [:cmd, "sudo sh -c \"echo 'deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main' > /etc/apt/sources.list.d/dotnetdev.list\"", assert: true]
+    it 'sets up package repository for dotnet 2.0.0 and above' do
+      data[:config][:dotnet] = '2.0.0'
+      should include_sexp [:cmd, 'sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BE1229CF', assert: true]
+      should include_sexp [:cmd, "sudo sh -c \"echo 'deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-trusty-prod trusty main' > /etc/apt/sources.list.d/dotnetdev.list\"", assert: true]
       should include_sexp [:cmd, 'sudo apt-get update -qq', timing: true, assert: true]
     end
 
@@ -44,19 +37,14 @@ describe Travis::Build::Script::Csharp, :sexp do
       should include_sexp [:cmd, 'sudo apt-get install -qq mono-complete mono-vbnc fsharp nuget referenceassemblies-pcl', timing: true, assert: true]
     end
 
-    it "installs dotnet 1.0" do
-      data[:config][:dotnet] = '1.0.0-preview2-003121'
-      should include_sexp [:cmd, 'sudo apt-get install -qq dotnet-dev-1.0.0-preview2-003121', timing: true, assert: true]
+    it "installs dotnet 1.1.5" do
+      data[:config][:dotnet] = '1.1.5'
+      should include_sexp [:cmd, 'sudo apt-get install -qq dotnet-dev-1.1.5', timing: true, assert: true]
     end
 
-    it "installs dotnet 2.0 preview 1" do
-      data[:config][:dotnet] = '2.0.0-preview1-005977'
-      should include_sexp [:cmd, 'sudo apt-get install -qq dotnet-dev-2.0.0-preview1-005977', timing: true, assert: true]
-    end
-
-    it "installs dotnet 2.0 preview 2 and above" do
-      data[:config][:dotnet] = '2.0.0-preview2-006497'
-      should include_sexp [:cmd, 'sudo apt-get install -qq dotnet-sdk-2.0.0-preview2-006497', timing: true, assert: true]
+    it "installs dotnet 2.0.0 and above" do
+      data[:config][:dotnet] = '2.0.0'
+      should include_sexp [:cmd, 'sudo apt-get install -qq dotnet-sdk-2.0.0', timing: true, assert: true]
     end
   end
 
@@ -201,35 +189,23 @@ describe Travis::Build::Script::Csharp, :sexp do
       should include_sexp [:cmd, "eval $(/usr/libexec/path_helper -s)", assert: true]
     end
 
-    it 'installs dotnet 1.0' do
+    it 'installs dotnet 1.1.5' do
       data[:config][:os] = 'osx'
-      data[:config][:dotnet] = '1.0.0-preview2-003121'
+      data[:config][:dotnet] = '1.1.5'
       should include_sexp [:cmd, "brew install openssl", timing: true, assert: true]
       should include_sexp [:cmd, "mkdir -p /usr/local/lib", assert: true]
       should include_sexp [:cmd, "ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/", assert: true]
       should include_sexp [:cmd, "ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/", assert: true]
-      should include_sexp [:cmd, "wget --retry-connrefused --waitretry=1 -O /tmp/dotnet.pkg https://dotnetcli.azureedge.net/dotnet/preview/Installers/1.0.0-preview2-003121/dotnet-dev-osx-x64.1.0.0-preview2-003121.pkg", timing: true, assert: true, echo: true]
+      should include_sexp [:cmd, "wget --retry-connrefused --waitretry=1 -O /tmp/dotnet.pkg https://dotnetcli.azureedge.net/dotnet/Sdk/1.1.5/dotnet-dev-osx-x64.1.1.5.pkg", timing: true, assert: true, echo: true]
       should include_sexp [:cmd, "sudo installer -package \"/tmp/dotnet.pkg\" -target \"/\" -verboseR", timing: true, assert: true]
       should include_sexp [:cmd, "eval $(/usr/libexec/path_helper -s)", assert: true]
     end
 
-    it 'installs dotnet 2.0 preview 1' do
+    it 'installs dotnet 2.0.0 and above' do
       data[:config][:os] = 'osx'
-      data[:config][:dotnet] = '2.0.0-preview1-005977'
-      should include_sexp [:cmd, "brew install openssl", timing: true, assert: true]
-      should include_sexp [:cmd, "mkdir -p /usr/local/lib", assert: true]
-      should include_sexp [:cmd, "ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/", assert: true]
-      should include_sexp [:cmd, "ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/", assert: true]
-      should include_sexp [:cmd, "wget --retry-connrefused --waitretry=1 -O /tmp/dotnet.pkg https://dotnetcli.azureedge.net/dotnet/Sdk/2.0.0-preview1-005977/dotnet-dev-osx-x64.2.0.0-preview1-005977.pkg", timing: true, assert: true, echo: true]
-      should include_sexp [:cmd, "sudo installer -package \"/tmp/dotnet.pkg\" -target \"/\" -verboseR", timing: true, assert: true]
-      should include_sexp [:cmd, "eval $(/usr/libexec/path_helper -s)", assert: true]
-    end
-
-    it 'installs dotnet 2.0 preview 2 and above' do
-      data[:config][:os] = 'osx'
-      data[:config][:dotnet] = '2.0.0-preview2-006497'
+      data[:config][:dotnet] = '2.0.0'
       should_not include_sexp [:cmd, "brew install openssl", timing: true, assert: true]
-      should include_sexp [:cmd, "wget --retry-connrefused --waitretry=1 -O /tmp/dotnet.pkg https://dotnetcli.azureedge.net/dotnet/Sdk/2.0.0-preview2-006497/dotnet-sdk-2.0.0-preview2-006497-osx-x64.pkg", timing: true, assert: true, echo: true]
+      should include_sexp [:cmd, "wget --retry-connrefused --waitretry=1 -O /tmp/dotnet.pkg https://dotnetcli.azureedge.net/dotnet/Sdk/2.0.0/dotnet-sdk-2.0.0-osx-x64.pkg", timing: true, assert: true, echo: true]
       should include_sexp [:cmd, "sudo installer -package \"/tmp/dotnet.pkg\" -target \"/\" -verboseR", timing: true, assert: true]
       should include_sexp [:cmd, "eval $(/usr/libexec/path_helper -s)", assert: true]
     end


### PR DESCRIPTION
The other repository is deprecated and only contains older versions.

Removes support for old -preview or -rc versions of .NET Core.

Fixes https://github.com/travis-ci/travis-ci/issues/8685
Fixes https://github.com/travis-ci/travis-ci/issues/8778