### PR TITLE
Do not use a binary for devtools

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -406,13 +406,9 @@ module Travis
           unless @devtools_installed
             case config[:os]
             when 'linux'
-              # We can't use devtools binaries with R-devel because the ABI has
-              # changed.
-              if config[:sudo] and r_version != 'devel'
-                r_binary_install ['devtools']
-              else
+              # We can't use devtools binaries because R versions < 3.5 are not
+              # compatible with R versions >= 3.5
                 r_install ['devtools']
-              end
             else
               devtools_check = '!requireNamespace("devtools", quietly = TRUE)'
               devtools_install = 'install.packages("devtools")'

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -142,13 +142,7 @@ describe Travis::Build::Script::R, :sexp do
                          assert: true, echo: true, timing: true]
   end
 
-  it 'installs binary devtools if sudo: required' do
-    data[:config][:sudo] = 'required'
-    should include_sexp [:cmd, /sudo apt-get install.*r-cran-devtools/,
-                         assert: true, echo: true, timing: true, retry: true]
-  end
-
-  it 'installs source devtools if sudo: is missing' do
+  it 'installs source devtools' do
     should include_sexp [:cmd, /Rscript -e 'install\.packages\(c\(\"devtools\"\)/,
                          assert: true, echo: true, timing: true]
 


### PR DESCRIPTION
Because of ABI incompatibilities between R 3.5 and previous versions we
cannot use a devtools binary

Fixes https://github.com/travis-ci/travis-ci/issues/8887