### PR TITLE
Add no_world_writable_dirs appliance

### DIFF
--- a/lib/travis/build/appliances.rb
+++ b/lib/travis/build/appliances.rb
@@ -34,6 +34,7 @@ require 'travis/build/appliances/validate'
 require 'travis/build/appliances/npm_registry'
 require 'travis/build/appliances/update_rubygems'
 require 'travis/build/appliances/apt_get_update'
+require 'travis/build/appliances/no_world_writable_dirs'
 
 module Travis
   module Build

--- a/lib/travis/build/appliances/no_world_writable_dirs.rb
+++ b/lib/travis/build/appliances/no_world_writable_dirs.rb
@@ -1,0 +1,17 @@
+require 'travis/build/appliances/base'
+
+module Travis
+  module Build
+    module Appliances
+      class NoWorldWritableDirs < Base
+        def apply
+          sh.cmd <<-EOF
+for dir in $(echo $PATH | tr : " "); do
+  test -d $dir && sudo chmod -vv o-w $dir | grep changed
+done
+          EOF
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -186,6 +186,7 @@ module Travis
           apply :rm_oraclejdk8_symlink
           apply :enable_i386
           apply :update_rubygems
+          apply :no_world_writable_dirs
         end
 
         def setup_filter


### PR DESCRIPTION
To ensure that no dir in `$PATH` is world-writable.

It turns out that the current clang 5.0.0 archive is faulty
and its `bin` is world-writable, causing
https://github.com/travis-ci/travis-ci/issues/8892.
We work around this issue in general by checking each dir in `$PATH`.

GNU `chmod` has a handy `--changes` flag that prints only the changes,
but this flag is not available for BSD `chmod` (on the Mac), so we
use `-vv` and filter the output instead.