### PR TITLE
Drop `--local` from local installation of `dpl`

### DIFF
--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -190,7 +190,7 @@ module Travis
 
               command = "gem install"
               if install_local?(edge)
-                command << " $TRAVIS_BUILD_DIR/dpl-*.gem --local"
+                command << " $TRAVIS_BUILD_DIR/dpl-*.gem"
               else
                 command << " dpl"
               end


### PR DESCRIPTION
Runtime dependencies are now installed at gem installation
time, so restricting to `--local` will fail to install dependent
gems.