### PR TITLE
Fix ensure_path_components appliance

### DIFF
--- a/lib/travis/build/appliances/ensure_path_components.rb
+++ b/lib/travis/build/appliances/ensure_path_components.rb
@@ -13,7 +13,7 @@ module Travis
           COMPONENTS.each do |pc|
             sh.cmd <<-EOF
 pc=#{pc}
-if [[ -n $pc && :$PATH: =~ :$pc: ]]; then export PATH=$PATH:$pc; fi
+if [[ -n $pc && ! :$PATH: =~ :$pc: ]]; then export PATH=$PATH:$pc; fi
 unset pc
             EOF
           end


### PR DESCRIPTION
The logic is flipped here; we want to add `$pc` if and only if
it is not found in `$PATH`.

Resolves https://github.com/travis-ci/travis-ci/issues/8890.