### PR TITLE
When using local `dpl` for deployment, build and install provider gem before invoking `dpl`

### DIFF
--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -225,9 +225,13 @@ module Travis
               sh.cmd("git checkout #{branch}",                              echo: true,  assert: !allow_failure, timing: true)
               sh.cmd("git show-ref -s HEAD",                                echo: true,  assert: !allow_failure, timing: true)
               cmd("gem build dpl.gemspec",                                  echo: true,  assert: !allow_failure, timing: true)
-              sh.if("-f dpl-#{provider}.gemspec") do
-                sh.cmd("gem build dpl-#{provider}.gemspec", echo: true, assert: !allow_failure, timing: true)
-              end
+              sh.raw "for f in dpl-*.gemspec; do"
+              sh.raw "  base=${f%*.gemspec}"
+              sh.raw "  if [[ x$(echo #{provider} | tr A-Z a-z | sed 's/[^a-z0-9]//g') = x$(echo ${base#dpl-*} | tr A-Z a-z | sed 's/[^a-z0-9]//g') ]]; then"
+              cmd    "    gem build $f;", echo: true, assert: !allow_failure, timing: true
+              sh.raw "    break;"
+              sh.raw "  fi"
+              sh.raw "done"
               sh.cmd("mv dpl-*.gem $TRAVIS_BUILD_DIR >& /dev/null",         echo: false, assert: !allow_failure, timing: true)
               sh.cmd("popd >& /dev/null",                                   echo: false, assert: !allow_failure, timing: true)
               # clean up, so that multiple edge providers can be run

--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -232,11 +232,11 @@ module Travis
               sh.raw "    break;"
               sh.raw "  fi"
               sh.raw "done"
-              sh.cmd("mv dpl-*.gem $TRAVIS_BUILD_DIR >& /dev/null",         echo: false, assert: !allow_failure, timing: true)
-              sh.cmd("popd >& /dev/null",                                   echo: false, assert: !allow_failure, timing: true)
+              sh.cmd("mv dpl-*.gem $TRAVIS_BUILD_DIR >& /dev/null",         echo: false, assert: !allow_failure, timing: false)
+              sh.cmd("popd >& /dev/null",                                   echo: false, assert: !allow_failure, timing: false)
               # clean up, so that multiple edge providers can be run
-              sh.cmd("rm -rf $(dirname #{source})",                         echo: false, assert: !allow_failure, timing: true)
-              sh.cmd("popd >& /dev/null",                                   echo: false, assert: !allow_failure, timing: true)
+              sh.cmd("rm -rf $(dirname #{source})",                         echo: false, assert: !allow_failure, timing: false)
+              sh.cmd("popd >& /dev/null",                                   echo: false, assert: !allow_failure, timing: false)
             ensure
               sh.cmd("test -e /tmp/dpl && rm -rf dpl", echo: false, assert: false, timing: true)
             end


### PR DESCRIPTION
`dpl` 1.9.0 now installs provider gem dynamically. It does this via 

    install_cmd = "gem install dpl-#{provider_gem_name || opt} -v #{ENV['DPL_VERSION'] || DPL::VERSION}"

https://github.com/travis-ci/dpl/blob/66ea4d5c7e6fe80f76945db9ceb5e761dc6c4642/lib/dpl/provider.rb#L83

which means fetching from rubygems.org.

For local `dpl`, then, we need to build and install the provider gem beforehand in order to test the new `dpl` code.

This resolves https://github.com/travis-ci/dpl/issues/770.