### PR TITLE
Apply no_world_writable_dirs before setting up filter

### DIFF
--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -186,11 +186,11 @@ module Travis
           apply :rm_oraclejdk8_symlink
           apply :enable_i386
           apply :update_rubygems
-          apply :no_world_writable_dirs
           apply :ensure_path_components
         end
 
         def setup_filter
+          apply :no_world_writable_dirs
           apply :setup_filter
         end
 


### PR DESCRIPTION
Otherwise, we see the following warning:

    /home/travis/filter.rb:43: warning: Insecure world writable dir /usr/local/clang-5.0.0/bin in PATH, mode 040777