### PR TITLE
Use full fingerprint when retrieving MongoDB 3.2 OpenPGP key

### DIFF
--- a/lib/travis/build/appliances/update_mongo32_key.rb
+++ b/lib/travis/build/appliances/update_mongo32_key.rb
@@ -6,7 +6,7 @@ module Travis
       class UpdateMongodb32Key < Base
         def apply
           sh.if "$(command -v lsb_release)" do
-            sh.cmd 'apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927', echo: false, assert: false, sudo: true
+            sh.cmd 'apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 42F3E95A2C4F08279C4960ADD68FA50FEA312927', echo: false, assert: false, sudo: true
           end
         end
       end

--- a/spec/build/script/shared/appliances/update_mongodb32_key.rb
+++ b/spec/build/script/shared/appliances/update_mongodb32_key.rb
@@ -1,5 +1,5 @@
 shared_examples_for 'update mongodb 3.2 gpg key' do
   it 'updates the mongodb gpg key since it expired and was refreshed' do
-    should include_sexp [:cmd, 'apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927', echo: false, assert: false, sudo: true]
+    should include_sexp [:cmd, 'apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 42F3E95A2C4F08279C4960ADD68FA50FEA312927', echo: false, assert: false, sudo: true]
   end
 end


### PR DESCRIPTION
32-bit OpenPGP key IDs should not used, because [it's computationally trivial to generate a new key with chosen ID](https://evil32.com/).