### PR TITLE
Bump fallback gimme install URL to v1.3.0

### DIFF
--- a/lib/travis/build/config.rb
+++ b/lib/travis/build/config.rb
@@ -42,7 +42,7 @@ module Travis
         gimme: {
           url: ENV.fetch(
             'TRAVIS_BUILD_GIMME_URL',
-            'https://raw.githubusercontent.com/travis-ci/gimme/v1.2.0/gimme'
+            'https://raw.githubusercontent.com/travis-ci/gimme/v1.3.0/gimme'
           )
         },
         go_version: ENV.fetch('TRAVIS_BUILD_GO_VERSION', '1.9'),


### PR DESCRIPTION
which is only used when the `app_host` config is empty or download via `app_host` fails.