### PR TITLE
Switch from xctool to xcodebuild+xcpretty for modern images

### DIFF
--- a/lib/travis/build/script/objective_c.rb
+++ b/lib/travis/build/script/objective_c.rb
@@ -20,7 +20,6 @@ module Travis
           super
           sh.fold 'announce' do
             sh.cmd 'xcodebuild -version -sdk'
-            sh.cmd 'xctool -version'
             sh.cmd 'xcrun simctl list'
           end
 
@@ -36,7 +35,7 @@ module Travis
           super
           sh.echo "Disabling Homebrew auto update. If your Homebrew package requires Homebrew DB be up to date, please run \\`brew update\\` explicitly.", ansi: :yellow
           sh.export 'HOMEBREW_NO_AUTO_UPDATE', '1', echo: true
-          [:sdk, :scheme, :project, :workspace].each do |key|
+          [:sdk, :scheme, :project, :workspace, :destination].each do |key|
             sh.export "TRAVIS_XCODE_#{key.upcase}", config[:"xcode_#{key}"].to_s.shellescape, echo: false
           end
         end
@@ -91,7 +90,7 @@ module Travis
 
           sh.else do
             if config[:xcode_scheme] && (config[:xcode_project] || config[:xcode_workspace])
-              sh.cmd "xctool #{xctool_args} build test"
+              sh.cmd "set -o pipefail && xcodebuild #{xcodebuild_args} build test | xcpretty"
             else
               # deprecate DEPRECATED_MISSING_WORKSPACE_OR_PROJECT
               sh.cmd "echo -e \"\\033[33;1mWARNING:\\033[33m Using Objective-C testing without specifying a scheme and either a workspace or a project is deprecated.\"", echo: false, timing: true
@@ -121,10 +120,10 @@ module Travis
             condition
           end
 
-          def xctool_args
-            config[:xctool_args].to_s.tap do |xctool_args|
-              %w[project workspace scheme sdk].each do |var|
-                xctool_args << " -#{var} #{config[:"xcode_#{var}"].to_s.shellescape}" if config[:"xcode_#{var}"]
+          def xcodebuild_args
+            config[:xcodebuild_args].to_s.tap do |xcodebuild_args|
+              %w[project workspace scheme sdk destination].each do |var|
+                xcodebuild_args << " -#{var} #{config[:"xcode_#{var}"].to_s.shellescape}" if config[:"xcode_#{var}"]
               end
             end.strip
           end

--- a/spec/build/script/objective_c_spec.rb
+++ b/spec/build/script/objective_c_spec.rb
@@ -104,14 +104,25 @@ describe Travis::Build::Script::ObjectiveC, :sexp do
     end
 
     describe 'if workspace and scheme is given' do
+      let(:branch) { sexp_find(sexp, [:else]) }
+
       before(:each) do
         data[:config][:xcode_workspace] = 'YourWorkspace.xcworkspace'
         data[:config][:xcode_scheme] = 'YourScheme'
       end
 
       it 'runs xcodebuild and xcpretty' do
-        branch = sexp_find(sexp, [:else])
         expect(branch).to include_sexp [:cmd, 'set -o pipefail && xcodebuild -workspace YourWorkspace.xcworkspace -scheme YourScheme build test | xcpretty', echo: true, timing: true]
+      end
+
+      it 'runs xctool for the xcode6.4 image' do
+        data[:config][:osx_image] = 'xcode6.4'
+        expect(branch).to include_sexp [:cmd, 'xctool -workspace YourWorkspace.xcworkspace -scheme YourScheme build test', echo: true, timing: true]
+      end
+
+      it 'runs xctool for the xcode7.3 image' do
+        data[:config][:osx_image] = 'xcode7.3'
+        expect(branch).to include_sexp [:cmd, 'xctool -workspace YourWorkspace.xcworkspace -scheme YourScheme build test', echo: true, timing: true]
       end
     end
 

--- a/spec/build/script/objective_c_spec.rb
+++ b/spec/build/script/objective_c_spec.rb
@@ -21,10 +21,6 @@ describe Travis::Build::Script::ObjectiveC, :sexp do
       expect(fold).to include_sexp [:cmd, 'xcodebuild -version -sdk', echo: true]
     end
 
-    it 'announces xcodebuild -version -sdk' do
-      expect(fold).to include_sexp [:cmd, 'xctool -version', echo: true]
-    end
-
     it 'announces RubyMotion version if project is a RubyMotion project' do
       sexp = sexp_find(subject, [:if, is_ruby_motion], [:then])
       expect(sexp).to include_sexp [:cmd, 'motion --version', echo: true]
@@ -62,6 +58,11 @@ describe Travis::Build::Script::ObjectiveC, :sexp do
     it 'sets TRAVIS_XCODE_WORKSPACE' do
       data[:config][:xcode_workspace] = 'MyWorkspace.xcworkspace'
       should include_sexp [:export, ['TRAVIS_XCODE_WORKSPACE', 'MyWorkspace.xcworkspace']]
+    end
+
+    it 'sets TRAVIS_XCODE_DESTINATION' do
+      data[:config][:xcode_destination] = 'platform=iOS Simulator,name=iPhone X'
+      should include_sexp [:export, ['TRAVIS_XCODE_DESTINATION', 'platform\=iOS\ Simulator,name\=iPhone\ X']]
     end
   end
 
@@ -108,9 +109,9 @@ describe Travis::Build::Script::ObjectiveC, :sexp do
         data[:config][:xcode_scheme] = 'YourScheme'
       end
 
-      it 'runs xctool' do
+      it 'runs xcodebuild and xcpretty' do
         branch = sexp_find(sexp, [:else])
-        expect(branch).to include_sexp [:cmd, 'xctool -workspace YourWorkspace.xcworkspace -scheme YourScheme build test', echo: true, timing: true]
+        expect(branch).to include_sexp [:cmd, 'set -o pipefail && xcodebuild -workspace YourWorkspace.xcworkspace -scheme YourScheme build test | xcpretty', echo: true, timing: true]
       end
     end
 
@@ -122,13 +123,18 @@ describe Travis::Build::Script::ObjectiveC, :sexp do
         data[:config][:xcode_scheme] = 'YourScheme'
       end
 
-      it 'runs xctool' do
-        expect(branch).to include_sexp [:cmd, 'xctool -project YourProject.xcodeproj -scheme YourScheme build test', echo: true, timing: true]
+      it 'runs xcodebuild and xcpretty' do
+        expect(branch).to include_sexp [:cmd, 'set -o pipefail && xcodebuild -project YourProject.xcodeproj -scheme YourScheme build test | xcpretty', echo: true, timing: true]
       end
 
-      it 'passes an SDK version to xctool' do
+      it 'passes an SDK version to xcodebuild' do
         data[:config][:xcode_sdk] = '7.0'
-        expect(branch).to include_sexp [:cmd, 'xctool -project YourProject.xcodeproj -scheme YourScheme -sdk 7.0 build test', echo: true, timing: true]
+        expect(branch).to include_sexp [:cmd, 'set -o pipefail && xcodebuild -project YourProject.xcodeproj -scheme YourScheme -sdk 7.0 build test | xcpretty', echo: true, timing: true]
+      end
+
+      it 'passes a destination to xcodebuild' do
+        data[:config][:xcode_destination] = 'platform=iOS Simulator,name=iPhone X'
+        expect(branch).to include_sexp [:cmd, 'set -o pipefail && xcodebuild -project YourProject.xcodeproj -scheme YourScheme -destination platform\=iOS\ Simulator,name\=iPhone\ X build test | xcpretty', echo: true, timing: true]
       end
     end
 


### PR DESCRIPTION
This changes images from xcode8 and onward to use xcodebuild piped into xcpretty as the default script instead of xctool.

To make this actually usable, I also added support for a new `xcode_destination` key in the job config, which becomes the `-destination` argument. xcodebuild needs this in most cases when running tests.

We decided to keep older images using xctool, so the `xcode6.4` and `xcode7.3` images are explicitly checked for and fallback to xctool.

This has been tested in staging and works as expected in both cases.