### PR TITLE
Do not dump logs

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -254,10 +254,6 @@ module Travis
             end
           end
 
-          # Always dump the .out logs, so you can inspect test .Rout for
-          # information.
-          dump_log("out")
-
           # Check revdeps, if requested.
           if @devtools_installed and config[:r_check_revdep]
             sh.echo "Checking reverse dependencies"


### PR DESCRIPTION
This was causing intermittent failures of some jobs with a lot of output.

Fixes https://github.com/travis-ci/travis-ci/issues/8964
  