### PR TITLE
Fix local dpl installation when cwd is not $TRAVIS_BUILD_DIR

### DIFF
--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -142,10 +142,10 @@ module Travis
 
             def install
               sh.if "$(rvm use $(travis_internal_ruby) do ruby -e \"puts RUBY_VERSION\") = 1.9*" do
-                cmd(dpl_install_command(WANT_18), echo: false, assert: !allow_failure, timing: true)
+                cmd(dpl_install_command(WANT_18), echo: true, assert: !allow_failure, timing: true)
               end
               sh.else do
-                cmd(dpl_install_command, echo: false, assert: !allow_failure, timing: true)
+                cmd(dpl_install_command, echo: true, assert: !allow_failure, timing: true)
               end
               sh.cmd "rm -f $TRAVIS_BUILD_DIR/dpl-*.gem", echo: false, assert: false, timing: false
             end

--- a/spec/build/addons/deploy_spec.rb
+++ b/spec/build/addons/deploy_spec.rb
@@ -37,15 +37,15 @@ describe Travis::Build::Addons::Deploy, :sexp do
     it "installs dpl < 1.9 if travis_internal_ruby returns 1.9*" do
       expect(
         sexp_find(sexp, [:if, "$(rvm use $(travis_internal_ruby) do ruby -e \"puts RUBY_VERSION\") = 1.9*"], [:then])
-      ).to include_sexp [:cmd, "rvm $(travis_internal_ruby) --fuzzy do ruby -S gem install dpl -v '< 1.9' ", assert: true, timing: true]
+      ).to include_sexp [:cmd, "rvm $(travis_internal_ruby) --fuzzy do ruby -S gem install dpl -v '< 1.9' ", echo: true, assert: true, timing: true]
     end
 
     it "installs latest dpl if travis_internal_ruby does not return 1.9*" do
       expect(
         sexp_find(sexp, [:if, "$(rvm use $(travis_internal_ruby) do ruby -e \"puts RUBY_VERSION\") = 1.9*"], [:else])
-      ).to include_sexp [:cmd, "rvm $(travis_internal_ruby) --fuzzy do ruby -S gem install dpl", assert: true, timing: true]
+      ).to include_sexp [:cmd, "rvm $(travis_internal_ruby) --fuzzy do ruby -S gem install dpl", echo: true, assert: true, timing: true]
     end
-    it { expect(sexp).to include_sexp [:cmd, 'rvm $(travis_internal_ruby) --fuzzy do ruby -S gem install dpl', assert: true, timing: true] }
+    it { expect(sexp).to include_sexp [:cmd, 'rvm $(travis_internal_ruby) --fuzzy do ruby -S gem install dpl', echo: true, assert: true, timing: true] }
     # it { expect(sexp).to include_sexp [:cmd, 'rvm $(travis_internal_ruby) --fuzzy do ruby -S dpl --provider=heroku --password=foo --email=user@host --fold', assert: true, timing: true] }
     # it { expect(sexp).to include_sexp terminate_on_failure }
     it { expect(sexp).to include_sexp [:cmd, "rvm $(travis_internal_ruby) --fuzzy do ruby -S dpl --provider=\"heroku\" --password=\"foo\" --email=\"user@host\" --fold; if [ $? -ne 0 ]; then echo \"failed to deploy\"; travis_terminate 2; fi", {:timing=>true}] }

--- a/spec/build/addons/deploy_spec.rb
+++ b/spec/build/addons/deploy_spec.rb
@@ -106,6 +106,7 @@ describe Travis::Build::Addons::Deploy, :sexp do
     let(:config) { { provider: 'heroku', edge: { source: 'svenvfuchs/dpl', branch: 'foo' } } }
 
     it { should match_sexp [:if, '($TRAVIS_BRANCH = master)'] }
+    it { store_example "edge"}
   end
 
   describe 'on tags' do


### PR DESCRIPTION
When execution gets to deployment and PWD is not `$TRAVIS_BUILD_DIR`, installing `dpl` with the locally built `dpl-*.gem` file fails.

This PR resolves this issue.

Failure with cf6d29c9c: https://travis-ci.org/BanzaiMan/travis_production_test/builds/333491097#L540
Success with fc63b337: https://staging.travis-ci.org/BanzaiMan/travis_staging_test/jobs/704197#L533