### PR TITLE
haxe: upgrade default neko version to 2.2.0

### DIFF
--- a/lib/travis/build/script/haxe.rb
+++ b/lib/travis/build/script/haxe.rb
@@ -19,7 +19,7 @@ module Travis
 
         DEFAULTS = {
           haxe: 'stable',
-          neko: '2.1.0'
+          neko: '2.2.0'
         }
 
         def export


### PR DESCRIPTION
Neko 2.2.0 is a minor release with bug fixes. It's compatible with the previous version.