### PR TITLE
Replace `crystal deps` with `shards install`

### DIFF
--- a/lib/travis/build/script/crystal.rb
+++ b/lib/travis/build/script/crystal.rb
@@ -48,13 +48,13 @@ module Travis
           super
 
           sh.cmd 'crystal --version'
-          sh.cmd 'crystal deps --version'
+          sh.cmd 'shards --version'
           sh.echo ''
         end
 
         def install
           sh.if '-f shard.yml' do
-            sh.cmd "crystal deps"
+            sh.cmd "shards install"
           end
         end
 

--- a/spec/build/script/crystal_spec.rb
+++ b/spec/build/script/crystal_spec.rb
@@ -12,8 +12,8 @@ describe Travis::Build::Script::Crystal, :sexp do
     should include_sexp [:cmd, "crystal --version", echo: true]
   end
 
-  it "announces `crystal deps --version`" do
-    should include_sexp [:cmd, "crystal deps --version", echo: true]
+  it "announces `shards --version`" do
+    should include_sexp [:cmd, "shards --version", echo: true]
   end
 
   it "runs tests by default" do


### PR DESCRIPTION
`crystal deps` was just a wrapper for `shards install` and will be removed from
the compiler in the next release (see crystal-lang/crystal#5544).

/cc @asterite, @jhass, @waj, and @will