### PR TITLE
Install titling LaTeX package

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -466,7 +466,7 @@ module Travis
 
             # Install common packages
             sh.cmd 'sudo tlmgr install inconsolata upquote '\
-              'courier courier-scaled helvetic', assert: false
+              'courier courier-scaled helvetic titling', assert: false
           end
         end
 


### PR DESCRIPTION
Recent build failure on OS X: https://travis-ci.org/r-prof/gprofiler/jobs/322013363#L329.

Reference for `titling.sty` -> titling package: https://bookdown.org/yihui/bookdown/latex.html

CC @jimhester @craigcitro.