### PR TITLE
Add missing space in the D support header

### DIFF
--- a/lib/travis/build/script/d.rb
+++ b/lib/travis/build/script/d.rb
@@ -19,7 +19,7 @@ module Travis
           super
 
           sh.echo 'D support for Travis-CI is community maintained.', ansi: :green
-          sh.echo 'Please make sure to ping @MartinNowak and @wilzbach'\
+          sh.echo 'Please make sure to ping @MartinNowak and @wilzbach '\
             'when filing issues under https://github.com/travis-ci/travis-ci/issues.', ansi: :green
 
           sh.echo 'DMD-related issues: https://issues.dlang.org', ansi: :green


### PR DESCRIPTION
e.g. https://travis-ci.org/dlang-community/D-Scanner/jobs/327003180

![image](https://user-images.githubusercontent.com/4370550/34777674-5bff1b8e-f61b-11e7-8d5f-9773dc31eb1a.png)

Sorry about missing this before.
See also: https://github.com/travis-ci/travis-build/pull/1282