### PR TITLE
Test compile CLI per documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ before_script:
 script:
   - bundle exec rake spec
   - ./script/validate-bash-syntax
+  - ln -s $(pwd) ~/.travis/travis-build && gem install bundler && bundle install --gemfile Gemfile && bundler binstubs travis && ./bin/travis compile --no-interactive && test -e build.sh
 
 after_success: bundle exec codeclimate-test-reporter
 


### PR DESCRIPTION
The [documentation](https://github.com/travis-ci/travis-build#use-as-addon-for-cli
) indicates you can run "travis compile" on a .travis.yml to generate a build.sh but I haven't gotten that to work.

I've altered the .travis.yml CI script to run what I think is a test that follows the documents here:

It appears to have the same error that I encounter locally

I've reported this tangentially as part of https://github.com/travis-ci/travis-ci/issues/9700 where I can't determine why "android" builds all go to GCE instead of Docker+EC2 but thought this would be a more thorough way to demonstrate what I sa

