### PR TITLE
Use the OpenCensus format for span ids

### DIFF
--- a/lib/travis/shell/generator.rb
+++ b/lib/travis/shell/generator.rb
@@ -4,13 +4,14 @@ module Travis
       TaintedOutput = Class.new(StandardError)
 
       attr_reader :nodes, :level, :trace
+      MAX_SPAN_ID = 0xffffffffffffffff
 
       def initialize(nodes)
         @nodes = nodes
         @level = 0
         @trace = [
           # root span id
-          Digest::SHA1.hexdigest(rand.to_s)
+          rand(1..MAX_SPAN_ID).to_s(16).rjust(16, "0")
         ]
       end
 

--- a/lib/travis/shell/generator/bash.rb
+++ b/lib/travis/shell/generator/bash.rb
@@ -119,7 +119,8 @@ module Travis
         # format roughly based on the stackdriver trace api
         #   https://cloud.google.com/trace/docs/reference/v2/rest/v2/projects.traces/batchWrite
         def handle_trace(name, body, options = {})
-          span_id = Digest::SHA1.hexdigest(rand.to_s)
+          span_id = rand 1..MAX_SPAN_ID
+          span_id = span_id.to_s(16).rjust(16, "0")
           name = name.to_s.lines.first.gsub(/<<.*/, '...')
 
           start_span = {


### PR DESCRIPTION
Since Stackdriver and the OpenCensus library expect the span_ids to be in a certain format (i.e. 16 digit hex number), we should use the same thing when creating the spans for ease of processing.

I've used the [same mechanism](https://github.com/census-instrumentation/opencensus-ruby/blob/master/lib/opencensus/trace/span_context.rb#L334) the opencensus-ruby library uses when creating new spans.