### PR TITLE
Revert "Use `echo` instead of `cat`"

### DIFF
--- a/lib/travis/build/git/clone.rb
+++ b/lib/travis/build/git/clone.rb
@@ -30,7 +30,7 @@ module Travis
                 sh.cmd "git -C #{dir} remote add origin #{data.source_url}", assert: true, retry: true
                 sh.cmd "git -C #{dir} pull origin #{branch} #{pull_args}", assert: false, retry: true
                 warn_github_status
-                sh.cmd "echo #{sparse_checkout} >> #{dir}/.git/info/sparseCheckout", assert: true, retry: true
+                sh.cmd "cat #{sparse_checkout} >> #{dir}/.git/info/sparseCheckout", assert: true, retry: true
                 sh.cmd "git -C #{dir} reset --hard", assert: true, timing: false
               else
                 sh.cmd "git clone #{clone_args} #{data.source_url} #{dir}", assert: false, retry: true


### PR DESCRIPTION
This reverts commit fa7d7c8abb0b5f4a6f71b51672819512d859b1bb.

We need to use cat instead of echo here, because we need to check
out files listed in #{sparse_checkout}, not #{sparse_checkout} file
itself (which is already available).