### PR TITLE
Fix for more valid dotnet versions

### DIFF
--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -29,7 +29,7 @@ module Travis
         end
 
         MONO_VERSION_REGEXP   = /^(\d{1})\.(\d{1,2})\.\d{1,2}$/
-        DOTNET_VERSION_REGEXP = /^(\d{1})\.(\d{1,2})\.\d{1,2}$/
+        DOTNET_VERSION_REGEXP = /^(\d{1})\.(\d{1,2})\.(\d{1,3})(-preview\d-\d{6})?$/
 
         def configure
           super


### PR DESCRIPTION
`2.1.101` is completely valid SDK version, as well as `2.1.300-preview1-008174`

cc @joshua-anderson @akoeplinger @nterry