### PR TITLE
Enhance ssh_known_hosts addon to accept pre-set host key

### DIFF
--- a/lib/travis/build/addons/ssh_known_hosts.rb
+++ b/lib/travis/build/addons/ssh_known_hosts.rb
@@ -26,31 +26,45 @@ module Travis
             sh.fold 'ssh_known_hosts.0' do
               sh.echo "Adding ssh known hosts (BETA)", ansi: :yellow
               config.each do |host|
-                begin
-                  host_uri = URI("ssh://#{host}")
-                rescue => e
-                  sh.echo "Skipping malformed host #{Shellwords.escape(host.inspect)}", ansi: :red
-                  warn e
-                  next
+                case host
+                when String
+                  keyscan(host)
+                when Hash
+                  host, type, key = host.values_at(:host, :type, :key)
+                  if host && type && key
+                    sh.cmd "echo '#{host} #{type} #{key}' >> $HOME/.ssh/known_hosts", echo: true
+                  else
+                    sh.echo "Missing at least one of host, type, and key in the ssh_known_hosts configuration", ansi: :yellow
+                  end
                 end
-
-                unless host_uri.host
-                  sh.echo "Skipping malformed host #{Shellwords.escape(host.inspect)}", ansi: :red
-                  next
-                end
-
-                sh.if "$(uname) = 'Darwin'" do
-                  sh.cmd "TRAVIS_SSH_KEY_TYPES='rsa,dsa'"
-                end
-                sh.else do
-                  sh.cmd "TRAVIS_SSH_KEY_TYPES='rsa,dsa,ecdsa'"
-                end
-                ssh_keyscan_command = "ssh-keyscan -t $TRAVIS_SSH_KEY_TYPES"
-                ssh_keyscan_command << " -p #{Shellwords.escape(host_uri.port)}" if host_uri.port
-                ssh_keyscan_command << " -H #{Shellwords.escape(host_uri.host)}"
-                sh.cmd "#{ssh_keyscan_command} 2>&1 | tee -a #{Travis::Build::HOME_DIR}/.ssh/known_hosts", echo: true, timing: true
               end
             end
+          end
+
+          def keyscan(host)
+            begin
+              host_uri = URI("ssh://#{host}")
+            rescue => e
+              sh.echo "Skipping malformed host #{Shellwords.escape(host.inspect)}", ansi: :red
+              warn e
+              return
+            end
+
+            unless host_uri.host
+              sh.echo "Skipping malformed host #{Shellwords.escape(host.inspect)}", ansi: :red
+              return
+            end
+
+            sh.if "$(uname) = 'Darwin'" do
+              sh.cmd "TRAVIS_SSH_KEY_TYPES='rsa,dsa'"
+            end
+            sh.else do
+              sh.cmd "TRAVIS_SSH_KEY_TYPES='rsa,dsa,ecdsa'"
+            end
+            ssh_keyscan_command = "ssh-keyscan -t $TRAVIS_SSH_KEY_TYPES"
+            ssh_keyscan_command << " -p #{Shellwords.escape(host_uri.port)}" if host_uri.port
+            ssh_keyscan_command << " -H #{Shellwords.escape(host_uri.host)}"
+            sh.cmd "#{ssh_keyscan_command} 2>&1 | tee -a #{Travis::Build::HOME_DIR}/.ssh/known_hosts", echo: true, timing: true
           end
       end
     end

--- a/spec/build/addons/ssh_known_hosts_spec.rb
+++ b/spec/build/addons/ssh_known_hosts_spec.rb
@@ -29,6 +29,13 @@ describe Travis::Build::Addons::SshKnownHosts, :sexp do
     it { should include_sexp [:cmd, add_host_cmd('git.example.org'), echo: true, timing: true] }
   end
 
+  context "when host is given as a hash with known ssh host key" do
+    let(:config) { [ 'git.example.org', {host: 'foo.example.com', type: 'ssh-ed25519', key: 'AAAAC3NzaC1lZDI1NTE5AAAAIOd6AtszfjD3nI7WvvnN+B39XsrjPzAMCByYO1hwUGf9'} ] }
+
+    it { should include_sexp [:cmd, add_host_cmd('git.example.org'), echo: true, timing: true] }
+    it { should include_sexp [:cmd, "echo 'foo.example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOd6AtszfjD3nI7WvvnN+B39XsrjPzAMCByYO1hwUGf9' >> $HOME/.ssh/known_hosts", echo: true] }
+  end
+
   context 'without any hosts' do
     let(:config) { nil }
 


### PR DESCRIPTION
Improve ssh_known_hosts to accept hashes of the form:

    host: foo.example.com
    type: ssh-rsa
    key:  AAAAC3NzaC1lZDI1NTE5AAAAIOd6AtszfjD3nI7WvvnN+B39XsrjPzAMCByYO1hwUGf9

and add this to `$HOME/.ssh/known_hosts` **instead of** running
`ssh-keyscan` on the given host.