### PR TITLE
Run after_failure when `sh.failure` is invoked

### DIFF
--- a/lib/travis/shell/builder.rb
+++ b/lib/travis/shell/builder.rb
@@ -84,6 +84,7 @@ module Travis
       def failure(message)
         export 'TRAVIS_CMD', 'no_script', echo: false
         echo message
+        raw 'travis_run_after_failure'
         raw 'set -e'
         raw 'false'
       end


### PR DESCRIPTION
Some build scripts calls `sh.failure` (not very common). This is a good opportunity to run the cleanup code before bailing out.

Resolves https://github.com/travis-ci/travis-ci/issues/8038 (which is R's case).