### PR TITLE
apt plugin: quote keyserver URLs in curl invocation

### DIFF
--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -160,7 +160,7 @@ module Travis
                 if sourceline.start_with?('ppa:')
                   sh.cmd "sudo -E apt-add-repository -y #{sourceline.inspect}", echo: true, assert: true, timing: true
                 else
-                  sh.cmd "curl -sSL #{safelisted_source_key_url(source).untaint} | sudo -E apt-key add -", echo: true, assert: true, timing: true
+                  sh.cmd "curl -sSL \"#{safelisted_source_key_url(source).untaint}\" | sudo -E apt-key add -", echo: true, assert: true, timing: true
                   # Avoid adding deb-src lines to work around https://bugs.launchpad.net/ubuntu/+source/software-properties/+bug/987264
                   sh.cmd "echo #{sourceline.inspect} | sudo tee -a /etc/apt/sources.list >/dev/null", echo: true, assert: true, timing: true
                 end


### PR DESCRIPTION
`untaint` seems ignoring `&` character which results with `curl` failure.

Example:

```
$ curl -sSL http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x8C718D3B5072E1F5 | sudo -E apt-key add -
gpg: no valid OpenPGP data found.

The command "curl -sSL http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x8C718D3B5072E1F5 | sudo -E apt-key add -" failed and exited with 2 during .

Your build has been stopped.
/home/travis/.travis/job_stages: line 186:  3233 Terminated              curl -sSL http://keyserver.ubuntu.com/pks/lookup?op=get
```

The URL contains `&`. Unless escaped properly, only the part preceding `&` will
be executed. The `&` (and other shell tokens) must be escaped with `\`, or the
entire URL must be encapsulated with `"`, e.g.

```
$ curl -sSL http://keyserver.ubuntu.com/pks/lookup?op=get\&search=0x8C718D3B5072E1F5
$ curl -sSL "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x8C718D3B5072E1F5"
```