### PR TITLE
Revert "Remove golang/gimme aliases"

### DIFF
--- a/lib/travis/build/config.rb
+++ b/lib/travis/build/config.rb
@@ -47,7 +47,7 @@ module Travis
             'https://raw.githubusercontent.com/travis-ci/gimme/v1.3.0/gimme'
           )
         },
-        go_version: ENV.fetch('TRAVIS_BUILD_GO_VERSION', '1.9'),
+        go_version: ENV.fetch('TRAVIS_BUILD_GO_VERSION', '1.10.x'),
         internal_ruby_regex: ENV.fetch(
           'TRAVIS_BUILD_INTERNAL_RUBY_REGEX',
           '^ruby-(2\.[0-2]\.[0-9]|1\.9\.3)'

--- a/lib/travis/build/config.rb
+++ b/lib/travis/build/config.rb
@@ -9,6 +9,10 @@ module Travis
       extend Hashr::Env
       self.env_namespace = 'travis_build'
 
+      def go_version_aliases_hash
+        @go_version_aliases_hash ||= version_aliases_hash('go')
+      end
+
       def ghc_version_aliases_hash
         @ghc_version_aliases_hash ||= version_aliases_hash('ghc')
       end
@@ -43,7 +47,7 @@ module Travis
             'https://raw.githubusercontent.com/travis-ci/gimme/v1.3.0/gimme'
           )
         },
-        go_version: ENV.fetch('TRAVIS_BUILD_GO_VERSION', '1.10.x'),
+        go_version: ENV.fetch('TRAVIS_BUILD_GO_VERSION', '1.9'),
         internal_ruby_regex: ENV.fetch(
           'TRAVIS_BUILD_INTERNAL_RUBY_REGEX',
           '^ruby-(2\.[0-2]\.[0-9]|1\.9\.3)'

--- a/lib/travis/build/rake_tasks.rb
+++ b/lib/travis/build/rake_tasks.rb
@@ -238,6 +238,43 @@ module Travis
         )
       end
 
+      def file_update_raw_go_versions
+        fetch_githubusercontent_file(
+          'travis-ci/gimme/master/.testdata/sample-binary-linux',
+          to: top + 'tmp/go-versions-binary-linux',
+          mode: 0o644
+        )
+      end
+
+      def file_update_go_versions
+        raw = (top + 'tmp/go-versions-binary-linux').read
+                                                    .split(/\n/)
+                                                    .reject do |line|
+          line.strip.empty? || line.strip.start_with?('#')
+        end
+
+        raw.sort!(&method(:semver_cmp))
+
+        out = {}
+        raw.each do |full_version|
+          out.merge!(
+            expand_semver_aliases(full_version, alias_major_minor: false)
+          )
+        end
+
+        raise StandardError, 'no go versions parsed' if out.empty?
+
+        out.merge!(
+          '1.2' => '1.2.2',
+          'go1' => 'go1'
+        )
+
+        dest = top + 'public/version-aliases/go.json'
+        dest.dirname.mkpath
+        dest.write(JSON.pretty_generate(out))
+        dest.chmod(0o644)
+      end
+
       def file_update_raw_ghc_versions
         fetch_githubusercontent_file(
           '~ghc',
@@ -314,6 +351,16 @@ module Travis
       desc 'update rustup'
       file('public/files/rustup-init.sh') { file_update_rustup }
 
+      desc 'update raw go versions'
+      file 'tmp/go-versions-binary-linux' do
+        file_update_raw_go_versions
+      end
+
+      desc 'update go versions'
+      file 'public/version-aliases/go.json' => 'tmp/go-versions-binary-linux' do
+        file_update_go_versions
+      end
+
       desc 'update raw ghc versions'
       file('tmp/ghc-versions.html') { file_update_raw_ghc_versions }
 
@@ -352,7 +399,8 @@ module Travis
 
       desc 'update version aliases'
       multitask update_version_aliases: Rake::FileList[
-        'public/version-aliases/ghc.json'
+        'public/version-aliases/ghc.json',
+        'public/version-aliases/go.json'
       ]
 
       desc 'update static files'

--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -11,6 +11,9 @@ module Travis
           },
           go: Travis::Build.config.go_version.untaint
         }
+        GO_VERSION_ALIASES = Travis::Build.config.go_version_aliases_hash.merge(
+          'default' => DEFAULTS[:go]
+        ).freeze
 
         def export
           super
@@ -130,7 +133,7 @@ module Travis
           def normalized_go_version
             v = Array(config[:go]).first.to_s
             return v if v == 'go1'
-            v.sub(/^go/, '')
+            GO_VERSION_ALIASES.fetch(v.sub(/^go/, ''), v).sub(/^go/, '')
           end
 
           def comparable_go_version

--- a/spec/build/config_spec.rb
+++ b/spec/build/config_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 describe Travis::Build::Config do
   subject { Travis::Build.config }
 
+  it 'defines #go_version_aliases_hash' do
+    expect(subject.go_version_aliases_hash).to_not be_empty
+  end
+
   it 'defines #ghc_version_aliases_hash' do
     expect(subject.ghc_version_aliases_hash).to_not be_empty
   end

--- a/spec/build/rake_tasks_spec.rb
+++ b/spec/build/rake_tasks_spec.rb
@@ -158,14 +158,17 @@ describe Travis::Build::RakeTasks do
     expect(thing).to_not be_exist
   end
 
-  it 'can clean up intermediate ghc version file' do
+  it 'can clean up intermediate go and ghc version files' do
     tmp = top + 'tmp'
     tmp.mkpath
     ghc_versions = tmp + 'ghc-versions.html'
     ghc_versions.write('wat')
+    go_versions = tmp + 'go-versions-binary-linux'
+    go_versions.write('huh')
     Rake::Task[:clean].reenable
     Rake::Task[:clean].invoke
     expect(ghc_versions).to_not be_exist
+    expect(go_versions).to_not be_exist
   end
 
   %w[
@@ -180,10 +183,12 @@ describe Travis::Build::RakeTasks do
     public/files/sc-osx.zip
     public/files/tmate-static-linux-amd64.tar.gz
     public/version-aliases/ghc.json
+    public/version-aliases/go.json
   ].each do |filename|
     it "can fetch #{filename}" do
       %w[
         tmp/ghc-versions.html
+        tmp/go-versions-binary-linux
       ].each { |t| Rake::Task[t].reenable }
 
       Rake::Task[filename].reenable
@@ -212,6 +217,27 @@ describe Travis::Build::RakeTasks do
       '9.1.x' => '9.1.9',
       '9.x' => '9.1.9',
       '9.x.x' => '9.1.9'
+    )
+  end
+
+  it 'expands available go versions into aliases' do
+    subject.file_update_raw_go_versions
+    subject.file_update_go_versions
+    aliases = JSON.parse(
+      (top + 'public/version-aliases/go.json').read
+    )
+    expect(aliases).to eq(
+      '1' => '1.9.1',
+      '1.2' => '1.2.2',
+      '1.2.3' => '1.2.3',
+      '1.2.x' => '1.2.3',
+      '1.4.0' => '1.4.0',
+      '1.4.x' => '1.4.0',
+      '1.9.1' => '1.9.1',
+      '1.9.x' => '1.9.1',
+      '1.x' => '1.9.1',
+      '1.x.x' => '1.9.1',
+      'go1' => 'go1'
     )
   end
 end

--- a/spec/build/script/go_spec.rb
+++ b/spec/build/script/go_spec.rb
@@ -19,7 +19,7 @@ describe Travis::Build::Script::Go, :sexp do
   end
 
   it 'sets TRAVIS_GO_VERSION' do
-    should include_sexp [:export, ['TRAVIS_GO_VERSION', '1.9']]
+    should include_sexp [:export, ['TRAVIS_GO_VERSION', defaults[:go]]]
   end
 
   it 'conditionally sets GOMAXPROCS to 2' do
@@ -27,7 +27,7 @@ describe Travis::Build::Script::Go, :sexp do
   end
 
   it 'sets the default go version if not :go config given' do
-    should include_sexp [:cmd, 'GIMME_OUTPUT="$(gimme 1.9 | tee -a $HOME/.bashrc)" && eval "$GIMME_OUTPUT"', assert: true, echo: true, timing: true]
+    should include_sexp [:cmd, %{GIMME_OUTPUT="$(gimme #{defaults[:go]} | tee -a $HOME/.bashrc)" && eval "$GIMME_OUTPUT"}, assert: true, echo: true, timing: true]
   end
 
   it 'sets the go version from config :go' do
@@ -108,7 +108,7 @@ describe Travis::Build::Script::Go, :sexp do
     end
   end
 
-  %w(1 1.2 1.2.2 1.3 1.5 1.6 tip).each do |recent_go_version|
+  %w(1.3 1.5 1.6 1.9 1.10.x master).each do |recent_go_version|
     describe "if no Makefile exists on #{recent_go_version}" do
       it 'installs with go get -t' do
         data[:config][:go] = recent_go_version

--- a/spec/build/script/go_spec.rb
+++ b/spec/build/script/go_spec.rb
@@ -19,7 +19,7 @@ describe Travis::Build::Script::Go, :sexp do
   end
 
   it 'sets TRAVIS_GO_VERSION' do
-    should include_sexp [:export, ['TRAVIS_GO_VERSION', defaults[:go]]]
+    should include_sexp [:export, ['TRAVIS_GO_VERSION', '1.10.1']]
   end
 
   it 'conditionally sets GOMAXPROCS to 2' do
@@ -27,7 +27,7 @@ describe Travis::Build::Script::Go, :sexp do
   end
 
   it 'sets the default go version if not :go config given' do
-    should include_sexp [:cmd, %{GIMME_OUTPUT="$(gimme #{defaults[:go]} | tee -a $HOME/.bashrc)" && eval "$GIMME_OUTPUT"}, assert: true, echo: true, timing: true]
+    should include_sexp [:cmd, %{GIMME_OUTPUT="$(gimme 1.10.1 | tee -a $HOME/.bashrc)" && eval "$GIMME_OUTPUT"}, assert: true, echo: true, timing: true]
   end
 
   it 'sets the go version from config :go' do


### PR DESCRIPTION
This is a revert of travis-ci/travis-build#1389, in the hopes of fixing https://github.com/travis-ci/travis-ci/issues/9725.

The main conflict is around this piece of code:

```
def go_get_cmd
  if go_version == 'go1' || (go_version[/^[0-9]/] && comparable_go_version <= Gem::Version.new('1.2'))
    'go get'
  else
    'go get -t'
  end
end
```

Which depends on `comparable_go_version` using the fully resolved version. For `1.x`, it is currently resolving to:

```
Gem::Version.new('1.x') <= Gem::Version.new('1.2')
```

Which resolves to true and thus picks the wrong branch, when gimme resolves that same `1.x` to `1.10.3`.

I'm not sure if any other gimme-specific changes or other un-reverts are required. I'm also happy to explore other approaches to fixing the issue.