### PR TITLE
Revert "Run 'apt-get update' last in list of scripts"

### DIFF
--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -164,6 +164,7 @@ module Travis
           apply :update_apt_keys
           apply :fix_hhvm_source
           apply :update_mongo_arch
+          apply :apt_get_update
           apply :fix_container_based_trusty
           apply :fix_sudo_enabled_trusty
           apply :update_glibc
@@ -189,7 +190,6 @@ module Travis
           apply :ensure_path_components
           apply :redefine_curl
           apply :nonblock_pipe
-          apply :apt_get_update
         end
 
         def setup_filter


### PR DESCRIPTION
My latest PR (https://github.com/travis-ci/travis-build/pull/1316) seems to have made the problem more widespread - I can at least reproduce it with all my test builds, which I couldn't before.

And while this is interesting for the investigation, I think it's better to revert it in order to reduce the disruption to our users.