### PR TITLE
Fix Postgres version path

### DIFF
--- a/lib/travis/build/templates/postgresql.sh
+++ b/lib/travis/build/templates/postgresql.sh
@@ -21,7 +21,7 @@ travis_setup_postgresql() {
   fi
 
   echo -e "${ANSI_YELLOW}Starting PostgreSQL v${version}${ANSI_CLEAR}"
-  export PATH="/usr/lib/postgresql${version}/bin:$PATH"
+  export PATH="/usr/lib/postgresql/${version}/bin:$PATH"
 
   if [[ "$TRAVIS_INIT" == upstart ]]; then
     start_cmd="sudo service postgresql start $version"

--- a/spec/build/addons/postgresql_spec.rb
+++ b/spec/build/addons/postgresql_spec.rb
@@ -17,7 +17,7 @@ describe Travis::Build::Addons::Postgresql, :sexp do
       'systemctl start postgresql@${version}-main',
       'sudo -u postgres createuser -s -p "$port" travis',
       'sudo -u postgres createdb -O travis -p "$port" travis',
-      'export PATH="/usr/lib/postgresql${version}/bin:$PATH"',
+      'export PATH="/usr/lib/postgresql/${version}/bin:$PATH"',
       'cp -rp \"/var/lib/postgresql/$version\" \"/var/ramfs/postgresql/$version\"'
     ] }
   end


### PR DESCRIPTION
Looks like there was a missing `/` here, since the version folders live inside `/postgresql`:


```
travis@travis-job-iriberri-travis-experim-133640077:/usr/lib$ cd postgresql/
travis@travis-job-iriberri-travis-experim-133640077:/usr/lib/postgresql$ ls
9.2  9.3  9.4  9.5  9.6
```