### PR TITLE
Tweaks for ppc64le

### DIFF
--- a/lib/travis/build/appliances/services.rb
+++ b/lib/travis/build/appliances/services.rb
@@ -13,7 +13,10 @@ module Travis
           'memcache'     => 'memcached',
           'neo4j-server' => 'neo4j',
           'rabbitmq'     => 'rabbitmq-server',
-          'redis'        => 'redis-server'
+          'redis'        => 'redis-server',
+          'postgres'     => 'postgresql',
+          'mongo'        => 'mongodb',
+          'mongod'       => 'mongodb'
         }
         TEMPLATES_PATH = File.expand_path('../../templates', __FILE__)
 

--- a/lib/travis/build/appliances/services.rb
+++ b/lib/travis/build/appliances/services.rb
@@ -55,8 +55,11 @@ module Travis
           sh.elif '"$TRAVIS_INIT" == upstart' do
             sh.cmd 'sudo service mongod start', echo: true, timing: true
           end
-          sh.elif '"$TRAVIS_INIT" == systemd' do
+          sh.elif '"$TRAVIS_INIT" == systemd && "$TRAVIS_ARCH" == x86_64' do
             sh.cmd 'sudo systemctl start mongod', echo: true, timing: true
+          end
+          sh.elif '"$TRAVIS_INIT" == systemd && "$TRAVIS_ARCH" == ppc64le' do
+            sh.cmd 'sudo systemctl start mongodb', echo: true, timing: true
           end
         end
 

--- a/lib/travis/build/templates/header.sh
+++ b/lib/travis/build/templates/header.sh
@@ -49,6 +49,8 @@ if [[ "$TRAVIS_OS_NAME" == linux ]]; then
   fi
 fi
 
+export TRAVIS_ARCH="$(uname -m)" # x86_64 or ppc64le
+
 TRAVIS_TEST_RESULT=
 TRAVIS_CMD=
 

--- a/spec/build/script/shared/appliances/services.rb
+++ b/spec/build/script/shared/appliances/services.rb
@@ -39,9 +39,13 @@ shared_examples_for 'starts services' do
           .to include_sexp(
             [:cmd, 'sudo service mongod start', echo: true, timing: true]
           )
-        expect(sexp_find(subject, [:elif, '"$TRAVIS_INIT" == systemd']))
+        expect(sexp_find(subject, [:elif, '"$TRAVIS_INIT" == systemd && "$TRAVIS_ARCH" == x86_64']))
           .to include_sexp(
             [:cmd, 'sudo systemctl start mongod', echo: true, timing: true]
+          )
+        expect(sexp_find(subject, [:elif, '"$TRAVIS_INIT" == systemd && "$TRAVIS_ARCH" == ppc64le']))
+          .to include_sexp(
+            [:cmd, 'sudo systemctl start mongodb', echo: true, timing: true]
           )
       end
     end

--- a/spec/build/templates/header_spec.rb
+++ b/spec/build/templates/header_spec.rb
@@ -61,7 +61,8 @@ describe 'header.sh', integration: true do
     TERM: 'xterm',
     USER: 'travis',
     TRAVIS_OS_NAME: 'linux|osx',
-    TRAVIS_DIST: 'precise|trusty|xenial'
+    TRAVIS_DIST: 'precise|trusty|xenial',
+    TRAVIS_ARCH: 'x86_64|ppc64le'
   }.each do |env_var, val|
     it "exports #{env_var}" do
       expect(bash_output).to match(/^declare -x #{env_var}="#{val}"$/)


### PR DESCRIPTION
- Add extra aliases for postgres and mongodb, so these are not easily typo'd in the `services` list
- Start mongodb differently when the architecture is PPC64LE
- Detect architecture at the start of the build and store it as `$TRAVIS_ARCH`