### PR TITLE
Cleanup the log a little

### DIFF
--- a/lib/travis/build/appliances/no_ipv6_localhost.rb
+++ b/lib/travis/build/appliances/no_ipv6_localhost.rb
@@ -5,7 +5,7 @@ module Travis
     module Appliances
       class NoIpv6Localhost < Base
         def apply
-          sh.raw %(sed -e 's/^\\([0-9a-f:]\\+\\s\\)localhost/\\1/' /etc/hosts > /tmp/hosts.tmp && cat /tmp/hosts.tmp | sudo tee /etc/hosts)
+          sh.raw %(sed -e 's/^\\([0-9a-f:]\\+\\s\\)localhost/\\1/' /etc/hosts > /tmp/hosts.tmp && cat /tmp/hosts.tmp | sudo tee /etc/hosts > /dev/null 2>&1)
         end
       end
     end

--- a/lib/travis/build/appliances/no_world_writable_dirs.rb
+++ b/lib/travis/build/appliances/no_world_writable_dirs.rb
@@ -7,7 +7,7 @@ module Travis
         def apply
           sh.cmd <<-EOF
 for dir in $(echo $PATH | tr : " "); do
-  test -d $dir && sudo chmod -vv o-w $dir | grep changed
+  test -d $dir && sudo chmod o-w $dir | grep changed
 done
           EOF
         end

--- a/lib/travis/build/appliances/rm_riak_source.rb
+++ b/lib/travis/build/appliances/rm_riak_source.rb
@@ -7,7 +7,7 @@ module Travis
         def apply
           command = <<-EOF
           if [[ -d /var/lib/apt/lists && -n $(command -v apt-get) ]]; then
-            grep -l -i -r basho /etc/apt/sources.list.d | xargs sudo rm -vf
+            grep -l -i -r basho /etc/apt/sources.list.d | xargs sudo rm -f
           fi
           EOF
           sh.cmd command, echo: false

--- a/lib/travis/build/appliances/wait_for_network.rb
+++ b/lib/travis/build/appliances/wait_for_network.rb
@@ -38,6 +38,7 @@ module Travis
             travis_wait_for_network
               '#{wait_retries}' '#{check_urls.join("' '")}'
           ].join(' ').untaint, echo: false
+          sh.echo
         end
 
         private def check_urls

--- a/lib/travis/build/script/shared/jdk.rb
+++ b/lib/travis/build/script/shared/jdk.rb
@@ -18,8 +18,7 @@ module Travis
             sh.export 'TERM', 'dumb'
           end
 
-          sh.echo "Disabling Gradle daemon", ansi: :yellow
-          sh.cmd 'mkdir -p ~/.gradle && echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties', echo: true
+          sh.cmd 'mkdir -p ~/.gradle && echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties', echo: false
         end
 
         def announce


### PR DESCRIPTION
I don't believe the fact that we disable the Gradle daemon is something many Ruby devs care about at all, so I propose to remove that message entirely. If this is important and unexpected to JRuby folks than we should document it.