### PR TITLE
Pin Nix to 2.0.4

### DIFF
--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -8,7 +8,9 @@ module Travis
   module Build
     class Script
       class Nix < Script
-        DEFAULTS = {}
+        DEFAULTS = {
+          nix: '2.0.4'
+        }
 
         def export
           super
@@ -40,8 +42,10 @@ module Travis
         def setup
           super
 
+          version = config[:nix]
+
           sh.fold 'nix.install' do
-            sh.cmd "wget --retry-connrefused --waitretry=1 -O /tmp/nix-install https://nixos.org/nix/install"
+            sh.cmd "wget --retry-connrefused --waitretry=1 -O /tmp/nix-install https://nixos.org/releases/nix/nix-#{version}/install"
             sh.cmd "yes | sh /tmp/nix-install"
 
             if config[:os] == 'linux'

--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -1,7 +1,8 @@
 # Maintained by
-#  - Domen Kožar   @domenkozar   <domen@dev.si>
-#  - Rok Garbas    @garbas       <rok@garbas.si>
-#  - Matthew Bauer @matthewbauer <mjbauer95@gmail.com>
+#  - Domen Kožar        @domenkozar   <domen@dev.si>
+#  - Rok Garbas         @garbas       <rok@garbas.si>
+#  - Matthew Bauer      @matthewbauer <mjbauer95@gmail.com>
+#  - Graham Christensen @grahamc      <graham@grahamc.com>
 
 module Travis
   module Build
@@ -57,7 +58,7 @@ module Travis
           super
 
           sh.echo 'Nix support for Travis CI is community maintained.', ansi: :green
-          sh.echo 'Please open any issues at https://github.com/travis-ci/travis-ci/issues/new and cc @domenkozar @garbas @matthewbauer', ansi: :green
+          sh.echo 'Please open any issues at https://github.com/travis-ci/travis-ci/issues/new and cc @domenkozar @garbas @matthewbauer @grahamc', ansi: :green
 
           sh.cmd "nix-env --version"
         end


### PR DESCRIPTION
Nix 2.1.0 will be released soon which has the potential to break the assumptions in this code. In the meantime let's pin Nix to 2.0.4 and allow testing upgrades later.

Can we:

1. get this deployed to staging or something to test it out in a lifelike env?
2. get this deployed shortly after to production? 2.1 could be released today or tomorrow at the soonest.

Also add myself as a maintainer.

CC @domenkozar @garbas @matthewbauer 
