### PR TITLE
use npm ci if available

### DIFF
--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -218,7 +218,11 @@ module Travis
 
           def npm_install(args)
             sh.fold "install.npm" do
-              sh.cmd "npm install #{args}", retry: true
+              sh.if "$(vers2int `npm -v`) -gt $(vers2int 5.7.1)" do
+                sh.cmd "npm ci #{args}", retry: true
+              sh.else do
+                sh.cmd "npm install #{args}", retry: true
+              end
               sh.if "$(vers2int `npm -v`) -gt $(vers2int #{NPM_QUIET_TREE_VERSION})" do
                 sh.cmd "npm ls", echo: true, assert: false
               end


### PR DESCRIPTION
This should run `npm ci` instead of `npm install` when `npm` version is above v5.8.0. This is much faster and has added benifits of using exact versions from `package-lock.json`.

Changelog for the npm version:
https://github.com/npm/npm/releases/tag/v5.8.0