### PR TITLE
start mongodb service on xenial

### DIFF
--- a/lib/travis/build/appliances/services.rb
+++ b/lib/travis/build/appliances/services.rb
@@ -32,11 +32,14 @@ module Travis
         end
 
         def apply_mongodb
-          sh.if "$(lsb_release -cs) != 'precise'" do
+          sh.if "$(lsb_release -cs) = 'precise'" do
+            sh.cmd 'sudo service mongodb start', assert: false, echo: true, timing: true
+          end
+          sh.elif "$(lsb_release -cs) = 'trusty'" do
             sh.cmd 'sudo service mongod start', assert: false, echo: true, timing: true
           end
           sh.else do
-            sh.cmd 'sudo service mongodb start', assert: false, echo: true, timing: true
+            sh.cmd 'sudo systemctl start mongodb.service', assert: false, echo: true, timing: true
           end
         end
 


### PR DESCRIPTION
As seen in the travis build log - https://travis-ci.org/grooverdan/travis-test/jobs/399396033#L366 , mongodb service does not start. as service name is mongodb.service https://packages.ubuntu.com/xenial/ppc64el/mongodb-server/filelist.
