### PR TITLE
Improve token handling for PRs

### DIFF
--- a/lib/travis/build/rake_tasks.rb
+++ b/lib/travis/build/rake_tasks.rb
@@ -43,7 +43,7 @@ module Travis
           releases_url = "repos/#{repo}/releases"
           logger.info "Fetching releases from #{conn.url_prefix.to_s}#{releases_url}"
           req.url releases_url
-          oauth_token = ENV['GITHUB_OAUTH_TOKEN']
+          oauth_token = ENV.fetch('GITHUB_OAUTH_TOKEN', ENV.fetch('no_scope_token', 'notset'))
           if oauth_token && !oauth_token.empty? && oauth_token != 'notset'
             logger.info "Adding 'Authorization' header for api.github.com request"
             req.headers['Authorization'] = "token #{oauth_token}"


### PR DESCRIPTION
Cross repository PR builds run often in errors while querying the
GitHub API during the rake tasks. This PR allows a fallback value for
the GitHub OAuth token under the name `no_scope_token`. This token has
no defined scope, yet does not get rate limited based on the IP address
of the NAT instances.