### PR TITLE
r: add feature to show logs on success

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -31,6 +31,7 @@ module Travis
           bioc_required: false,
           bioc_use_devel: false,
           disable_homebrew: false,
+          dump_logs: false,
           r: 'release'
         }
 
@@ -258,6 +259,10 @@ module Travis
               dump_error_logs
               sh.failure "Found warnings, treating as errors (as requested)."
             end
+          end
+
+          if config[:dump_logs]
+            dump_error_logs
           end
 
         end


### PR DESCRIPTION
Currently we only get to see log files if there was an error. However I would like to be able to manually inspect the log files even if there was no error.  This PR adds that.

@jimhester 