### PR TITLE
Wait for network prior to continuing execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ coverage/
 /public/files/
 /lib/travis/build/addons/sauce_connect/templates/sauce_connect.sh
 .rake_tasks
+examples/*.sh

--- a/lib/travis/build/appliances.rb
+++ b/lib/travis/build/appliances.rb
@@ -39,6 +39,7 @@ require 'travis/build/appliances/update_mongo_arch'
 require 'travis/build/appliances/apt_get_update'
 require 'travis/build/appliances/no_world_writable_dirs'
 require 'travis/build/appliances/ensure_path_components'
+require 'travis/build/appliances/wait_for_network'
 
 module Travis
   module Build

--- a/lib/travis/build/appliances/wait_for_network.rb
+++ b/lib/travis/build/appliances/wait_for_network.rb
@@ -13,15 +13,18 @@ module Travis
               local count=1
               local url="http://#{app_host}/empty.txt?job_id=${job_id}&repo=${repo}"
 
-              while [[ "${count}" -lt 10 ]]; do
+              set -o xtrace
+              while [[ "${count}" -lt 20 ]]; do
                 if travis_download "${url}?count=${count}" /dev/null; then
                   echo -e "${ANSI_GREEN}Network availability confirmed.${ANSI_RESET}"
+                  set +o xtrace
                   return
                 fi
                 count=$((count + 1))
                 sleep 1
               done
 
+              set +o xtrace
               echo -e "${ANSI_RED}Timeout waiting for network availability.${ANSI_RESET}"
             }
           BASHSNIP

--- a/lib/travis/build/appliances/wait_for_network.rb
+++ b/lib/travis/build/appliances/wait_for_network.rb
@@ -13,18 +13,15 @@ module Travis
               local count=1
               local url="http://#{app_host}/empty.txt?job_id=${job_id}&repo=${repo}"
 
-              set -o xtrace
               while [[ "${count}" -lt 20 ]]; do
                 if travis_download "${url}?count=${count}" /dev/null; then
                   echo -e "${ANSI_GREEN}Network availability confirmed.${ANSI_RESET}"
-                  set +o xtrace
                   return
                 fi
                 count=$((count + 1))
                 sleep 1
               done
 
-              set +o xtrace
               echo -e "${ANSI_RED}Timeout waiting for network availability.${ANSI_RESET}"
             }
           BASHSNIP

--- a/lib/travis/build/appliances/wait_for_network.rb
+++ b/lib/travis/build/appliances/wait_for_network.rb
@@ -14,7 +14,7 @@ module Travis
               local url="http://#{app_host}/empty.txt?job_id=${job_id}&repo=${repo}"
 
               while [[ "${count}" -lt 10 ]]; do
-                if ! travis_download "${url}?count=${count}" /dev/null; then
+                if travis_download "${url}?count=${count}" /dev/null; then
                   echo -e "${ANSI_GREEN}Network availability confirmed.${ANSI_RESET}"
                   return
                 fi

--- a/lib/travis/build/appliances/wait_for_network.rb
+++ b/lib/travis/build/appliances/wait_for_network.rb
@@ -1,0 +1,14 @@
+require 'travis/build/appliances/base'
+
+module Travis
+  module Build
+    module Appliances
+      class WaitForNetwork < Base
+        def apply
+          sh.raw 'travis_wait_for_network "${TRAVIS_JOB_ID}" "${TRAVIS_REPO_SLUG}"'
+        end
+      end
+    end
+  end
+end
+

--- a/lib/travis/build/appliances/wait_for_network.rb
+++ b/lib/travis/build/appliances/wait_for_network.rb
@@ -5,10 +5,31 @@ module Travis
     module Appliances
       class WaitForNetwork < Base
         def apply
-          sh.raw 'travis_wait_for_network "${TRAVIS_JOB_ID}" "${TRAVIS_REPO_SLUG}"'
+
+          sh.raw <<~BASHSNIP
+            travis_wait_for_network() {
+              local job_id="${1}"
+              local repo="${2}"
+              local count=1
+              local url="http://#{app_host}/empty.txt?job_id=${job_id}&repo=${repo}"
+
+              while [[ "${count}" -lt 10 ]]; do
+                if ! travis_download "${url}?count=${count}" /dev/null; then
+                  echo -e "${ANSI_GREEN}Network availability confirmed.${ANSI_RESET}"
+                  return
+                fi
+                count=$((count + 1))
+                sleep 1
+              done
+
+              echo -e "${ANSI_RED}Timeout waiting for network availability.${ANSI_RESET}"
+            }
+          BASHSNIP
+
+          sh.cmd "travis_wait_for_network '#{data.job[:id]}' '#{data.slug}'",
+                 echo: false
         end
       end
     end
   end
 end
-

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -150,6 +150,7 @@ module Travis
             template(
               'header.sh',
               build_dir: BUILD_DIR,
+              app_host: app_host,
               internal_ruby_regex: Travis::Build.config.internal_ruby_regex.untaint,
               root: '/',
               home: HOME_DIR

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -162,6 +162,7 @@ module Travis
           apply :show_system_info
           apply :rm_riak_source
           apply :fix_rwky_redis
+          apply :wait_for_network
           apply :update_apt_keys
           apply :fix_hhvm_source
           apply :update_mongo_arch

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -85,7 +85,7 @@ module Travis
         sh.raw "# END_FUNCS"
 
         sh.raw "source $HOME/.travis/job_stages"
-        sh.raw "travis_wait_for_network"
+        sh.raw 'travis_wait_for_network "${TRAVIS_JOB_ID}" "${TRAVIS_REPO_SLUG}"'
 
         STAGES.each do |stage|
           case stage.run_in_debug

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -85,7 +85,6 @@ module Travis
         sh.raw "# END_FUNCS"
 
         sh.raw "source $HOME/.travis/job_stages"
-        sh.raw 'travis_wait_for_network "${TRAVIS_JOB_ID}" "${TRAVIS_REPO_SLUG}"'
 
         STAGES.each do |stage|
           case stage.run_in_debug

--- a/lib/travis/build/stages.rb
+++ b/lib/travis/build/stages.rb
@@ -85,6 +85,7 @@ module Travis
         sh.raw "# END_FUNCS"
 
         sh.raw "source $HOME/.travis/job_stages"
+        sh.raw "travis_wait_for_network"
 
         STAGES.each do |stage|
           case stage.run_in_debug

--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -270,12 +270,12 @@ travis_download() {
   local dst="${2}"
 
   if curl --version &>/dev/null; then
-    curl -fsSL --retry=9 --retry-delay=1 -o "${dst}" "${src}" 2>/dev/null
+    curl -fsSL --connect-timeout=5 --retry=9 --retry-delay=1 -o "${dst}" "${src}" 2>/dev/null
     return $?
   fi
 
   if wget --version &>/dev/null; then
-    wget --tries=10 --wait=1 -q "${src}" -O "${dst}" 2>/dev/null
+    wget --connect-timeout=5 --tries=10 --wait=1 -q "${src}" -O "${dst}" 2>/dev/null
     return $?
   fi
 
@@ -286,7 +286,9 @@ travis_wait_for_network() {
   local url="<%= app_host %>/empty.txt"
   url="${url}?job_id=${1:-${TRAVIS_JOB_ID}}"
   url="${url}&repo=${2:-${TRAVIS_REPO_SLUG}}"
+  echo "$(date +%s) start  ${url}" >"<%= home %>/.travis-network.log"
   travis_download "${url}" /dev/null
+  echo "$(date +%s) finish ${url}" >>"<%= home %>/.travis-network.log"
 }
 
 decrypt() {

--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -285,8 +285,12 @@ travis_download() {
 travis_wait_for_network() {
   local result=0
   local count=1
+  local url="<%= app_host %>/empty.txt"
+  url="${url}?job_id=${TRAVIS_JOB_ID}"
+  url="${url}&repo=${TRAVIS_REPO_SLUG}"
+
   while [ $count -le 9 ]; do
-    travis_download "<%= app_host %>/empty.txt" /dev/null && break
+    travis_download "${url}&count=${count}" /dev/null && break
     count=$(($count + 1))
     sleep 1
   done

--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -270,7 +270,7 @@ travis_download() {
   local dst="${2}"
 
   if curl --version &>/dev/null; then
-    curl -fsSL --connect-timeout=5 -o "${dst}" "${src}" 2>/dev/null
+    curl -fsSL --connect-timeout=5 "${src}" -o "${dst}" 2>/dev/null
     return $?
   fi
 
@@ -280,24 +280,6 @@ travis_download() {
   fi
 
   return 1
-}
-
-travis_wait_for_network() {
-  local count=1
-  local url="http://<%= app_host %>/empty.txt"
-  url="${url}?job_id=${1:-${TRAVIS_JOB_ID}}"
-  url="${url}&repo=${2:-${TRAVIS_REPO_SLUG}}"
-
-  while [[ "${count}" -lt 10 ]]; do
-    echo "$(date +%s) start url=${url} count=${count}" >>"<%= home %>/.travis-network.log"
-    if ! travis_download "${url}?count=${count}" /dev/null; then
-      echo "$(date +%s) finish url=${url} count=${count}" >>"<%= home %>/.travis-network.log"
-      return
-    fi
-    count=$((count + 1))
-    echo "$(date +%s) retry url=${url} count=${count}" >>"<%= home %>/.travis-network.log"
-    sleep 1
-  done
 }
 
 decrypt() {

--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -270,12 +270,12 @@ travis_download() {
   local dst="${2}"
 
   if curl --version &>/dev/null; then
-    curl -fsSL --connect-timeout=5 --retry=9 --retry-delay=1 -o "${dst}" "${src}" 2>/dev/null
+    curl -fsSL --connect-timeout=5 -o "${dst}" "${src}" 2>/dev/null
     return $?
   fi
 
   if wget --version &>/dev/null; then
-    wget --connect-timeout=5 --tries=10 --wait=1 -q "${src}" -O "${dst}" 2>/dev/null
+    wget --connect-timeout=5 -q "${src}" -O "${dst}" 2>/dev/null
     return $?
   fi
 
@@ -283,12 +283,21 @@ travis_download() {
 }
 
 travis_wait_for_network() {
-  local url="<%= app_host %>/empty.txt"
+  local count=1
+  local url="http://<%= app_host %>/empty.txt"
   url="${url}?job_id=${1:-${TRAVIS_JOB_ID}}"
   url="${url}&repo=${2:-${TRAVIS_REPO_SLUG}}"
-  echo "$(date +%s) start  ${url}" >"<%= home %>/.travis-network.log"
-  travis_download "${url}" /dev/null
-  echo "$(date +%s) finish ${url}" >>"<%= home %>/.travis-network.log"
+
+  while [[ "${count}" -lt 10 ]]; do
+    echo "$(date +%s) start url=${url} count=${count}" >>"<%= home %>/.travis-network.log"
+    if ! travis_download "${url}?count=${count}" /dev/null; then
+      echo "$(date +%s) finish url=${url} count=${count}" >>"<%= home %>/.travis-network.log"
+      return
+    fi
+    count=$((count + 1))
+    echo "$(date +%s) retry url=${url} count=${count}" >>"<%= home %>/.travis-network.log"
+    sleep 1
+  done
 }
 
 decrypt() {

--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -265,7 +265,7 @@ travis_fold() {
   echo -en "travis_fold:${action}:${name}\r${ANSI_CLEAR}"
 }
 
-travis_http_fetch() {
+travis_download() {
   local src="${1}"
   local dst="${2}"
 
@@ -286,7 +286,7 @@ travis_wait_for_network() {
   local result=0
   local count=1
   while [ $count -le 9 ]; do
-    travis_http_fetch "<%= app_host %>/empty.txt" /dev/null && break
+    travis_download "<%= app_host %>/empty.txt" /dev/null && break
     count=$(($count + 1))
     sleep 1
   done
@@ -334,8 +334,6 @@ fi
 if [[ -f /etc/apt/sources.list.d/neo4j.list ]] ; then
   sudo rm -f /etc/apt/sources.list.d/neo4j.list
 fi
-
-travis_wait_for_network
 
 mkdir -p <%= build_dir %>
 cd       <%= build_dir %>

--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -270,12 +270,12 @@ travis_download() {
   local dst="${2}"
 
   if curl --version &>/dev/null; then
-    curl -fsSL -o "${dst}" "${src}" 2>/dev/null
+    curl -fsSL --retry=9 --retry-delay=1 -o "${dst}" "${src}" 2>/dev/null
     return $?
   fi
 
   if wget --version &>/dev/null; then
-    wget -q "${src}" -O "${dst}" 2>/dev/null
+    wget --tries=10 --wait=1 -q "${src}" -O "${dst}" 2>/dev/null
     return $?
   fi
 
@@ -283,17 +283,10 @@ travis_download() {
 }
 
 travis_wait_for_network() {
-  local result=0
-  local count=1
   local url="<%= app_host %>/empty.txt"
-  url="${url}?job_id=${TRAVIS_JOB_ID}"
-  url="${url}&repo=${TRAVIS_REPO_SLUG}"
-
-  while [ $count -le 9 ]; do
-    travis_download "${url}&count=${count}" /dev/null && break
-    count=$(($count + 1))
-    sleep 1
-  done
+  url="${url}?job_id=${1:-${TRAVIS_JOB_ID}}"
+  url="${url}&repo=${2:-${TRAVIS_REPO_SLUG}}"
+  travis_download "${url}" /dev/null
 }
 
 decrypt() {

--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -270,12 +270,12 @@ travis_download() {
   local dst="${2}"
 
   if curl --version &>/dev/null; then
-    curl -fsSL --connect-timeout=5 "${src}" -o "${dst}" 2>/dev/null
+    curl -fsSL --connect-timeout 5 "${src}" -o "${dst}" 2>/dev/null
     return $?
   fi
 
   if wget --version &>/dev/null; then
-    wget --connect-timeout=5 -q "${src}" -O "${dst}" 2>/dev/null
+    wget --connect-timeout 5 -q "${src}" -O "${dst}" 2>/dev/null
     return $?
   fi
 


### PR DESCRIPTION
The intent of this change is to ensure that execution waits until the network is available enough to make an HTTP request of the `travis-build` API.

From [this job](https://staging.travis-ci.org/meatballhat/yolo-octo-adventure/builds/713898):

![screenshot_2018-03-05_18-01-44](https://user-images.githubusercontent.com/45143/37004712-53e4587a-209f-11e8-99af-24f5780e16f2.png)

and the corresponding heroku logs from `travis-build-staging`:

```
2018-03-05T22:58:58.885064+00:00 heroku[router]: at=info method=GET path="/empty.txt?job_id=713899&repo=meatballhat/yolo-octo-adventure?count=1" host=build-staging.travis-ci.org request_id=0cf61427-783a-42bc-9891-e980c89f23d9 fwd="35.225.134.118" dyno=web.1 connect=1ms service=44ms status=200 bytes=244 protocol=https
```