### PR TITLE
Automate Go and GHC version upgrades

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ jobs:
       dist: trusty
       env:
       script: ./script/docker-build-and-push
+      after_success:
+        - ./script/create-version-aliases-pr
       if: (NOT type IN (pull_request)) AND (branch = master)
 
 before_script:

--- a/lib/travis/build/rake_tasks.rb
+++ b/lib/travis/build/rake_tasks.rb
@@ -260,6 +260,7 @@ module Travis
         path = top + 'tmp/go-versions-binary-linux'
         if data = latest_go_releases
           dest = Pathname.new(path)
+          dest.dirname.mkpath
           dest.write data.join("\n")
         else
           fetch_githubusercontent_file(

--- a/script/create-version-aliases-pr
+++ b/script/create-version-aliases-pr
@@ -1,0 +1,51 @@
+#!/usr/bin/bash
+
+function set_up_git_credentials {
+  if [ -z "`git config --get --global credential.helper`" ]; then
+    notice "set up credential.helper"
+    git config credential.helper "store --file=.git/credentials"
+    echo "https://${GITHUB_OAUTH_TOKEN}:@github.com" > .git/credentials 2>/dev/null
+  fi
+  if [ -z "`git config --get --global user.email`" ]; then
+    notice "set up user.email"
+    git config --global user.email "contact@travis-ci.com"
+  fi
+  if [ -z "`git config --get --global user.name`" ]; then
+    notice "set up user.name"
+    git config --global user.name "Travis CI travis-build PR writer"
+  fi
+}
+
+DEFAULT_BRANCH=master
+BRANCH=version-aliases-update
+
+dirty=()
+
+for f in public/version-aliases/*.json; do
+  if ! git diff-index --quiet HEAD $f; then
+    dirty[${#dirty}]=$(basename $f)
+    git add $f
+  fi
+done
+
+if git diff-index --quiet --cached HEAD --; then
+  # git index is clean
+  exit
+fi
+
+set_up_git_credentials
+
+git checkout -b $BRANCH
+
+git commit -m "Add ${dirty[@]}\n\nBased on $TRAVIS_BUILD_URL"
+
+git push origin
+
+if [ $? -gt 0 ]; then
+  echo "failed to push commit"
+  exit 1
+fi
+
+curl -X POST -fsS -H "Content-Type: application/json" -H "Authorization: token ${GITHUB_OAUTH_TOKEN}" \
+  -d "{\"title\":\"Update public/version-aliases\",\"body\":\"Update ${dirty[@]}\",\"head\":\"${BRANCH}\",\"base\":\"${DEFAULT_BRANCH}\"}" \
+  https://api.github.com/repos/travis-ci/travis-build/

--- a/script/create-version-aliases-pr
+++ b/script/create-version-aliases-pr
@@ -37,7 +37,7 @@ set_up_git_credentials
 
 git checkout -b $BRANCH
 
-git commit -m "Add ${dirty[@]}\n\nBased on $TRAVIS_BUILD_URL"
+git commit -m "Add ${dirty[@]}\n\nBased on https://travis-ci.org/${TRAVIS_REPO_SLUG}/builds/${TRAVIS_BUILD_ID}"
 
 git push origin
 

--- a/script/create-version-aliases-pr
+++ b/script/create-version-aliases-pr
@@ -37,9 +37,9 @@ set_up_git_credentials
 
 git checkout -b $BRANCH
 
-git commit -m "Add ${dirty[@]}\n\nBased on https://travis-ci.org/${TRAVIS_REPO_SLUG}/builds/${TRAVIS_BUILD_ID}"
+git commit -m "Add ${dirty[*]}\n\nBased on https://travis-ci.org/${TRAVIS_REPO_SLUG}/builds/${TRAVIS_BUILD_ID}"
 
-git push origin
+git push origin $BRANCH
 
 if [ $? -gt 0 ]; then
   echo "failed to push commit"

--- a/spec/build/rake_tasks_spec.rb
+++ b/spec/build/rake_tasks_spec.rb
@@ -107,6 +107,31 @@ describe Travis::Build::RakeTasks do
           )
         ]
       end
+
+      stub.get('/go/+refs?format=JSON') do |*|
+        [
+          200,
+          { 'Content-Type' => 'application/json' },
+          <<-EOF.gsub(/^\s+> ?/, '')
+            > )]}'
+            > {
+            >   "HEAD": {
+            >     "value": "91d326e7341247dc3f4c391cc7eb7dd7163446aa",
+            >     "target": "refs/heads/master"
+            >   },
+            >   "refs/tags/go1.9.1": {
+            >     "value": "90205f0f872829e26cff6f2e19987a946de84f1e"
+            >   },
+            >   "refs/tags/go1.4.0": {
+            >     "value": "90205f0f872829e26cff6f2e19987a946de84f1e"
+            >   },
+            >   "refs/tags/go1.2.3": {
+            >     "value": "90205f0f872829e26cff6f2e19987a946de84f1e"
+            >   }
+            > }
+          EOF
+        ]
+      end
     end
   end
 


### PR DESCRIPTION
Currently, we rely on travis-ci/gimme to provide the most up-to-date list of Go releases to use. This requires manual intervention whenever there is a new release. (For example, Go 1.10.2 was released [on May 1, 2018](https://golang.org/doc/devel/release.html#go1.10.minor), 24 days ago, but we have users asking for it now https://github.com/travis-ci/travis-ci/issues/9652.)

This is cumbersome and unnecessary.

We automate this process by consulting https://go.googlesource.com/go/+refs?format=JSON and discovering all most recent releases 1.2.x and up.

Then, in exactly one job which runs the `assets:precompile` Rake task, we check if any of the files in `public/version-aliases` is updated, and if so, create a Pull Request to this repository to be reviewed and merged.