### PR TITLE
Do not update repository list in the background

### DIFF
--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -185,7 +185,7 @@ module Travis
               end
 
               sh.export 'DEBIAN_FRONTEND', 'noninteractive', echo: true
-              sh.cmd "sudo -E apt-get -yq update &>> ~/apt-get-update.log", echo: true, timing: true
+              sh.cmd "sudo -E apt-get -yq update >> ~/apt-get-update.log", echo: true, timing: true
               apt_opt_cmd = <<~APT_OPTS_RETRIEVAL
               TRAVIS_APT_OPTS="$(
                 apt-get --version | awk '


### PR DESCRIPTION
Updating the repository list might take some time but it should finish before packages from the repository are installed.
This small but important patch does it in the foreground.

The following is an example to reproduce the issue.
```
        apt:
          update: true
          sources:
            - llvm-toolchain-precise
           packages:
             - clang-6
             - clang-format-6
```

The following is an example build where it happened: https://travis-ci.org/MartinNowack/klee/builds/410425177