### PR TITLE
julia: Only run `Pkg.clone(pwd())` on < `0.7-`

### DIFF
--- a/lib/travis/build/script/julia.rb
+++ b/lib/travis/build/script/julia.rb
@@ -71,12 +71,7 @@ module Travis
             sh.if '-a .git/shallow' do
               sh.cmd 'git fetch --unshallow'
             end
-            # It would be nice to combine conditionals here
-            sh.if '! -f Project.toml' do
-              sh.if '! -f JuliaProject.toml' do
-                sh.cmd 'julia --color=yes -e "if VERSION < v\"0.7-\"; Pkg.clone(pwd()); end"'
-              end
-            end
+            sh.cmd 'julia --color=yes -e "if VERSION < v\"0.7-\" && !isfile(\"Project.toml\") && !isfile(\"JuliaProject.toml\"); Pkg.clone(pwd()); end"'
             sh.cmd 'julia --color=yes -e "Pkg.build(\"${JL_PKG}\")"'
             sh.if '-f test/runtests.jl' do
               sh.cmd 'julia --check-bounds=yes --color=yes ' \

--- a/lib/travis/build/script/julia.rb
+++ b/lib/travis/build/script/julia.rb
@@ -71,7 +71,7 @@ module Travis
             sh.if '-a .git/shallow' do
               sh.cmd 'git fetch --unshallow'
             end
-            sh.if '-f Project.toml' do
+            sh.if '! -f Project.toml' do
               sh.cmd 'julia --color=yes -e "if VERSION < v\"0.7-\"; Pkg.clone(pwd()); end"'
             end
             sh.cmd 'julia --color=yes -e "Pkg.build(\"${JL_PKG}\")"'

--- a/lib/travis/build/script/julia.rb
+++ b/lib/travis/build/script/julia.rb
@@ -71,7 +71,9 @@ module Travis
             sh.if '-a .git/shallow' do
               sh.cmd 'git fetch --unshallow'
             end
-            sh.cmd "julia --color=yes -e 'Pkg.clone(pwd())'"
+            sh.if '-f Project.toml' do
+              sh.cmd 'julia --color=yes -e "if VERSION < v\"0.7-\"; Pkg.clone(pwd()); end"'
+            end
             sh.cmd 'julia --color=yes -e "Pkg.build(\"${JL_PKG}\")"'
             sh.if '-f test/runtests.jl' do
               sh.cmd 'julia --check-bounds=yes --color=yes ' \

--- a/lib/travis/build/script/julia.rb
+++ b/lib/travis/build/script/julia.rb
@@ -71,8 +71,11 @@ module Travis
             sh.if '-a .git/shallow' do
               sh.cmd 'git fetch --unshallow'
             end
+            # It would be nice to combine conditionals here
             sh.if '! -f Project.toml' do
-              sh.cmd 'julia --color=yes -e "if VERSION < v\"0.7-\"; Pkg.clone(pwd()); end"'
+              sh.if '! -f JuliaProject.toml' do
+                sh.cmd 'julia --color=yes -e "if VERSION < v\"0.7-\"; Pkg.clone(pwd()); end"'
+              end
             end
             sh.cmd 'julia --color=yes -e "Pkg.build(\"${JL_PKG}\")"'
             sh.if '-f test/runtests.jl' do

--- a/lib/travis/build/script/julia.rb
+++ b/lib/travis/build/script/julia.rb
@@ -71,7 +71,7 @@ module Travis
             sh.if '-a .git/shallow' do
               sh.cmd 'git fetch --unshallow'
             end
-            sh.cmd 'julia --color=yes -e "if VERSION < v\"0.7-\" && !isfile(\"Project.toml\") && !isfile(\"JuliaProject.toml\"); Pkg.clone(pwd()); end"'
+            sh.cmd 'julia --color=yes -e "if VERSION < v\"0.7.0-DEV.5183\" || (!isfile(\"Project.toml\") && !isfile(\"JuliaProject.toml\")); Pkg.clone(pwd()); end"'
             sh.cmd 'julia --color=yes -e "Pkg.build(\"${JL_PKG}\")"'
             sh.if '-f test/runtests.jl' do
               sh.cmd 'julia --check-bounds=yes --color=yes ' \


### PR DESCRIPTION
Recent changes to Julia 0.7 have obviated the need for a `Pkg.clone()` step; so if there is a `Project.toml` file in the current directory, and we're running on Julia 0.7+, then don't bother to `Pkg.clone(pwd())`.  If there is no `Project.toml` file, or if we're running on Julia 0.6, then we should still `Pkg.clone(pwd())`.

@kristofferc @ninjin @tkelman @simonbyrne 