### PR TITLE
C#: new package repo layout for Mono and add Ubuntu 18.04 repos for Mono+.NET Core

### DIFF
--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -187,6 +187,9 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
           super
 
           sh.export 'TRAVIS_SOLUTION', config_solution.shellescape if config_solution
+          sh.export 'STANDARD_CI_SOURCE_REVISION_ID', '${TRAVIS_COMMIT}'
+          sh.export 'STANDARD_CI_REPOSITORY_URL', 'https://github.com/${TRAVIS_REPO_SLUG}'
+          sh.export 'STANDARD_CI_REPOSITORY_TYPE', 'git'
         end
 
         def install

--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -80,6 +80,10 @@ View valid versions of \"mono\" at https://docs.travis-ci.com/user/languages/csh
                     sh.cmd "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu #{repo_prefix}xenial#{repo_suffix} main' > /etc/apt/sources.list.d/mono-official.list\"", assert: true
                     sh.cmd "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu nightly-xenial main' >> /etc/apt/sources.list.d/mono-official.list\"", assert: true if is_mono_nightly
                   end
+                  sh.elif '$(lsb_release -cs) = bionic' do
+                    sh.cmd "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu #{repo_prefix}bionic#{repo_suffix} main' > /etc/apt/sources.list.d/mono-official.list\"", assert: true
+                    sh.cmd "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu nightly-bionic main' >> /etc/apt/sources.list.d/mono-official.list\"", assert: true if is_mono_nightly
+                  end
                   sh.else do
                     sh.failure "The version of this operating system is not supported by Mono. View valid versions at https://docs.travis-ci.com/user/languages/csharp/"
                   end
@@ -137,6 +141,9 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
               end
               sh.elif '$(lsb_release -cs) = xenial' do
                 sh.cmd "sudo sh -c \"echo 'deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-xenial-prod xenial main' > /etc/apt/sources.list.d/dotnetdev.list\"", assert: true
+              end
+              sh.elif '$(lsb_release -cs) = bionic' do
+                sh.cmd "sudo sh -c \"echo 'deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-bionic-prod bionic main' > /etc/apt/sources.list.d/dotnetdev.list\"", assert: true
               end
               sh.else do
                 sh.failure "The version of this operating system is not supported by .NET Core. View valid versions at https://docs.travis-ci.com/user/languages/csharp/"

--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -187,9 +187,9 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
           super
 
           sh.export 'TRAVIS_SOLUTION', config_solution.shellescape if config_solution
-          sh.export 'STANDARD_CI_SOURCE_REVISION_ID', '${TRAVIS_COMMIT}'
-          sh.export 'STANDARD_CI_REPOSITORY_URL', 'https://github.com/${TRAVIS_REPO_SLUG}'
-          sh.export 'STANDARD_CI_REPOSITORY_TYPE', 'git'
+          sh.export 'STANDARD_CI_SOURCE_REVISION_ID', '${TRAVIS_COMMIT}', echo: false
+          sh.export 'STANDARD_CI_REPOSITORY_URL', 'https://github.com/${TRAVIS_REPO_SLUG}', echo: false
+          sh.export 'STANDARD_CI_REPOSITORY_TYPE', 'git', echo: false
         end
 
         def install

--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -64,28 +64,26 @@ View valid versions of \"mono\" at https://docs.travis-ci.com/user/languages/csh
 
                 if is_mono_after_5_0
                   # new Mono repo layout
-                  repo_prefix = 'alpha-' if config_mono == 'alpha' || config_mono == 'nightly' || config_mono == 'weekly'
-                  repo_prefix = 'beta-'  if config_mono == 'beta'
+                  repo_prefix = is_mono_preview || is_mono_nightly ? 'preview-' : 'stable-'
                   repo_suffix = "/snapshots/#{config_mono}" if !is_mono_version_keyword?
 
                   # main packages
                   sh.if '$(lsb_release -cs) = precise' do
                     sh.cmd "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu #{repo_prefix}precise#{repo_suffix} main' > /etc/apt/sources.list.d/mono-official.list\"", assert: true
+                    sh.cmd "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu nightly-precise main' >> /etc/apt/sources.list.d/mono-official.list\"", assert: true if is_mono_nightly
                   end
                   sh.elif '$(lsb_release -cs) = trusty' do
                     sh.cmd "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu #{repo_prefix}trusty#{repo_suffix} main' > /etc/apt/sources.list.d/mono-official.list\"", assert: true
+                    sh.cmd "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu nightly-trusty main' >> /etc/apt/sources.list.d/mono-official.list\"", assert: true if is_mono_nightly
                   end
                   sh.elif '$(lsb_release -cs) = xenial' do
                     sh.cmd "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu #{repo_prefix}xenial#{repo_suffix} main' > /etc/apt/sources.list.d/mono-official.list\"", assert: true
+                    sh.cmd "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu nightly-xenial main' >> /etc/apt/sources.list.d/mono-official.list\"", assert: true if is_mono_nightly
                   end
                   sh.else do
                     sh.failure "The version of this operating system is not supported by Mono. View valid versions at https://docs.travis-ci.com/user/languages/csharp/"
                   end
 
-                  # nightly packages
-                  if config_mono == 'nightly' || config_mono == 'weekly'
-                    sh.cmd "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu nightly main' >> /etc/apt/sources.list.d/mono-official.list\"", assert: true
-                  end
                 else
                   # old Mono repo layout
                   sh.if '$(lsb_release -cs) = precise' do
@@ -202,12 +200,10 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
           case config_mono
           when 'latest'
             return base_url + 'mdk-latest.pkg'
-          when 'alpha'
-            return base_url + 'mdk-latest-alpha.pkg'
-          when 'beta'
-            return base_url + 'mdk-latest-beta.pkg'
+          when 'alpha', 'beta', 'preview'
+            return base_url + 'mdk-latest-preview.pkg'
           when 'weekly', 'nightly'
-            return base_url + 'mdk-latest-weekly.pkg'
+            return base_url + 'mdk-latest-nightly.pkg'
           else
             if is_mono_after_4_4
               return base_url + config_mono + "/macos-10-universal/MonoFramework-MDK-#{config_mono}.macos10.xamarin.universal.pkg"
@@ -260,7 +256,15 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
         end
 
         def is_mono_version_keyword?
-          ['latest', 'alpha', 'beta', 'weekly', 'nightly', 'none'].include? config_mono
+          ['latest', 'alpha', 'beta', 'preview', 'weekly', 'nightly', 'none'].include? config_mono
+        end
+
+        def is_mono_nightly
+          config_mono == 'nightly' || config_mono == 'weekly'
+        end
+
+        def is_mono_preview
+          config_mono == 'alpha' || config_mono == 'beta' || config_mono == 'preview'
         end
 
         def is_mono_2_10_8

--- a/spec/build/script/csharp_spec.rb
+++ b/spec/build/script/csharp_spec.rb
@@ -15,7 +15,7 @@ describe Travis::Build::Script::Csharp, :sexp do
   describe 'configure' do
     it 'sets up package repository for mono' do
       should include_sexp [:cmd, 'sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF', assert: true]
-      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu trusty main' > /etc/apt/sources.list.d/mono-official.list\"", assert: true]
+      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu stable-trusty main' > /etc/apt/sources.list.d/mono-official.list\"", assert: true]
       should include_sexp [:cmd, 'sudo apt-get update -qq', timing: true, assert: true]
     end
 
@@ -100,37 +100,45 @@ describe Travis::Build::Script::Csharp, :sexp do
     end
 
     it 'selects latest version by default' do
-      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu trusty main' > /etc/apt/sources.list.d/mono-official.list\"", assert: true]
+      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu stable-trusty main' > /etc/apt/sources.list.d/mono-official.list\"", assert: true]
+      should_not include_sexp [:cmd, "nightly", assert: true]
     end
 
-    it 'selects correct version' do
+    it 'selects correct version on old repo' do
       data[:config][:mono] = '3.12.0'
       should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian wheezy/snapshots/3.12.0 main' >> /etc/apt/sources.list.d/mono-official.list\"", assert: true]
     end
 
     it 'selects correct version on new repo' do
       data[:config][:mono] = '5.2.0'
-      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu trusty/snapshots/5.2.0 main' > /etc/apt/sources.list.d/mono-official.list\"", assert: true]
+      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu stable-trusty/snapshots/5.2.0 main' > /etc/apt/sources.list.d/mono-official.list\"", assert: true]
     end
 
-    it 'selects alpha version when specified' do
+    it 'selects preview when alpha version is specified' do
       data[:config][:mono] = 'alpha'
-      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu alpha-trusty main' > /etc/apt/sources.list.d/mono-official.list\"", assert: true]
+      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu preview-trusty main' > /etc/apt/sources.list.d/mono-official.list\"", assert: true]
     end
 
-    it 'selects beta version when specified' do
+    it 'selects preview when beta version is specified' do
       data[:config][:mono] = 'beta'
-      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu beta-trusty main' > /etc/apt/sources.list.d/mono-official.list\"", assert: true]
+      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu preview-trusty main' > /etc/apt/sources.list.d/mono-official.list\"", assert: true]
     end
 
-    it 'selects nightly (which really is weekly, but kept to avoid breaking existing scripts) version when specified' do
+    it 'selects preview when specified' do
+      data[:config][:mono] = 'preview'
+      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu preview-trusty main' > /etc/apt/sources.list.d/mono-official.list\"", assert: true]
+    end
+
+    it 'selects nightly version when specified' do
       data[:config][:mono] = 'nightly'
-      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu nightly main' >> /etc/apt/sources.list.d/mono-official.list\"", assert: true]
+      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu preview-trusty main' > /etc/apt/sources.list.d/mono-official.list\"", assert: true]
+      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu nightly-trusty main' >> /etc/apt/sources.list.d/mono-official.list\"", assert: true]
     end
 
-    it 'selects weekly version when specified' do
+    it 'selects nightly when weekly version is specified' do
       data[:config][:mono] = 'weekly'
-      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu nightly main' >> /etc/apt/sources.list.d/mono-official.list\"", assert: true]
+      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu preview-trusty main' > /etc/apt/sources.list.d/mono-official.list\"", assert: true]
+      should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu nightly-trusty main' >> /etc/apt/sources.list.d/mono-official.list\"", assert: true]
     end
 
     it 'selects no version of Mono when specified' do
@@ -215,22 +223,34 @@ describe Travis::Build::Script::Csharp, :sexp do
       should include_sexp [:cmd, "sudo installer -package \"/tmp/dotnet.pkg\" -target \"/\" -verboseR", timing: true, assert: true]
       should include_sexp [:cmd, "eval $(/usr/libexec/path_helper -s)", assert: true]
     end
-    it 'selects alpha' do
+    it 'selects preview when alpha specified' do
       data[:config][:os] = 'osx'
       data[:config][:mono] = 'alpha'
-      should include_sexp [:cmd, "wget --retry-connrefused --waitretry=1 -O /tmp/mdk.pkg http://download.mono-project.com/archive/mdk-latest-alpha.pkg", timing: true, assert: true, echo: true]
+      should include_sexp [:cmd, "wget --retry-connrefused --waitretry=1 -O /tmp/mdk.pkg http://download.mono-project.com/archive/mdk-latest-preview.pkg", timing: true, assert: true, echo: true]
     end
 
-    it 'selects beta' do
+    it 'selects preview when beta specified' do
       data[:config][:os] = 'osx'
       data[:config][:mono] = 'beta'
-      should include_sexp [:cmd, "wget --retry-connrefused --waitretry=1 -O /tmp/mdk.pkg http://download.mono-project.com/archive/mdk-latest-beta.pkg", timing: true, assert: true, echo: true]
+      should include_sexp [:cmd, "wget --retry-connrefused --waitretry=1 -O /tmp/mdk.pkg http://download.mono-project.com/archive/mdk-latest-preview.pkg", timing: true, assert: true, echo: true]
     end
 
-    it 'selects weekly' do
+    it 'selects preview' do
+      data[:config][:os] = 'osx'
+      data[:config][:mono] = 'preview'
+      should include_sexp [:cmd, "wget --retry-connrefused --waitretry=1 -O /tmp/mdk.pkg http://download.mono-project.com/archive/mdk-latest-preview.pkg", timing: true, assert: true, echo: true]
+    end
+
+    it 'selects nightly when weekly specified' do
       data[:config][:os] = 'osx'
       data[:config][:mono] = 'weekly'
-      should include_sexp [:cmd, "wget --retry-connrefused --waitretry=1 -O /tmp/mdk.pkg http://download.mono-project.com/archive/mdk-latest-weekly.pkg", timing: true, assert: true, echo: true]
+      should include_sexp [:cmd, "wget --retry-connrefused --waitretry=1 -O /tmp/mdk.pkg http://download.mono-project.com/archive/mdk-latest-nightly.pkg", timing: true, assert: true, echo: true]
+    end
+
+    it 'selects nightly' do
+      data[:config][:os] = 'osx'
+      data[:config][:mono] = 'nightly'
+      should include_sexp [:cmd, "wget --retry-connrefused --waitretry=1 -O /tmp/mdk.pkg http://download.mono-project.com/archive/mdk-latest-nightly.pkg", timing: true, assert: true, echo: true]
     end
 
     it 'selects 4.0.1' do


### PR DESCRIPTION
There was some consolidation on the Mono package repository recently, the `alpha` and `beta` channels got merged into `preview` and `weekly` was renamed to `nightly`.

Also added Ubuntu 18.4 "bionic" repos to be prepared when it's available :)

Added the  Standard CI environment variables based on the spec from https://github.com/dotnet/designs/blob/master/accepted/build/standard-ci-env-variables.md