### PR TITLE
bump sbt-extras version for sbt 1.x support

### DIFF
--- a/lib/travis/build/script/scala.rb
+++ b/lib/travis/build/script/scala.rb
@@ -11,7 +11,7 @@ module Travis
         }
 
         SBT_PATH = '/usr/local/bin/sbt'
-        SBT_SHA  = '4ad1b8a325f75c1a66f3fd100635da5eb28d9c91'
+        SBT_SHA  = 'd559cf7c483dc775c28f3f760246cb0b476dbf02'
         SBT_URL  = "https://raw.githubusercontent.com/paulp/sbt-extras/#{SBT_SHA}/sbt"
 
         def configure

--- a/spec/build/script/scala_spec.rb
+++ b/spec/build/script/scala_spec.rb
@@ -4,7 +4,7 @@ describe Travis::Build::Script::Scala, :sexp do
   let(:data)   { payload_for(:push, :scala) }
   let(:script) { described_class.new(data) }
   let(:sbt_path) { '/usr/local/bin/sbt'}
-  let(:sbt_sha) { '4ad1b8a325f75c1a66f3fd100635da5eb28d9c91'}
+  let(:sbt_sha) { 'd559cf7c483dc775c28f3f760246cb0b476dbf02'}
   let(:sbt_url) { "https://raw.githubusercontent.com/paulp/sbt-extras/#{sbt_sha}/sbt"}
 
   subject      { script.sexp }


### PR DESCRIPTION
Travis CI uses paulp/sbt-extras as its sbt launcher.

sbt-extras versions before May 9, 2016 don't support sbt 1.x (they don't know the right URL to download updates from), and the version on Travis is from Aug 19, 2015.

This PR updates the sbt-extras version to the latest.