### PR TITLE
Do not remove SUID bits for chrome-sandbox

### DIFF
--- a/lib/travis/build/appliances/disable_sudo.rb
+++ b/lib/travis/build/appliances/disable_sudo.rb
@@ -33,7 +33,7 @@ touch \$HOME/.sudo-run
 exit 1
 EOF
         EOC
-        CLEANUP = 'sudo -n sh -c "chmod 4755 _sudo; chown root:root _sudo; mv _sudo `which sudo`; find / \\( -perm -4000 -o -perm -2000 \\) -a ! -name sudo -exec chmod a-s {} \; 2>/dev/null && sed -e \'s/^%.*//\' -i.bak /etc/sudoers && rm -f /etc/sudoers.d/travis"'
+        CLEANUP = 'sudo -n sh -c "chmod 4755 _sudo; chown root:root _sudo; mv _sudo `which sudo`; find / \\( -perm -4000 -o -perm -2000 \\) -a ! -name sudo -a ! -name chrome-sandbox -exec chmod a-s {} \; 2>/dev/null && sed -e \'s/^%.*//\' -i.bak /etc/sudoers && rm -f /etc/sudoers.d/travis"'
 
         def apply
           sh.raw WRITE_SUDO

--- a/spec/build/script/shared/appliances/disable_sudo.rb
+++ b/spec/build/script/shared/appliances/disable_sudo.rb
@@ -1,5 +1,5 @@
 shared_examples_for 'paranoid mode on/off' do
-  let(:remove_suid) { %r(find / \\\( -perm -4000 -o -perm -2000 \\\) -a ! -name sudo -exec chmod a-s \{\} \\;) }
+  let(:remove_suid) { %r(find / \\\( -perm -4000 -o -perm -2000 \\\) -a ! -name sudo -a ! -name chrome-sandbox -exec chmod a-s \{\} \\;) }
 
   it 'does not remove access to sudo by default' do
     should_not include_sexp [:cmd, remove_suid]


### PR DESCRIPTION
Assumptions have changed for `chrome-sandbox` to have suid bits. This
PR ensures those bits are not removed if set.

(edit by AJ)
Addresses https://github.com/travis-ci/travis-ci/issues/8836
