### PR TITLE
File name is .git/info/sparse-checkout, not sparseCheckout

### DIFF
--- a/lib/travis/build/git/clone.rb
+++ b/lib/travis/build/git/clone.rb
@@ -26,11 +26,11 @@ module Travis
                 sh.echo "Cloning with sparse checkout specified with #{sparse_checkout}", ansi: :yellow
                 sh.cmd "git init #{dir}", assert: true, retry: true
                 sh.cmd "git -C #{dir} config core.sparseCheckout true", assert: true, retry: true
-                sh.cmd "echo #{sparse_checkout} >> #{dir}/.git/info/sparseCheckout", assert: true, retry: true
+                sh.cmd "echo #{sparse_checkout} >> #{dir}/.git/info/sparse-checkout", assert: true, retry: true
                 sh.cmd "git -C #{dir} remote add origin #{data.source_url}", assert: true, retry: true
                 sh.cmd "git -C #{dir} pull origin #{branch} #{pull_args}", assert: false, retry: true
                 warn_github_status
-                sh.cmd "cat #{sparse_checkout} >> #{dir}/.git/info/sparseCheckout", assert: true, retry: true
+                sh.cmd "cat #{sparse_checkout} >> #{dir}/.git/info/sparse-checkout", assert: true, retry: true
                 sh.cmd "git -C #{dir} reset --hard", assert: true, timing: false
               else
                 sh.cmd "git clone #{clone_args} #{data.source_url} #{dir}", assert: false, retry: true

--- a/spec/build/git/clone_spec.rb
+++ b/spec/build/git/clone_spec.rb
@@ -171,7 +171,7 @@ describe Travis::Build::Git::Clone, :sexp do
   context "When sparse_checkout is requested" do
     before { payload[:config][:git]['sparse_checkout'] = 'sparse_checkout_file' }
     it { should include_sexp [:cmd, "git -C travis-ci/travis-ci pull origin master --depth=50", echo: true, timing: true, retry: true]}
-    it { should include_sexp [:cmd, "echo sparse_checkout_file >> travis-ci/travis-ci/.git/info/sparseCheckout", assert: true, echo: true, timing: true, retry: true]}
+    it { should include_sexp [:cmd, "echo sparse_checkout_file >> travis-ci/travis-ci/.git/info/sparse-checkout", assert: true, echo: true, timing: true, retry: true]}
     it { store_example "git-sparse-checkout"}
   end
 end


### PR DESCRIPTION
Using sparseCheckout leads to empty working directory when
sparse_checkout option is active.