### PR TITLE
Add retry logic to the dart sdk curl request

### DIFF
--- a/lib/travis/build/script/dart.rb
+++ b/lib/travis/build/script/dart.rb
@@ -93,7 +93,7 @@ MESSAGE
 
           sh.fold 'dart_install' do
             sh.echo 'Installing Dart', ansi: :yellow
-            sh.cmd "curl #{archive_url}/sdk/dartsdk-#{os}-x64-release.zip > $HOME/dartsdk.zip"
+            sh.cmd "curl --connect-timeout 15 --retry 5 #{archive_url}/sdk/dartsdk-#{os}-x64-release.zip > $HOME/dartsdk.zip"
             sh.cmd "unzip $HOME/dartsdk.zip -d $HOME > /dev/null"
             sh.cmd "rm $HOME/dartsdk.zip"
             sh.cmd 'export DART_SDK="$HOME/dart-sdk"'


### PR DESCRIPTION
For now I set this to 5 retries, with the default exponential backoff (will end up being 1, 2, 4, 8, 16 seconds between failures), and a connection timeout of 15 seconds (connection timeouts are the main failures I have seen).

cc @kevmoo 