### PR TITLE
C#: Migrate xbuild to msbuild

### DIFF
--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -171,7 +171,7 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
           super
 
           sh.cmd 'mono --version', timing: true if is_mono_enabled
-          sh.cmd 'xbuild /version', timing: true if is_mono_enabled
+          sh.cmd "#{mono_build_cmd} /version", timing: true if is_mono_enabled
           sh.echo ''
 
           sh.cmd 'dotnet --info', timing: true if is_dotnet_enabled
@@ -190,7 +190,7 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
 
         def script
           if config_solution && is_mono_enabled
-            sh.cmd "xbuild /p:Configuration=Release #{config_solution}", timing: true
+            sh.cmd "#{mono_build_cmd} /p:Configuration=Release #{config_solution}", timing: true
           else
             sh.failure 'No solution or script defined, exiting'
           end
@@ -227,6 +227,10 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
 
         def dotnet_package_prefix
           return is_dotnet_after_2_0? ? "sdk" : "dev"
+        end
+
+        def mono_build_cmd
+          is_mono_after_5_0 ? "msbuild" : "xbuild" 
         end
 
         def is_mono_version_valid?

--- a/spec/build/script/csharp_spec.rb
+++ b/spec/build/script/csharp_spec.rb
@@ -158,7 +158,13 @@ describe Travis::Build::Script::Csharp, :sexp do
     end
 
     it 'announces xbuild version' do
+      data[:config][:mono] = '3.8.0'
       should include_sexp [:cmd, 'xbuild /version', echo: true, timing: true]
+    end
+
+    it 'announces msbuild version' do
+      data[:config][:mono] = '5.0.0'
+      should include_sexp [:cmd, 'msbuild /version', echo: true, timing: true]
     end
   end
 
@@ -177,7 +183,7 @@ describe Travis::Build::Script::Csharp, :sexp do
 
     it 'builds specified solution' do
       data[:config][:solution] = 'foo.sln'
-      should include_sexp [:cmd, 'xbuild /p:Configuration=Release foo.sln', echo: true, timing: true]
+      should include_sexp [:cmd, 'msbuild /p:Configuration=Release foo.sln', echo: true, timing: true]
     end
   end
 


### PR DESCRIPTION
With the release of Mono 5, xbuild has been deprecated in favor of msbuild (Further details here).

Luckily, the syntax is exactly the same, so updating just a matter of changing every reference of xbuild to msbuild.

Closes https://github.com/travis-ci/travis-build/pull/1060