### PR TITLE
add mariadb new key for distros > trusty

### DIFF
--- a/lib/travis/build/addons/mariadb.rb
+++ b/lib/travis/build/addons/mariadb.rb
@@ -7,14 +7,20 @@ module Travis
       class Mariadb < Base
         SUPER_USER_SAFE = true
 
-        MARIADB_GPG_KEY = '0xcbcb082a1bb943db'
+        MARIADB_GPG_KEY_OLD = '0xcbcb082a1bb943db'
+        MARIADB_GPG_KEY_NEW = '0xf1656f24c74cd1d8'
         MARIADB_MIRROR  = 'nyc2.mirrors.digitalocean.com'
 
         def after_prepare
           sh.fold 'mariadb' do
             sh.echo "Installing MariaDB version #{mariadb_version}", ansi: :yellow
             sh.cmd "service mysql stop", sudo: true
-            sh.cmd "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 #{MARIADB_GPG_KEY}", sudo: true
+            sh.if '$(lsb_release -cs) == precise || $(lsb_release -cs) == trusty' do
+              sh.cmd "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 #{MARIADB_GPG_KEY_OLD}", sudo: true
+            end
+            sh.else do
+              sh.cmd "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 #{MARIADB_GPG_KEY_NEW}", sudo: true
+            end
             sh.cmd 'add-apt-repository "deb http://%p/mariadb/repo/%p/ubuntu $(lsb_release -cs) main"' % [MARIADB_MIRROR, mariadb_version], sudo: true
             sh.cmd "apt-get update -qq", assert: false, sudo: true
             sh.cmd "PACKAGES='mariadb-server mariadb-server-#{mariadb_version}'", echo: true

--- a/spec/build/addons/mariadb_spec.rb
+++ b/spec/build/addons/mariadb_spec.rb
@@ -20,7 +20,7 @@ describe Travis::Build::Addons::Mariadb, :sexp do
   end
 
   it { should include_sexp [:cmd, "service mysql stop", sudo: true] }
-  it { should include_sexp [:cmd, "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 #{Travis::Build::Addons::Mariadb::MARIADB_GPG_KEY}", sudo: true] }
+  it { should include_sexp [:cmd, "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 #{Travis::Build::Addons::Mariadb::MARIADB_GPG_KEY_OLD}", sudo: true] }
   it { should include_sexp [:cmd, 'add-apt-repository "deb http://%p/mariadb/repo/%p/ubuntu $(lsb_release -cs) main"' % [Travis::Build::Addons::Mariadb::MARIADB_MIRROR, config], sudo: true] }
   it { should include_sexp [:cmd, "apt-get update -qq", sudo: true] }
   it { should include_sexp [:cmd, "PACKAGES='mariadb-server mariadb-server-10.0'", echo: true] }


### PR DESCRIPTION
new key from: https://downloads.mariadb.org/mariadb/repositories/#distro=Ubuntu&distro_release=xenial--ubuntu_xenial&version=10.0

Observed on ```os: linux-ppc64le``` builds but eventually will apply to all images

like:
https://travis-ci.org/grooverdan/travis-test/jobs/397217466#L462