### PR TITLE
introduce /sexp endpoint that prints out the ast

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,5 +5,7 @@ services:
       context: .
       args:
       - GITHUB_OAUTH_TOKEN
+    environment:
+    - RACK_ENV=production
     ports:
     - 4000:4000

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -83,6 +83,10 @@ module Travis
           Travis::Build.logger.error(e.backtrace)
         end
 
+        if ENV['RACK_ENV'] == 'development'
+          raise e
+        end
+
         show_compile_error_msg(e, event)
       end
 

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -83,10 +83,6 @@ module Travis
           Travis::Build.logger.error(e.backtrace)
         end
 
-        if ENV['RACK_ENV'] == 'development'
-          raise e
-        end
-
         show_compile_error_msg(e, event)
       end
 


### PR DESCRIPTION
During development I found myself wanting to inspect the abstract syntax tree before compilation. This introduces a new `/sexp` endpoint that prints that out.

Example output:

```
➜  ~ curl -i -XPOST -d@job_payload.json localhost:9292/sexp
HTTP/1.1 100 Continue

HTTP/1.1 200 OK
Content-Type: application/text
Vary: Accept-Encoding
X-Content-Type-Options: nosniff
Content-Length: 45386

[:script,
 [[:trace,
   :header,
   [:cmds,
    [[:raw,
      "#!/bin/bash\n" +
      "if [[ -s //etc/profile ]]; then\n" +
      "  source //etc/profile\n" +
      "fi\n" +
      "\n" +
      "if [[ -s $HOME/.bash_profile ]] ; then\n" +
      "  source $HOME/.bash_profile\n" +
      "fi\n" +

...

     [:raw, "travis_run_after_success"],
     [:raw, "travis_run_after_failure"],
     [:raw, "travis_run_after_script"],
     [:raw, "travis_run_finish"]]]],
  [:raw,
   "echo -e \"\\nDone. Your build exited with $TRAVIS_TEST_RESULT.\"\n" +
   "\n" +
   "travis_terminate $TRAVIS_TEST_RESULT\n"]]]
```

I also introduced a `raise e` to prevent _all_ errors from resulting in "There was an error in the .travis.yml file from which we could not recover." during development -- it prints the returns a stack trace instead.

refs https://github.com/travis-ci/reliability/issues/142