### PR TITLE
Set strict-ssl to false for Node.js 0.9.x

### DIFF
--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -190,7 +190,7 @@ module Travis
           end
 
           def npm_strict_ssl?
-            !node_0_6? && !node_0_8?
+            !node_0_6? && !node_0_8? && !node_0_9?
           end
 
           def node_0_6?
@@ -199,6 +199,10 @@ module Travis
 
           def node_0_8?
             (config[:node_js] || '').to_s.split('.')[0..1] == %w(0 8)
+          end
+
+          def node_0_9?
+            (config[:node_js] || '').to_s.split('.')[0..1] == %w(0 9)
           end
 
           def use_npm_cache?

--- a/spec/build/script/node_js_spec.rb
+++ b/spec/build/script/node_js_spec.rb
@@ -133,7 +133,7 @@ describe Travis::Build::Script::NodeJs, :sexp do
   describe 'strict-ssl' do
     # let(:npm_set_strict_ssl) { [:cmd, 'npm conf set strict-ssl false', assert: true, echo: true] }
     let(:npm_set_strict_ssl) { [:cmd, 'npm conf set strict-ssl false', assert: true, echo: true, timing: true] }
-    ['0.6', '0.6.1', '0.6.99', '0.8', '0.8.1', '0.8.99'].each do |version|
+    ['0.6', '0.6.1', '0.6.99', '0.8', '0.8.1', '0.8.99', '0.9', '0.9.1', '0.9.99'].each do |version|
       it "sets strict-ssl to false for node #{version}" do
         data[:config][:node_js] = version
         should include_sexp npm_set_strict_ssl


### PR DESCRIPTION
https://github.com/npm/npm/issues/20191 cert issue also affects node 0.9

Previous PRs applied the `strict-ssl` fix for older versions of node:

Node 0.6: https://github.com/travis-ci/travis-build/pull/188
Node 0.8: https://github.com/travis-ci/travis-build/pull/1350