### PR TITLE
Removing old-message about apt-get being disabled

### DIFF
--- a/lib/travis/build/appliances/apt_get_update.rb
+++ b/lib/travis/build/appliances/apt_get_update.rb
@@ -4,15 +4,8 @@ module Travis
   module Build
     module Appliances
       class AptGetUpdate < Base
-        MSGS = {
-          disabled: "Running apt-get update by default has been disabled.",
-          opt_in:   "You can opt into running apt-get update by setting this in your .travis.yml file:\n\n  addons:\n    apt:\n      update: true"
-        }
-
         def apply
           use_mirror if use_mirror?
-          disabled   if disabled?
-          update     if update?
         end
 
         def apply?
@@ -35,18 +28,6 @@ module Travis
             else
               !config[:update].is_a?(FalseClass) && !used?
             end
-          end
-
-          def disabled
-            sh.echo MSGS[:disabled], ansi: :yellow
-            sh.echo MSGS[:opt_in]
-          end
-
-          def update
-            sh.cmd <<-EOF
-              sudo rm -rf /var/lib/apt/lists/*
-              sudo apt-get update #{'-qq  >/dev/null 2>&1' unless debug?}
-            EOF
           end
 
           def used?

--- a/spec/build/script_spec.rb
+++ b/spec/build/script_spec.rb
@@ -152,7 +152,6 @@ describe Travis::Build::Script, :sexp do
       context 'with config[:apt][:update] not given' do
         before { payload[:config].delete(:apt) }
         it { expect(code).to_not include 'sudo apt-get update' }
-        it { expect(code).to include 'Running apt-get update by default has been disabled' }
       end
 
       context 'with config[:apt][:update] not given and apt-get update used in before_install' do
@@ -171,7 +170,6 @@ describe Travis::Build::Script, :sexp do
       context 'with config[:apt][:update] being false' do
         before { payload[:config][:apt] = { update: false } }
         it { expect(code).to_not include 'sudo apt-get update' }
-        it { expect(code).to include 'Running apt-get update by default has been disabled' }
       end
 
       context 'with config[:addons][:apt][:update] being true' do
@@ -183,7 +181,6 @@ describe Travis::Build::Script, :sexp do
       context 'with config[:addons][:apt][:update] being false' do
         before { payload[:config][:addons][:apt] = { update: false } }
         it { expect(code).to_not include 'sudo apt-get update' }
-        it { expect(code).to include 'Running apt-get update by default has been disabled' }
       end
     end
   end


### PR DESCRIPTION
corresponding docs change is [here](https://github.com/travis-ci/docs-travis-ci-com/pull/1864).