### PR TITLE
Add in Dep for Golang builds

### DIFF
--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -70,7 +70,7 @@ module Travis
             sh.echo 'Using Go 1.5 Vendoring, not checking for Godeps'
           end
           sh.else do
-            sh .if '-f Godeps/Godeps.json' do
+            sh.if '-f Godeps/Godeps.json' do
               sh.export 'GOPATH', '${TRAVIS_BUILD_DIR}/Godeps/_workspace:$GOPATH', retry: false
               sh.export 'PATH', '${TRAVIS_BUILD_DIR}/Godeps/_workspace/bin:$PATH', retry: false
 
@@ -80,6 +80,10 @@ module Travis
                   sh.cmd 'godep restore', retry: true, timing: true, assert: true, echo: true
                 end
               end
+            end
+            sh.elif '-f Gopkg.toml' do 
+              fetch_dep
+              sh.cmd 'dep ensure', retry: true, timing: true, assert: true, echo: true
             end
           end
 
@@ -194,6 +198,21 @@ module Travis
             sh.export 'PATH', "#{HOME_DIR}/bin:$PATH", retry: false, echo: false
             # install bootstrap version so that tip/master/whatever can be used immediately
             sh.cmd %Q'gimme #{DEFAULTS[:go]} &>/dev/null'
+          end
+
+          def fetch_dep
+            dep = "$HOME/gopath/bin/dep"
+
+            sh.mkdir "$HOME/gopath/bin", echo: false, recursive: true
+
+            sh.if "$TRAVIS_OS_NAME = osx" do
+              sh.cmd "curl -o #{dep} https://github.com/golang/dep/releases/download/v0.3.2/dep-darwin-amd64", echo: false
+            end
+            sh.elif "$TRAVIS_OS_NAME = linux" do
+              sh.cmd "curl -o #{dep} https://github.com/golang/dep/releases/download/v0.3.2/dep-linux-amd64", echo: false
+            end
+
+            sh.cmd "chmod +x #{dep}"
           end
 
           def fetch_godep


### PR DESCRIPTION
Hi there,

Out of some need for my own projects, I started a branch to add in dep (seems fairly consistent with godep).

I am not done with this yet, FYI, but wanted to get a PR up so I could figure out if there was anything stupid I'm forgetting. I notice you have `app_host` for getting binaries for example, I imagine that's to not get punished over hitting github a million times?