### PR TITLE
macOS: Check a secondary path for system_info file

### DIFF
--- a/lib/travis/build/appliances/show_system_info.rb
+++ b/lib/travis/build/appliances/show_system_info.rb
@@ -37,10 +37,17 @@ module Travis
             sh.if "-f #{info_file}" do
               sh.cmd "cat #{info_file}"
             end
+            sh.if "-f #{secondary_info_file}" do
+              sh.cmd "cat #{secondary_info_file}"
+            end
           end
 
           def info_file
             '/usr/share/travis/system_info'
+          end
+
+          def secondary_info_file
+            '/usr/local/travis/system_info'
           end
       end
     end

--- a/spec/build/script/shared/appliances/show_system_info.rb
+++ b/spec/build/script/shared/appliances/show_system_info.rb
@@ -1,14 +1,16 @@
 shared_examples_for 'show system info' do
   let(:sexp) { sexp_find(subject, [:fold, 'system_info']) }
 
-  let(:echo_notice)   { [:echo, "Build system information", ansi: :yellow] }
-  let(:echo_language) { [:echo, /Build language/] }
-  let(:echo_group)    { [:echo, 'Build group: dev'] }
-  let(:echo_dist)     { [:echo, 'Build dist: trusty'] }
-  let(:echo_build_id) { [:echo, /Build id: \d+/] }
-  let(:echo_job_id)   { [:echo, /Job id: \d+/] }
-  let(:path)          { '/usr/share/travis/system_info' }
-  let(:system_info)   { [:cmd, "cat #{path}"] }
+  let(:echo_notice)    { [:echo, "Build system information", ansi: :yellow] }
+  let(:echo_language)  { [:echo, /Build language/] }
+  let(:echo_group)     { [:echo, 'Build group: dev'] }
+  let(:echo_dist)      { [:echo, 'Build dist: trusty'] }
+  let(:echo_build_id)  { [:echo, /Build id: \d+/] }
+  let(:echo_job_id)    { [:echo, /Job id: \d+/] }
+  let(:path)           { '/usr/share/travis/system_info' }
+  let(:system_info)    { [:cmd, "cat #{path}"] }
+  let(:secondary_path) { '/usr/local/travis/system_info' }
+  let(:secondary_info) { [:cmd, "cat #{secondary_path}"] }
 
   it 'displays a header message' do
     expect(sexp).to include_sexp echo_notice
@@ -47,5 +49,10 @@ shared_examples_for 'show system info' do
   it 'runs command if the system info file exists' do
     branch = sexp_find(sexp, [:if, "-f #{path}"], [:then])
     expect(branch).to include_sexp system_info
+  end
+
+  it 'runs secondary command if the secondary system info file exists' do
+    branch = sexp_find(sexp, [:if, "-f #{secondary_path}"], [:then])
+    expect(branch).to include_sexp secondary_info
   end
 end


### PR DESCRIPTION
In macOS 10.11, the system started protecting the /usr directory tree from writes except for in /usr/local. It looks like to handle that, we started putting the system_info file in /usr/local/travis/system_info instead of /usr/share/travis/system_info.

It doesn't look like travis-build was ever updated to handle this new path, so it's been silently failing to print the system info report for quite some time, at least on images from the last 2-3 years.

This change adds another check for this alternate location.