### PR TITLE
Set strict-ssl to false for Node.js 0.8.x

### DIFF
--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -190,11 +190,15 @@ module Travis
           end
 
           def npm_strict_ssl?
-            !node_0_6?
+            !node_0_6? && !node_0_8?
           end
 
           def node_0_6?
             (config[:node_js] || '').to_s.split('.')[0..1] == %w(0 6)
+          end
+
+          def node_0_8?
+            (config[:node_js] || '').to_s.split('.')[0..1] == %w(0 8)
           end
 
           def use_npm_cache?

--- a/spec/build/script/node_js_spec.rb
+++ b/spec/build/script/node_js_spec.rb
@@ -130,10 +130,10 @@ describe Travis::Build::Script::NodeJs, :sexp do
     end
   end
 
-  describe 'node 0.6.x' do
+  describe 'strict-ssl' do
     # let(:npm_set_strict_ssl) { [:cmd, 'npm conf set strict-ssl false', assert: true, echo: true] }
     let(:npm_set_strict_ssl) { [:cmd, 'npm conf set strict-ssl false', assert: true, echo: true, timing: true] }
-    ['0.6', '0.6.1', '0.6.99'].each do |version|
+    ['0.6', '0.6.1', '0.6.99', '0.8', '0.8.1', '0.8.99'].each do |version|
       it "sets strict-ssl to false for node #{version}" do
         data[:config][:node_js] = version
         should include_sexp npm_set_strict_ssl


### PR DESCRIPTION
So this is the same as #188 , but extends to Node.js 0.8.x now. Old versions of npm included in these versions have a specific CA embedded in npm and now that it's changed no longer validates.

Ref: https://github.com/npm/npm/issues/20191