### PR TITLE
SetupFilter: log an error if fallback curl fails

### DIFF
--- a/lib/travis/build/appliances/setup_filter.rb
+++ b/lib/travis/build/appliances/setup_filter.rb
@@ -42,6 +42,9 @@ module Travis
               if [ $? -ne 0 ]; then
                 echo "Download from %{url} failed. Trying %{fallback_url} ..."
                 curl -sf -o ~/filter.rb %{fallback_url}
+                if [ $? -ne 0 ]; then
+                  echo "Download from %{fallback_url} failed."
+                fi
               fi
           ),
           pty: %(


### PR DESCRIPTION
This produces a more understandable failure message in cases such as https://travis-ci.org/rust-lang/rust/jobs/389759833.