### PR TITLE
Use full key ids for updating apt-keys

### DIFF
--- a/lib/travis/build/appliances/update_apt_keys.rb
+++ b/lib/travis/build/appliances/update_apt_keys.rb
@@ -9,7 +9,7 @@ module Travis
             command = <<~KEYUPDATE
             apt-key adv --list-public-keys --with-fingerprint --with-colons |
               awk -F: '
-                  $1=="pub" && $2=="e" { state="expired" }
+                  $1=="pub" && $2~/^[er]$/ { state="expired" }
                   $1=="fpr" && state == "expired" {
                     out = sprintf("%s %s", out, $(NF -1))
                     state="valid"


### PR DESCRIPTION
New version of https://github.com/travis-ci/travis-build/pull/1471, as the updated commits do not show up in the pull request :interrobang: 