### PR TITLE
Filter `yarn global bin` output for `/`

### DIFF
--- a/lib/travis/build/appliances/ensure_path_components.rb
+++ b/lib/travis/build/appliances/ensure_path_components.rb
@@ -6,14 +6,14 @@ module Travis
       class EnsurePathComponents < Base
 
         COMPONENTS = [
-          '$(yarn global bin)'
+          '$(yarn global bin | grep /)'
         ]
 
         def apply
           COMPONENTS.each do |pc|
             sh.cmd <<-EOF
 pc=#{pc}
-if [[ -z $(echo :$PATH: | grep :$pc:) ]]; then export PATH=$PATH:$pc; fi
+if [[ -n $pc && -z $(echo :$PATH: | grep :$pc:) ]]; then export PATH=$PATH:$pc; fi
 unset pc
             EOF
           end

--- a/lib/travis/build/appliances/ensure_path_components.rb
+++ b/lib/travis/build/appliances/ensure_path_components.rb
@@ -13,7 +13,7 @@ module Travis
           COMPONENTS.each do |pc|
             sh.cmd <<-EOF
 pc=#{pc}
-if [[ -n $pc && -z $(echo :$PATH: | grep :$pc:) ]]; then export PATH=$PATH:$pc; fi
+if [[ -n $pc && :$PATH: =~ :$pc: ]]; then export PATH=$PATH:$pc; fi
 unset pc
             EOF
           end


### PR DESCRIPTION
It turns out that `yarn` writes undersiable error message to
STDOUT if `node` or `nodejs` is not found on `$PATH`.
Adding this string is problematic, as it contains spaces.

Resolves https://github.com/travis-ci/travis-ci/issues/8921.