### PR TITLE
Add c2d4u PPA dependencies

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -73,14 +73,19 @@ module Travis
                 sh.cmd 'sudo apt-key adv --keyserver keyserver.ubuntu.com '\
                   '--recv-keys E084DAB9'
 
-                # Add marutter's c2d4u repository.
+                # Add marutter's c2d4u plus ppa dependencies as listed on launchpad
                 if r_version_less_than('3.5.0')
                   sh.cmd 'sudo add-apt-repository -y "ppa:marutter/rrutter"'
                   sh.cmd 'sudo add-apt-repository -y "ppa:marutter/c2d4u"'
                 else
                   sh.cmd 'sudo add-apt-repository -y "ppa:marutter/rrutter3.5"'
                   sh.cmd 'sudo add-apt-repository -y "ppa:marutter/c2d4u3.5"'
+                  sh.cmd 'sudo add-apt-repository -y "ppa:ubuntugis/ppa"'
+                  sh.cmd 'sudo add-apt-repository -y "ppa:opencpu/jq"'
                 end
+
+                # Both c2d4u and c2d4u3.5 depend on this ppa for ffmpeg
+                sh.cmd 'sudo add-apt-repository -y "ppa:kirillshkrogalev/ffmpeg-next"'
 
                 # Update after adding all repositories. Retry several
                 # times to work around flaky connection to Launchpad PPAs.


### PR DESCRIPTION
The c2d4u repos depend on other ppa's listed on launchpad under *technical details*. We need to enable those as well to get the dependencies that the cd2d4u packages were built against.

Here is the [post by Michael Rutter](https://stat.ethz.ch/pipermail/r-sig-debian/2018-May/002872.html) on the r-sig-debian mailing list that confirms this.

[<img width="728" alt="screen shot 2018-05-27 at 3 20 49 pm" src="https://user-images.githubusercontent.com/216319/40586387-b5098234-61c1-11e8-84d1-10e2a704a577.png">](https://launchpad.net/~marutter/+archive/ubuntu/c2d4u3.5)

@jimhester 