### PR TITLE
Ensure no yarn path is cached after calling `yarn --version`

### DIFF
--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -43,6 +43,7 @@ module Travis
           sh.cmd 'nvm --version'
           sh.if "-f yarn.lock" do
              sh.cmd 'yarn --version'
+             sh.cmd 'hash -r', echo: false
           end
         end
 

--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -43,7 +43,7 @@ module Travis
           sh.cmd 'nvm --version'
           sh.if "-f yarn.lock" do
              sh.cmd 'yarn --version'
-             sh.cmd 'hash -r', echo: false
+             sh.cmd 'hash -d yarn', echo: false
           end
         end
 


### PR DESCRIPTION
Somehow, calling `yarn --version` will cache the `yarn` path. This can cause an issue when installing an earlier `yarn` version afterward.

This change ensures no `yarn` path is cached.