### PR TITLE
Add more mirrors for the D install script

### DIFF
--- a/lib/travis/build/script/d.rb
+++ b/lib/travis/build/script/d.rb
@@ -18,8 +18,13 @@ module Travis
           super
 
           sh.echo 'D support for Travis-CI is community maintained.', ansi: :green
-          sh.echo 'Please make sure to ping @MartinNowak, @klickverbot and @ibuclaw '\
+          sh.echo 'Please make sure to ping @MartinNowak and @wilzbach'\
             'when filing issues under https://github.com/travis-ci/travis-ci/issues.', ansi: :green
+
+          sh.echo 'DMD-related issues: https://issues.dlang.org', ansi: :green
+          sh.echo 'LDC-related issues: https://github.com/ldc-developers/ldc/issues', ansi: :green
+          sh.echo 'GDC-related issues: https://bugzilla.gdcproject.org', ansi: :green
+          sh.echo 'DUB-related issues: https://github.com/dlang/dub/issues', ansi: :green
 
           sh.fold 'compiler-download' do
             sh.echo 'Installing compiler and dub', ansi: :yellow

--- a/spec/build/script/d_spec.rb
+++ b/spec/build/script/d_spec.rb
@@ -13,7 +13,13 @@ describe Travis::Build::Script::D, :sexp do
   it_behaves_like 'a build script sexp'
 
   it 'downloads and runs the installer script' do
-    should include_sexp [:cmd, %r{curl.*https://dlang\.org/install\.sh.*\|\|.*curl.*https://nightlies\.dlang\.org/install\.sh}m,
+    should include_sexp [:cmd, %r{https://dlang\.org/install\.sh},
+                         assert: true, echo: true, timing: true]
+    should include_sexp [:cmd, %r{https://downloads\.dlang\.org/other/install\.sh},
+                         assert: true, echo: true, timing: true]
+    should include_sexp [:cmd, %r{https://nightlies\.dlang\.org/install\.sh},
+                         assert: true, echo: true, timing: true]
+    should include_sexp [:cmd, %r{https://github\.com/dlang/installer/raw/stable/script/install\.sh},
                          assert: true, echo: true, timing: true]
     should include_sexp [:cmd, %r{source.*bash.*install\.sh.*--activate},
                          assert: true, echo: true, timing: true]


### PR DESCRIPTION
Motivation: Network connections can fail and sometimes do they. CI shouldn't fail though.

The installer script is pushed to three locations (https://github.com/dlang/installer/pull/287).

See also: https://github.com/travis-ci/travis-build/pull/910 (introduction of the first mirror)


CC @MartinNowak @klickverbot @ibuclaw