### PR TITLE
Run 'apt-get update' last in list of scripts

### DIFF
--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -164,7 +164,6 @@ module Travis
           apply :update_apt_keys
           apply :fix_hhvm_source
           apply :update_mongo_arch
-          apply :apt_get_update
           apply :fix_container_based_trusty
           apply :fix_sudo_enabled_trusty
           apply :update_glibc
@@ -190,6 +189,7 @@ module Travis
           apply :ensure_path_components
           apply :redefine_curl
           apply :nonblock_pipe
+          apply :apt_get_update
         end
 
         def setup_filter


### PR DESCRIPTION
I'm investigating the (more or less) recent networking issues with apt (https://github.com/travis-pro/team-jade/issues/793) and I noticed that we do quite a bit of network reconfiguration (e.g. `fix_resolv_conf`, `fix_etc_hosts`) after running this initial `apt-get update` (which is the one that seems to be failing on and off).

I'm wondering if there's any side effects to running this last, once we're finished changing the config so we're sure nothing else interferes.