### PR TITLE
[community:r] add 'quit-with-status' argument to BiocCheck

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -249,7 +249,7 @@ module Travis
             # BiocCheck the package
             sh.fold 'Bioc-check' do
               sh.echo 'Checking with: BiocCheck( "${PKG_TARBALL}" ) '
-              sh.cmd 'Rscript -e "BiocCheck::BiocCheck(\"${PKG_TARBALL}\")"'
+              sh.cmd 'Rscript -e "BiocCheck::BiocCheck(\"${PKG_TARBALL}\", \'quit-with-status\'=TRUE)"'
             end
           end
 


### PR DESCRIPTION
This PR will add an argument for the proper exit code from `BiocCheck("*.tar.gz", 'quit-with-status'=TRUE)`. 
Without it, all checks will have a `0` exit code whether or not the tests fail.
**cc-JJJJ**: @jimhester @joepvd @jeroen @joecorcoran 