### PR TITLE
[community:r] add BiocCheck to r.rb in travis-build

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -239,8 +239,8 @@ module Travis
             sh.cmd "R CMD check \"${PKG_TARBALL}\" #{config[:r_check_args]}; "\
               "CHECK_RET=$?", assert: false
             if config[:bioc_check]
-            sh.echo 'Checking with: R CMD BiocCheck "${PKG_TARBALL}" '
-                sh.cmd "R CMD BiocCheck \"${PKG_TARBALL}\""
+            sh.echo 'Checking with: BiocCheck( "${PKG_TARBALL}" ) '
+                sh.cmd 'Rscript -e "BiocCheck(\"${PKG_TARBALL}\")"'
             end
           end
           export_rcheck_dir

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -237,12 +237,16 @@ module Travis
               "#{config[:r_check_args]}"
             sh.cmd "R CMD check \"${PKG_TARBALL}\" #{config[:r_check_args]}; "\
               "CHECK_RET=$?", assert: false
-            if config[:bioc_check]
-            sh.echo 'Checking with: BiocCheck( "${PKG_TARBALL}" ) '
-                sh.cmd 'Rscript -e "BiocCheck::BiocCheck(\"${PKG_TARBALL}\")"'
-            end
           end
           export_rcheck_dir
+
+          if config[:bioc_check]
+            # BiocCheck the package
+            sh.fold 'Bioc-check' do
+              sh.echo 'Checking with: BiocCheck( "${PKG_TARBALL}" ) '
+                  sh.cmd 'Rscript -e "BiocCheck::BiocCheck(\"${PKG_TARBALL}\")"'
+            end
+          end
 
           if @devtools_installed
             # Output check summary

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -29,6 +29,7 @@ module Travis
           # Bioconductor
           bioc: 'https://bioconductor.org/biocLite.R',
           bioc_required: false,
+          bioc_check: false,
           bioc_use_devel: false,
           disable_homebrew: false,
           r: 'release'
@@ -237,6 +238,9 @@ module Travis
               "#{config[:r_check_args]}"
             sh.cmd "R CMD check \"${PKG_TARBALL}\" #{config[:r_check_args]}; "\
               "CHECK_RET=$?", assert: false
+            if bioc_check
+                sh.cmd "R CMD BiocCheck \"${PKG_TARBALL}\""
+            end
           end
           export_rcheck_dir
 
@@ -404,6 +408,9 @@ module Travis
                   ');'\
                   'cat(append = TRUE, file = "~/.Rprofile.site", "options(repos = BiocInstaller::biocinstallRepos());")'
                 sh.cmd "Rscript -e '#{bioc_install_script}'", retry: true
+               if bioc_check
+                 sh.cmd "Rscript -e 'BiocInstaller::biocLite(\"BiocCheck\")'"
+               end
             end
           end
           @bioc_installed = true
@@ -546,7 +553,7 @@ module Travis
           when 'bioc-devel'
             config[:bioc_required] = true
             config[:bioc_use_devel] = true
-            'devel'
+            'release'
           when 'bioc-release'
             config[:bioc_required] = true
             config[:bioc_use_devel] = false

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -244,7 +244,7 @@ module Travis
             # BiocCheck the package
             sh.fold 'Bioc-check' do
               sh.echo 'Checking with: BiocCheck( "${PKG_TARBALL}" ) '
-                  sh.cmd 'Rscript -e "BiocCheck::BiocCheck(\"${PKG_TARBALL}\")"'
+              sh.cmd 'Rscript -e "BiocCheck::BiocCheck(\"${PKG_TARBALL}\")"'
             end
           end
 

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -240,7 +240,7 @@ module Travis
               "CHECK_RET=$?", assert: false
             if config[:bioc_check]
             sh.echo 'Checking with: BiocCheck( "${PKG_TARBALL}" ) '
-                sh.cmd 'Rscript -e "BiocCheck(\"${PKG_TARBALL}\")"'
+                sh.cmd 'Rscript -e "BiocCheck::BiocCheck(\"${PKG_TARBALL}\")"'
             end
           end
           export_rcheck_dir

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -238,7 +238,8 @@ module Travis
               "#{config[:r_check_args]}"
             sh.cmd "R CMD check \"${PKG_TARBALL}\" #{config[:r_check_args]}; "\
               "CHECK_RET=$?", assert: false
-            if bioc_check
+            if config[:bioc_check]
+            sh.echo 'Checking with: R CMD BiocCheck "${PKG_TARBALL}" '
                 sh.cmd "R CMD BiocCheck \"${PKG_TARBALL}\""
             end
           end
@@ -408,7 +409,7 @@ module Travis
                   ');'\
                   'cat(append = TRUE, file = "~/.Rprofile.site", "options(repos = BiocInstaller::biocinstallRepos());")'
                 sh.cmd "Rscript -e '#{bioc_install_script}'", retry: true
-               if bioc_check
+               if config[:bioc_check]
                  sh.cmd "Rscript -e 'BiocInstaller::biocLite(\"BiocCheck\")'"
                end
             end

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -194,8 +194,8 @@ describe Travis::Build::Script::R, :sexp do
 
     it 'does BiocCheck if requested' do
       data[:config][:bioc_check] = true
-      should include_sexp [:cmd, /.*BiocCheck.*/,
-                           assert: true, echo: true, timing: true]
+      should include_sexp [:cmd, /.*BiocCheck::BiocCheck.*/,
+                           echo: true, timing: true]
     end
 
     it 'does install bioc with bioc_packages' do

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -192,6 +192,11 @@ describe Travis::Build::Script::R, :sexp do
                            assert: true, echo: true, retry: true, timing: true]
     end
 
+    it 'does BiocCheck if requested' do
+      data[:config][:bioc_check] = true
+      should include_sexp [:cmd, /.*BiocCheck.*/,
+                           assert: true, echo: true, timing: true]
+
     it 'does install bioc with bioc_packages' do
       data[:config][:bioc_packages] = ['GenomicFeatures']
       should include_sexp [:cmd, /.*biocLite.*/,

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -196,6 +196,7 @@ describe Travis::Build::Script::R, :sexp do
       data[:config][:bioc_check] = true
       should include_sexp [:cmd, /.*BiocCheck.*/,
                            assert: true, echo: true, timing: true]
+    end
 
     it 'does install bioc with bioc_packages' do
       data[:config][:bioc_packages] = ['GenomicFeatures']


### PR DESCRIPTION
Hi Jim and Craig, @jimhester @craigcitro 

Here is my attempt at the pull request mentioned in travis-ci/travis-ci#9455

Users that add: 
```
r: bioc-devel

bioc_check: true
```
Should get a check of the package with `R CMD BiocCheck`.

I've tried to test this locally but I am unable to build the `ci.sh` from the `travis compile` command (I'm using the `travisci/ci-garnet:packer-1512502276-986baf0`. I suspect that I have to install additional dependencies. Any pointers are appreciated. I'm using this as reference: https://stackoverflow.com/a/45761267

Regards,
Marcel 