### PR TITLE
Tweak `sed` regex to match localhost line in `/etc/hosts`

### DIFF
--- a/lib/travis/build/appliances/put_localhost_first.rb
+++ b/lib/travis/build/appliances/put_localhost_first.rb
@@ -6,7 +6,7 @@ module Travis
       class PutLocalhostFirst < Base
         def apply
           # gather names mapped to 127.0.0.1
-          sh.raw %q(grep '^127\.0\.0\.1' /etc/hosts | sed -e 's/^127\.0\.0\.1 \\(.*\\)/\1/g' | sed -e 's/localhost \\(.*\\)/\1/g' | tr "\n" " " > /tmp/hosts_127_0_0_1)
+          sh.raw %q(grep '^127\.0\.0\.1' /etc/hosts | sed -e 's/^127\.0\.0\.1\\s\\{1,\\}\\(.*\\)/\1/g' | sed -e 's/localhost \\(.*\\)/\1/g' | tr "\n" " " > /tmp/hosts_127_0_0_1)
           # remove lines with 127.0.0.1
           sh.raw %q(sed '/^127\.0\.0\.1/d' /etc/hosts > /tmp/hosts_sans_127_0_0_1)
           # reconstruct /etc/hosts

--- a/spec/build/script/shared/appliances/put_localhost_first.rb
+++ b/spec/build/script/shared/appliances/put_localhost_first.rb
@@ -1,5 +1,5 @@
 shared_examples_for 'put localhost first in etc/hosts' do
-  let(:put_localhost_first) { %q(grep '^127\.0\.0\.1' /etc/hosts | sed -e 's/^127\.0\.0\.1 \\(.*\\)/\1/g' | sed -e 's/localhost \\(.*\\)/\1/g' | tr "\n" " " > /tmp/hosts_127_0_0_1) }
+  let(:put_localhost_first) { %q(grep '^127\.0\.0\.1' /etc/hosts | sed -e 's/^127\.0\.0\.1\\s\\{1,\\}\\(.*\\)/\1/g' | sed -e 's/localhost \\(.*\\)/\1/g' | tr "\n" " " > /tmp/hosts_127_0_0_1) }
 
   it 'places localhost first in /etc/hosts' do
     should include_sexp [:raw, put_localhost_first]


### PR DESCRIPTION
The space between `127.0.0.1` and `localhost` could be a tab,
which causes the previous regex to miss this line, and preserve
the line we do not want.

This resolves https://github.com/travis-ci/travis-ci/issues/9167.