### PR TITLE
Fix postgresql addon for Xenial

### DIFF
--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -239,7 +239,11 @@ module Travis
 
           def stop_postgresql
             sh.echo "PostgreSQL package is detected. Stopping postgresql service. See https://github.com/travis-ci/travis-ci/issues/5737 for more information.", ansi: :yellow
-            sh.cmd "sudo service postgresql stop", echo: true
+            if data.has_systemd?
+              sh.cmd "sudo systemctl stop postgresql", echo: true
+            else
+              sh.cmd "sudo service postgresql stop", echo: true
+            end
           end
       end
     end

--- a/lib/travis/build/addons/postgresql.rb
+++ b/lib/travis/build/addons/postgresql.rb
@@ -11,17 +11,20 @@ module Travis
         DEFAULT_FALLBACK_PORT = 5433
 
         def after_prepare
-          return if not data.is_linux?
+          if not data.is_linux?
+            sh.echo "Addon PostgreSQL is not supported on #{data[:config][:os]}", ansi: :red
+            return
+          end
           sh.fold 'postgresql' do
             sh.export 'PATH', "/usr/lib/postgresql/#{version}/bin:$PATH", echo: false
             sh.echo "Starting PostgreSQL v#{version}", ansi: :yellow
 
             if data.is_precise? || data.is_trusty?
               stop_command = "service postgresql stop"
-              start_command = "service postgresql start"
+              start_command = "service postgresql start #{version}"
             else
               stop_command = "systemctl stop postgresql"
-              start_command = "systemctl start postgresql@${version}-main"
+              start_command = "systemctl start postgresql@#{version}-main"
             end
             sh.cmd stop_command, assert: false, sudo: true, echo: true, timing: true
             sh.if "-d /var/ramfs && ! -d /var/ramfs/postgresql/#{version}", echo: false do

--- a/lib/travis/build/data.rb
+++ b/lib/travis/build/data.rb
@@ -222,15 +222,15 @@ module Travis
       end
 
       def is_xenial?
-        is_linux? && data[:config][:os] == 'xenial'
+        is_linux? && data[:config][:dist] == 'xenial'
       end
 
       def is_trusty?
-        is_linux? && data[:config][:os] == 'trusty'
+        is_linux? && data[:config][:dist] == 'trusty'
       end
 
       def is_precise?
-        is_linux? && data[:config][:os] == 'precise'
+        is_linux? && data[:config][:dist] == 'precise'
       end
     end
   end

--- a/lib/travis/build/data.rb
+++ b/lib/travis/build/data.rb
@@ -216,6 +216,22 @@ module Travis
       def installation_token
         GithubApps.new(installation_id).access_token
       end
+
+      def is_linux?
+        data[:config][:os] == 'linux'
+      end
+
+      def is_xenial?
+        is_linux? && data[:config][:os] == 'xenial'
+      end
+
+      def is_trusty?
+        is_linux? && data[:config][:os] == 'trusty'
+      end
+
+      def is_precise?
+        is_linux? && data[:config][:os] == 'precise'
+      end
     end
   end
 end

--- a/lib/travis/build/data.rb
+++ b/lib/travis/build/data.rb
@@ -232,6 +232,14 @@ module Travis
       def is_precise?
         is_linux? && data[:config][:dist] == 'precise'
       end
+
+      def has_upstart?
+        is_precise? || is_trusty?
+      end
+
+      def has_systemd?
+        is_linux? && !has_upstart?
+      end
     end
   end
 end

--- a/spec/build/addons/postgresql_spec.rb
+++ b/spec/build/addons/postgresql_spec.rb
@@ -2,26 +2,62 @@ require 'spec_helper'
 
 describe Travis::Build::Addons::Postgresql, :sexp do
   let(:script) { stub('script') }
-  let(:config) { '9.3' }
-  let(:data)   { payload_for(:push, :ruby, config: { addons: { postgresql: config } }) }
+  let(:data)   { payload_for(:push, :ruby, config: { addons: { postgresql: config }, dist: dist, os: os }) }
   let(:sh)     { Travis::Shell::Builder.new }
   let(:addon)  { described_class.new(script, sh, Travis::Build::Data.new(data), config) }
   subject      { sh.to_sexp }
   before       { addon.after_prepare }
 
-  it { store_example }
+  context 'for dist: trusty' do
+    let(:config) { '9.3' }
+    let(:dist)   { 'trusty' }
+    let(:os)     { 'linux' }
 
-  it_behaves_like 'compiled script' do
-    let(:cmds) { ['service postgresql start 9.3'] }
+    it { store_example }
+
+    it_behaves_like 'compiled script' do
+      let(:cmds) { ["service postgresql start #{config}"] }
+    end
+
+    it { should include_sexp [:export, ['PATH', "/usr/lib/postgresql/#{config}/bin:$PATH"]] }
+    it { should include_sexp [:echo, "Starting PostgreSQL v#{config}", ansi: :yellow] }
+    it { should include_sexp [:cmd, "cp -rp /var/lib/postgresql/#{config} /var/ramfs/postgresql/#{config}", sudo: true] }
+    it { should include_sexp [:cmd, "sudo -u postgres createuser -s -p #{described_class::DEFAULT_PORT} travis &>/dev/null", echo: true, timing: true] }
+    it { should include_sexp [:cmd, "sudo -u postgres createuser -s -p #{described_class::DEFAULT_FALLBACK_PORT} travis &>/dev/null", echo: true, timing: true] }
+    it { should include_sexp [:cmd, "sudo -u postgres createdb -O travis -p #{described_class::DEFAULT_PORT} travis &>/dev/null", echo: true, timing: true] }
+    it { should include_sexp [:cmd, "sudo -u postgres createdb -O travis -p #{described_class::DEFAULT_FALLBACK_PORT} travis &>/dev/null", echo: true, timing: true] }
+
+    it { should include_sexp [:cmd, 'service postgresql stop', sudo: true, echo: true, timing: true] }
+    it { should include_sexp [:cmd, "service postgresql start #{config}", sudo: true, echo: true, timing: true] }
   end
 
-  it { should include_sexp [:export, ['PATH', '/usr/lib/postgresql/9.3/bin:$PATH']] }
-  it { should include_sexp [:echo, 'Starting PostgreSQL v9.3', ansi: :yellow] }
-  it { should include_sexp [:cmd, 'service postgresql stop', sudo: true, echo: true, timing: true] }
-  it { should include_sexp [:cmd, 'cp -rp /var/lib/postgresql/9.3 /var/ramfs/postgresql/9.3', sudo: true] }
-  it { should include_sexp [:cmd, 'service postgresql start 9.3', sudo: true, echo: true, timing: true] }
-  it { should include_sexp [:cmd, "sudo -u postgres createuser -s -p #{described_class::DEFAULT_PORT} travis &>/dev/null", echo: true, timing: true] }
-  it { should include_sexp [:cmd, "sudo -u postgres createuser -s -p #{described_class::DEFAULT_FALLBACK_PORT} travis &>/dev/null", echo: true, timing: true] }
-  it { should include_sexp [:cmd, "sudo -u postgres createdb -O travis -p #{described_class::DEFAULT_PORT} travis &>/dev/null", echo: true, timing: true] }
-  it { should include_sexp [:cmd, "sudo -u postgres createdb -O travis -p #{described_class::DEFAULT_FALLBACK_PORT} travis &>/dev/null", echo: true, timing: true] }
+  context 'for dist: xenial' do
+    let(:config) { '10' }
+    let(:dist)   { 'xenial' }
+    let(:os)     { 'linux' }
+
+    it_behaves_like 'compiled script' do
+      let(:cmds) { ["systemctl start postgresql@#{config}-main"] }
+    end
+
+    it { should include_sexp [:export, ['PATH', "/usr/lib/postgresql/#{config}/bin:$PATH"]] }
+    it { should include_sexp [:echo, "Starting PostgreSQL v#{config}", ansi: :yellow] }
+    it { should include_sexp [:cmd, "cp -rp /var/lib/postgresql/#{config} /var/ramfs/postgresql/#{config}", sudo: true] }
+    it { should include_sexp [:cmd, "sudo -u postgres createuser -s -p #{described_class::DEFAULT_PORT} travis &>/dev/null", echo: true, timing: true] }
+    it { should include_sexp [:cmd, "sudo -u postgres createuser -s -p #{described_class::DEFAULT_FALLBACK_PORT} travis &>/dev/null", echo: true, timing: true] }
+    it { should include_sexp [:cmd, "sudo -u postgres createdb -O travis -p #{described_class::DEFAULT_PORT} travis &>/dev/null", echo: true, timing: true] }
+    it { should include_sexp [:cmd, "sudo -u postgres createdb -O travis -p #{described_class::DEFAULT_FALLBACK_PORT} travis &>/dev/null", echo: true, timing: true] }
+
+    it { should include_sexp [:cmd, 'systemctl stop postgresql', sudo: true, echo: true, timing: true] }
+    it { should include_sexp [:cmd, "systemctl start postgresql@#{config}-main", sudo: true, echo: true, timing: true] }
+  end
+
+  context 'for os: osx' do
+    let(:os) { 'osx' }
+    let(:config) { '9.6' }
+    let(:dist) { 'irrelevant' }
+
+    it { should include_sexp [:echo, "Addon PostgreSQL is not supported on #{os}", ansi: :red] }
+    it { should_not include_sexp [:echo, "Starting PostgreSQL v#{config}", ansi: :yellow] }
+  end
 end


### PR DESCRIPTION
- Adds convenience methods to `data` top determine what type of system this is running on
- Use systemd on Xenial, Upstart on previous Ubuntus
- Do not run addon on non-linux