### PR TITLE
Delay setting user-defined env vars after built-ins

### DIFF
--- a/lib/travis/build/script/c.rb
+++ b/lib/travis/build/script/c.rb
@@ -7,11 +7,11 @@ module Travis
         }
 
         def export
-          super
           sh.export 'CC', compiler
           if data.cache?(:ccache)
             sh.export 'PATH', "/usr/lib/ccache:$PATH"
           end
+          super
         end
 
         def announce

--- a/lib/travis/build/script/cpp.rb
+++ b/lib/travis/build/script/cpp.rb
@@ -7,12 +7,12 @@ module Travis
         }
 
         def export
-          super
           sh.export 'CXX', cxx
           sh.export 'CC', cc # some projects also need to compile some C, e.g. Rubinius. MK.
           if data.cache?(:ccache)
             sh.export 'PATH', "/usr/lib/ccache:$PATH"
           end
+          super
         end
 
         def announce

--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -179,9 +179,8 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
         end
 
         def export
-          super
-
           sh.export 'TRAVIS_SOLUTION', config_solution.shellescape if config_solution
+          super
         end
 
         def install
@@ -230,7 +229,7 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
         end
 
         def mono_build_cmd
-          is_mono_after_5_0 ? "msbuild" : "xbuild" 
+          is_mono_after_5_0 ? "msbuild" : "xbuild"
         end
 
         def is_mono_version_valid?

--- a/lib/travis/build/script/dart.rb
+++ b/lib/travis/build/script/dart.rb
@@ -69,12 +69,11 @@ MESSAGE
         end
 
         def export
-          super
-
           sh.export 'TRAVIS_DART_TEST', (!!task[:test]).to_s, echo: false
           sh.export 'TRAVIS_DART_ANALYZE', (!!task[:dartanalyzer]).to_s, echo: false
           sh.export 'TRAVIS_DART_FORMAT', (!!task[:dartfmt]).to_s, echo: false
           sh.export 'TRAVIS_DART_VERSION', task[:dart], echo: false
+          super
         end
 
         def setup

--- a/lib/travis/build/script/elixir.rb
+++ b/lib/travis/build/script/elixir.rb
@@ -10,8 +10,8 @@ module Travis
         KIEX_MIX_HOME    = '$HOME/.kiex/mix/'
 
         def export
-          super
           sh.export 'TRAVIS_ELIXIR_VERSION', elixir_version, echo: false
+          super
         end
 
         def setup

--- a/lib/travis/build/script/erlang.rb
+++ b/lib/travis/build/script/erlang.rb
@@ -7,8 +7,8 @@ module Travis
         }
 
         def export
-          super
           sh.export 'TRAVIS_OTP_RELEASE', otp_release, echo: false
+          super
         end
 
         def setup

--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -16,11 +16,11 @@ module Travis
         ).freeze
 
         def export
-          super
           sh.export 'TRAVIS_GO_VERSION', go_version, echo: false
           sh.if '-z $GOMAXPROCS' do
             sh.export 'GOMAXPROCS', '2', echo: false
           end
+          super
         end
 
         def prepare

--- a/lib/travis/build/script/haxe.rb
+++ b/lib/travis/build/script/haxe.rb
@@ -23,10 +23,9 @@ module Travis
         }
 
         def export
-          super
-
           sh.export 'TRAVIS_HAXE_VERSION', haxe_version, echo: false
           sh.export 'TRAVIS_NEKO_VERSION', config[:neko].to_s, echo: false
+          super
         end
 
         def configure

--- a/lib/travis/build/script/julia.rb
+++ b/lib/travis/build/script/julia.rb
@@ -16,10 +16,9 @@ module Travis
         }
 
         def export
-          super
-
           sh.export 'TRAVIS_JULIA_VERSION', config[:julia].to_s.shellescape,
             echo: false
+          super
         end
 
         def setup

--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -10,10 +10,9 @@ module Travis
         DEFAULTS = {}
 
         def export
-          super
-
           # prevent curl from polluting logs but still show errors
           sh.export 'NIX_CURL_FLAGS', '-sS'
+          super
         end
 
         def configure

--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -9,10 +9,10 @@ module Travis
         NPM_QUIET_TREE_VERSION = '5'
 
         def export
-          super
           if node_js_given_in_config?
             sh.export 'TRAVIS_NODE_VERSION', version, echo: false
           end
+          super
         end
 
         def setup

--- a/lib/travis/build/script/objective_c.rb
+++ b/lib/travis/build/script/objective_c.rb
@@ -33,12 +33,12 @@ module Travis
         end
 
         def export
-          super
           sh.echo "Disabling Homebrew auto update. If your Homebrew package requires Homebrew DB be up to date, please run \\`brew update\\` explicitly.", ansi: :yellow
           sh.export 'HOMEBREW_NO_AUTO_UPDATE', '1', echo: true
           [:sdk, :scheme, :project, :workspace].each do |key|
             sh.export "TRAVIS_XCODE_#{key.upcase}", config[:"xcode_#{key}"].to_s.shellescape, echo: false
           end
+          super
         end
 
         def setup_cache

--- a/lib/travis/build/script/perl.rb
+++ b/lib/travis/build/script/perl.rb
@@ -7,8 +7,8 @@ module Travis
         }
 
         def export
-          super
           sh.export 'TRAVIS_PERL_VERSION', version, echo: false
+          super
         end
 
         def configure

--- a/lib/travis/build/script/perl6.rb
+++ b/lib/travis/build/script/perl6.rb
@@ -13,8 +13,8 @@ module Travis
         }
 
         def export
-          super
           sh.export 'TRAVIS_PERL6_VERSION', version, echo: false
+          super
         end
 
         def configure

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -13,8 +13,8 @@ module Travis
         end
 
         def export
-          super
           sh.export 'TRAVIS_PHP_VERSION', version, echo: false
+          super
         end
 
         def setup

--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -13,8 +13,8 @@ module Travis
         PYENV_PATH_FILE      = '/etc/profile.d/pyenv.sh'
 
         def export
-          super
           sh.export 'TRAVIS_PYTHON_VERSION', version, echo: false
+          super
         end
 
         def configure

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -44,7 +44,6 @@ module Travis
         end
 
         def export
-          super
           sh.export 'TRAVIS_R_VERSION', r_version, echo: false
           sh.export 'TRAVIS_R_VERSION_STRING', config[:r].to_s, echo: false
           sh.export 'R_LIBS_USER', '~/R/Library', echo: false
@@ -52,6 +51,7 @@ module Travis
           sh.export '_R_CHECK_CRAN_INCOMING_', 'false', echo: false
           sh.export 'NOT_CRAN', 'true', echo: false
           sh.export 'R_PROFILE', "~/.Rprofile.site", echo: false
+          super
         end
 
         def configure

--- a/lib/travis/build/script/rust.rb
+++ b/lib/travis/build/script/rust.rb
@@ -10,9 +10,8 @@ module Travis
         }
 
         def export
-          super
-
           sh.export 'TRAVIS_RUST_VERSION', config[:rust].to_s.shellescape, echo: false
+          super
         end
 
         def setup_cache

--- a/lib/travis/build/script/scala.rb
+++ b/lib/travis/build/script/scala.rb
@@ -24,8 +24,8 @@ module Travis
         end
 
         def export
-          super
           sh.export 'TRAVIS_SCALA_VERSION', version, echo: false
+          super
         end
 
         def setup

--- a/lib/travis/build/script/shared/jdk.rb
+++ b/lib/travis/build/script/shared/jdk.rb
@@ -8,8 +8,8 @@ module Travis
         end
 
         def export
-          super
           sh.export 'TRAVIS_JDK_VERSION', config[:jdk], echo: false if uses_jdk?
+          super
         end
 
         def setup

--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -20,8 +20,8 @@ module Travis
         }
 
         def export
-          super
           sh.export 'TRAVIS_RUBY_VERSION', config[:rvm], echo: false if rvm?
+          super
         end
 
         def setup

--- a/lib/travis/build/script/smalltalk.rb
+++ b/lib/travis/build/script/smalltalk.rb
@@ -41,10 +41,10 @@ module Travis
         end
 
         def export
-          super
           sh.export 'TRAVIS_SMALLTALK_CONFIG', smalltalk_config, echo: false
           sh.export 'TRAVIS_SMALLTALK_VERSION', smalltalk_version, echo: false
           sh.export 'TRAVIS_SMALLTALK_VM', smalltalk_vm, echo: false
+          super
         end
 
         def setup
@@ -102,7 +102,7 @@ module Travis
           def is_squeak?
             is_platform?('squeak')
           end
-          
+
           def is_etoys?
             is_platform?('etoys')
           end


### PR DESCRIPTION
So that the user-defined environment variables can make use of
default ones, such as `TRAVIS_RUBY_VERSION`.

Resolves https://github.com/travis-ci/travis-ci/issues/8858