### PR TITLE
Support infrastructure-specific APT mirror substitution

### DIFF
--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -185,7 +185,7 @@ module Travis
               end
 
               sh.export 'DEBIAN_FRONTEND', 'noninteractive', echo: true
-              sh.cmd "sudo -E apt-get -yq update &>> ~/apt-get-update.log", echo: true, timing: true
+              sh.cmd 'travis_apt_get_update', retry: true, echo: true, timing: true
               sh.raw bash('travis_apt_get_options')
               command = 'sudo -E apt-get -yq --no-install-suggests --no-install-recommends ' \
                 "$(travis_apt_get_options) install #{safelisted.join(' ')}"
@@ -195,7 +195,7 @@ module Travis
               sh.if '$result -ne 0' do
                 sh.fold 'apt-get.diagnostics' do
                   sh.echo "apt-get install failed", ansi: :red
-                  sh.cmd 'cat ~/apt-get-update.log', echo: true
+                  sh.cmd 'cat ${TRAVIS_BUILD_HOME}/apt-get-update.log', echo: true
                 end
                 sh.raw "TRAVIS_CMD='#{command}'"
                 sh.raw "travis_assert $result"

--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -153,7 +153,6 @@ module Travis
             end
 
             unless safelisted.empty?
-              sh.export 'DEBIAN_FRONTEND', 'noninteractive', echo: true
               safelisted.each do |source|
                 sourceline = source['sourceline'].untaint
                 if sourceline.start_with?('ppa:')
@@ -184,7 +183,6 @@ module Travis
                 stop_postgresql
               end
 
-              sh.export 'DEBIAN_FRONTEND', 'noninteractive', echo: true
               sh.cmd 'travis_apt_get_update', retry: true, echo: true, timing: true
               sh.raw bash('travis_apt_get_options')
               command = 'sudo -E apt-get -yq --no-install-suggests --no-install-recommends ' \

--- a/lib/travis/build/addons/mariadb.rb
+++ b/lib/travis/build/addons/mariadb.rb
@@ -22,7 +22,7 @@ module Travis
               sh.cmd "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 #{MARIADB_GPG_KEY_NEW}", sudo: true
             end
             sh.cmd 'add-apt-repository "deb http://%p/mariadb/repo/%p/ubuntu $(lsb_release -cs) main"' % [MARIADB_MIRROR, mariadb_version], sudo: true
-            sh.cmd "apt-get update -qq", assert: false, sudo: true
+            sh.cmd 'travis_apt_get_update', retry: true, echo: true
             sh.cmd "PACKAGES='mariadb-server mariadb-server-#{mariadb_version}'", echo: true
             sh.cmd "if [[ $(lsb_release -cs) = 'precise' ]]; then PACKAGES=\"${PACKAGES} libmariadbclient-dev\"; fi", echo: true
             sh.cmd "apt-get install -y -o Dpkg::Options::='--force-confnew' $PACKAGES", sudo: true, echo: true, timing: true

--- a/lib/travis/build/addons/rethinkdb.rb
+++ b/lib/travis/build/addons/rethinkdb.rb
@@ -17,7 +17,7 @@ module Travis
               sh.cmd "service rethinkdb stop", sudo: true
               sh.cmd "wget -qO- https://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -v -''", echo: true
               sh.cmd 'echo -e "\ndeb http://download.rethinkdb.com/apt $(lsb_release -cs) main" | sudo tee -a /etc/apt/sources.list > /dev/null'
-              sh.cmd "apt-get update -qq", assert: false, sudo: true
+              sh.cmd 'travis_apt_get_update', assert: false, sudo: true
               sh.cmd "package_version=`apt-cache show rethinkdb | grep -F \"Version: #{rethinkdb_version}\" | sort -r | head -n 1 | awk '{printf $2}'`"
               sh.cmd "apt-get install -y -o Dpkg::Options::='--force-confnew' rethinkdb=$package_version", sudo: true, echo: true, timing: true
               sh.echo "Installing RethinkDB default instance configuration"

--- a/lib/travis/build/appliances/apt_get_update.rb
+++ b/lib/travis/build/appliances/apt_get_update.rb
@@ -24,7 +24,6 @@ module Travis
           end
 
           def update
-            sh.raw bash('travis_apt_get_update')
             sh.cmd "travis_apt_get_update #{debug? ? 'debug' : ''}", retry: true
           end
 

--- a/lib/travis/build/appliances/apt_get_update.rb
+++ b/lib/travis/build/appliances/apt_get_update.rb
@@ -25,7 +25,7 @@ module Travis
 
           def update
             sh.raw bash('travis_apt_get_update')
-            sh.cmd "travis_retry travis_apt_get_update #{debug? ? 'debug' : ''}"
+            sh.cmd "travis_apt_get_update #{debug? ? 'debug' : ''}", retry: true
           end
 
           def used?

--- a/lib/travis/build/appliances/apt_get_update.rb
+++ b/lib/travis/build/appliances/apt_get_update.rb
@@ -25,7 +25,7 @@ module Travis
 
           def update
             sh.raw bash('travis_apt_get_update')
-            sh.cmd "travis_apt_get_update #{debug? ? 'debug' : ''}"
+            sh.cmd "travis_retry travis_apt_get_update #{debug? ? 'debug' : ''}"
           end
 
           def used?

--- a/lib/travis/build/appliances/apt_get_update.rb
+++ b/lib/travis/build/appliances/apt_get_update.rb
@@ -5,23 +5,15 @@ module Travis
     module Appliances
       class AptGetUpdate < Base
         def apply
-          use_mirror if use_mirror?
-          update     if update?
+          use_mirror
+          update if update?
         end
 
         def apply?
-          is_linux?
+          true
         end
 
         private
-
-          def is_linux?
-            data[:config][:os] == 'linux'
-          end
-
-          def disabled?
-            ENV['APT_GET_UPDATE_OPT_IN'] && !update?
-          end
 
           def update?
             if ENV['APT_GET_UPDATE_OPT_IN']
@@ -32,10 +24,8 @@ module Travis
           end
 
           def update
-            sh.cmd <<~EOF
-              sudo rm -rf /var/lib/apt/lists/*
-              sudo apt-get update #{'-qq  >/dev/null 2>&1' unless debug?}
-            EOF
+            sh.raw bash('travis_apt_get_update')
+            sh.cmd "travis_apt_get_update #{debug? ? 'debug' : ''}"
           end
 
           def used?
@@ -46,16 +36,17 @@ module Travis
             end
           end
 
-          def use_mirror?
-            !!mirror && rollout?(:apt_get_mirror_ubuntu, uid: repo_id, owner: repo_owner)
-          end
-
           def use_mirror
-            sh.cmd "sudo sed -i -e 's|http://.*\.ubuntu\.com/ubuntu/|#{mirror.dup.untaint}|' /etc/apt/sources.list"
+            define_mirrors_by_infrastructure
+            sh.raw bash('travis_munge_apt_sources')
+            sh.cmd 'travis_munge_apt_sources'
           end
 
-          def mirror
-            ENV['APT_GET_MIRROR_UBUNTU']
+          def define_mirrors_by_infrastructure
+            sh.raw 'declare -A TRAVIS_APT_MIRRORS_BY_INFRASTRUCTURE'
+            mirrors.each do |infra, url|
+              sh.raw %{TRAVIS_APT_MIRRORS_BY_INFRASTRUCTURE[#{infra}]="#{url}"}
+            end
           end
 
           def debug?
@@ -80,6 +71,10 @@ module Travis
 
           def config
             apt_config || {}
+          end
+
+          def mirrors
+            (Travis::Build.config[:apt_mirrors] || {}).to_hash
           end
 
           def apt_config

--- a/lib/travis/build/appliances/update_glibc.rb
+++ b/lib/travis/build/appliances/update_glibc.rb
@@ -10,9 +10,9 @@ module Travis
 
         def apply
           return unless data.disable_sudo?
-          sh.if "-n $(command -v lsb_release) && $(lsb_release -cs) = 'precise'" do
+          sh.if '${TRAVIS_OS_NAME} == linux && ${TRAVIS_DIST} == precise' do
             sh.fold "fix.CVE-2015-7547" do
-              sh.export 'DEBIAN_FRONTEND', 'noninteractive'
+              sh.echo 'Forcing update of libc6', ansi: :yellow
               sh.cmd 'travis_apt_get_update'
               sh.if '${TRAVIS_OS_NAME} != darwin' do
                 sh.cmd 'sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install libc6'

--- a/lib/travis/build/appliances/update_glibc.rb
+++ b/lib/travis/build/appliances/update_glibc.rb
@@ -13,12 +13,10 @@ module Travis
           sh.if "-n $(command -v lsb_release) && $(lsb_release -cs) = 'precise'" do
             sh.fold "fix.CVE-2015-7547" do
               sh.export 'DEBIAN_FRONTEND', 'noninteractive'
-              sh.cmd <<-EOF
-if [ ! $(uname|grep Darwin) ]; then
-  sudo -E apt-get -yq update 2>&1 >> ~/apt-get-update.log
-  sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install libc6
-fi
-              EOF
+              sh.cmd 'travis_apt_get_update'
+              sh.if '${TRAVIS_OS_NAME} != darwin' do
+                sh.cmd 'sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install libc6'
+              end
             end
           end
         end

--- a/lib/travis/build/bash/travis_apt_get_update.bash
+++ b/lib/travis/build/bash/travis_apt_get_update.bash
@@ -3,11 +3,13 @@ travis_apt_get_update() {
     return
   fi
 
-  local opts='-qq &>/dev/null'
+  local logdest="${TRAVIS_BUILD_HOME}/apt-get-update.log"
+  local opts='-yq'
   if [[ "${1}" == debug ]]; then
     opts=''
+    logdest='/dev/stderr'
   fi
 
   sudo rm -rf "${TRAVIS_BUILD_ROOT}/var/lib/apt/lists/"*
-  sudo apt-get update ${opts}
+  sudo apt-get update ${opts} 2>&1 | tee -a "${logdest}" &>/dev/null
 }

--- a/lib/travis/build/bash/travis_apt_get_update.bash
+++ b/lib/travis/build/bash/travis_apt_get_update.bash
@@ -1,0 +1,13 @@
+travis_apt_get_update() {
+  if ! command -v apt-get &>/dev/null; then
+    return
+  fi
+
+  local opts='-qq &>/dev/null'
+  if [[ "${1}" == debug ]]; then
+    opts=''
+  fi
+
+  sudo rm -rf "${TRAVIS_BUILD_ROOT}/var/lib/apt/lists/"*
+  sudo apt-get update ${opts}
+}

--- a/lib/travis/build/bash/travis_ghc_install.bash
+++ b/lib/travis/build/bash/travis_ghc_install.bash
@@ -16,7 +16,7 @@ travis_ghc_install() {
     echo -e "\\n${ANSI_GREEN}Adding ppa:hvr/ghc.${ANSI_RESET}" >&2
     sudo apt-add-repository -y ppa:hvr/ghc
   fi
-  sudo apt-get update -yqq
+  travis_apt_get_update
   if sudo apt-get install -yq "ghc-${ghc_version}"; then
     echo -e "\\n${ANSI_GREEN}Successfully installed 'ghc-${ghc_version}'.${ANSI_RESET}" >&2
   else

--- a/lib/travis/build/bash/travis_munge_apt_sources.bash
+++ b/lib/travis/build/bash/travis_munge_apt_sources.bash
@@ -16,6 +16,7 @@ travis_munge_apt_sources() {
   fi
 
   if [[ ! "${mirror}" ]]; then
+    echo -e "${ANSI_YELLOW}No APT mirror found; skipping source munging.${ANSI_RESET}"
     return
   fi
 

--- a/lib/travis/build/bash/travis_munge_apt_sources.bash
+++ b/lib/travis/build/bash/travis_munge_apt_sources.bash
@@ -16,9 +16,11 @@ travis_munge_apt_sources() {
   fi
 
   if [[ ! "${mirror}" ]]; then
-    echo -e "${ANSI_YELLOW}No APT mirror found; skipping source munging.${ANSI_RESET}"
+    echo -e "${ANSI_YELLOW}No APT mirror found; not updating ${src}.${ANSI_RESET}"
     return
   fi
+
+  echo -e "${ANSI_YELLOW}Setting APT mirror in ${src}: ${mirror}${ANSI_RESET}"
 
   sed -e "s,http://.*\\.ubuntu\\.com/ubuntu/,${mirror}," \
     "${src}" >"${tmp_dest}"

--- a/lib/travis/build/bash/travis_munge_apt_sources.bash
+++ b/lib/travis/build/bash/travis_munge_apt_sources.bash
@@ -1,0 +1,26 @@
+travis_munge_apt_sources() {
+  if ! command -v apt-get &>/dev/null; then
+    return
+  fi
+
+  local src="${TRAVIS_BUILD_ROOT}/etc/apt/sources.list"
+  local tmp_dest="${TRAVIS_TMPDIR}/etc-apt-sources.list"
+
+  if [[ ! -f "${src}" ]]; then
+    return
+  fi
+
+  local mirror="${TRAVIS_APT_MIRRORS_BY_INFRASTRUCTURE[${TRAVIS_INFRA}]}"
+  if [[ ! "${mirror}" ]]; then
+    mirror="${TRAVIS_APT_MIRRORS_BY_INFRASTRUCTURE[unknown]}"
+  fi
+
+  if [[ ! "${mirror}" ]]; then
+    return
+  fi
+
+  sed -e "s,http://.*\\.ubuntu\\.com/ubuntu/,${mirror}," \
+    "${src}" >"${tmp_dest}"
+  sudo mv "${src}" "${src}.travis-build.bak"
+  sudo mv "${tmp_dest}" "${src}"
+}

--- a/lib/travis/build/bash/travis_munge_apt_sources.bash
+++ b/lib/travis/build/bash/travis_munge_apt_sources.bash
@@ -4,7 +4,9 @@ travis_munge_apt_sources() {
   fi
 
   local src="${TRAVIS_BUILD_ROOT}/etc/apt/sources.list"
+  src="${src//\/\//\/}"
   local tmp_dest="${TRAVIS_TMPDIR}/etc-apt-sources.list"
+  tmp_dest="${tmp_dest//\/\//\/}"
 
   if [[ ! -f "${src}" ]]; then
     return

--- a/lib/travis/build/bash/travis_setup_env.bash
+++ b/lib/travis/build/bash/travis_setup_env.bash
@@ -56,7 +56,7 @@ travis_setup_env() {
   export TRAVIS_TMPDIR
 
   TRAVIS_INFRA=unknown
-  if [[ ! "${TRAVIS_DISABLE_INFRA_DETECTION}" ]]; then
+  if [[ "${TRAVIS_ENABLE_INFRA_DETECTION}" ]]; then
     TRAVIS_INFRA="$(travis_whereami | awk -F= '/^infra/ { print $2 }')"
   fi
   export TRAVIS_INFRA

--- a/lib/travis/build/bash/travis_setup_env.bash
+++ b/lib/travis/build/bash/travis_setup_env.bash
@@ -53,6 +53,12 @@ travis_setup_env() {
   TRAVIS_TMPDIR="$(mktemp -d 2>/dev/null || mktemp -d -t 'travis_tmp')"
   export TRAVIS_TMPDIR
 
+  TRAVIS_INFRA=unknown
+  if [[ ! "${TRAVIS_DISABLE_INFRA_DETECTION}" ]]; then
+    TRAVIS_INFRA="$(travis_whereami | awk -F= '/^infra/ { print $2 }')"
+  fi
+  export TRAVIS_INFRA
+
   if command -v pgrep &>/dev/null; then
     pgrep -u "${USER}" 2>/dev/null |
       grep -v -w "${$}" >"${TRAVIS_TMPDIR}/pids_before"

--- a/lib/travis/build/bash/travis_setup_env.bash
+++ b/lib/travis/build/bash/travis_setup_env.bash
@@ -7,6 +7,8 @@ travis_setup_env() {
   export ANSI_RESET="\033[0m"
   export ANSI_CLEAR="\033[0K"
 
+  export DEBIAN_FRONTEND=noninteractive
+
   if [ "${TERM}" = dumb ]; then
     unset TERM
   fi

--- a/lib/travis/build/bash/travis_whereami.bash
+++ b/lib/travis/build/bash/travis_whereami.bash
@@ -1,0 +1,4 @@
+travis_whereami() {
+  curl -sSL -H 'Accept: text/plain' \
+    "${TRAVIS_WHEREAMI_URL:-https://whereami.travis-ci.com}"
+}

--- a/lib/travis/build/config.rb
+++ b/lib/travis/build/config.rb
@@ -24,6 +24,24 @@ module Travis
           'TRAVIS_BUILD_API_TOKEN', ENV.fetch('API_TOKEN', '')
         ),
         app_host: ENV.fetch('TRAVIS_BUILD_APP_HOST', ''),
+        apt_mirrors: {
+          ec2: ENV.fetch(
+            'TRAVIS_BUILD_APT_MIRRORS_EC2',
+            'http://us-east-1.ec2.archive.ubuntu.com/ubuntu/'
+          ),
+          gce: ENV.fetch(
+            'TRAVIS_BUILD_APT_MIRRORS_GCE',
+            'http://us-central1.gce.archive.ubuntu.com/ubuntu/'
+          ),
+          packet: ENV.fetch(
+            'TRAVIS_BUILD_APT_MIRRORS_PACKET',
+            'http://archive.ubuntu.com/ubuntu/'
+          ),
+          unknown: ENV.fetch(
+            'TRAVIS_BUILD_APT_MIRRORS_UNKNOWN',
+            'http://archive.ubuntu.com/ubuntu/'
+          )
+        },
         apt_package_safelist: {
           precise: ENV.fetch('TRAVIS_BUILD_APT_PACKAGE_SAFELIST_PRECISE', ''),
           trusty: ENV.fetch('TRAVIS_BUILD_APT_PACKAGE_SAFELIST_TRUSTY', '')

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -68,6 +68,7 @@ module Travis
         travis_trace_span
         travis_vers2int
         travis_wait
+        travis_whereami
       ].freeze
       private_constant :TRAVIS_FUNCTIONS
 

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -48,6 +48,7 @@ module Travis
       DEFAULTS = {}
 
       TRAVIS_FUNCTIONS = %w[
+        travis_apt_get_update
         travis_assert
         travis_bash_qsort_numeric
         travis_cmd

--- a/lib/travis/build/script/crystal.rb
+++ b/lib/travis/build/script/crystal.rb
@@ -21,7 +21,7 @@ module Travis
               sh.cmd %q(sudo sh -c "apt-key add '${TRAVIS_BUILD_HOME}/crystal_repository_key.asc'")
 
               sh.cmd %Q(sudo sh -c 'echo "deb #{version[:url]} crystal main" > /etc/apt/sources.list.d/crystal-nightly.list')
-              sh.cmd %q(sudo sh -c 'apt-get update')
+              sh.cmd %q(travis_apt_get_update)
               sh.cmd %Q(sudo apt-get install -y #{version[:package]} libgmp-dev)
             when 'osx'
               if config[:crystal] && config[:crystal] != "latest"

--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -53,11 +53,11 @@ View valid versions of \"mono\" at https://docs.travis-ci.com/user/languages/csh
             case config_os
             when 'linux'
               if is_mono_2_10_8
-                sh.cmd 'sudo apt-get update -qq', timing: true, assert: true
+                sh.cmd 'travis_apt_get_update', retry: true, timing: true, assert: true
                 sh.cmd 'sudo apt-get install -qq mono-complete mono-vbnc', timing: true, assert: true
               elsif is_mono_3_2_8
                 sh.cmd 'sudo apt-add-repository ppa:directhex/ppa -y', assert: true # Official ppa of the mono debian maintainer
-                sh.cmd 'sudo apt-get update -qq', timing: true, assert: true
+                sh.cmd 'travis_apt_get_update', retry: true, timing: true, assert: true
                 sh.cmd 'sudo apt-get install -qq mono-complete mono-vbnc fsharp', timing: true, assert: true
               else
                 setup_pgp_key "mono"
@@ -97,7 +97,7 @@ View valid versions of \"mono\" at https://docs.travis-ci.com/user/languages/csh
                   sh.cmd "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/debian wheezy/snapshots/#{config_mono} main' >> /etc/apt/sources.list.d/mono-official.list\"", assert: true
                 end
 
-                sh.cmd 'sudo apt-get update -qq', timing: true, assert: true
+                sh.cmd 'travis_apt_get_update', retry: true, timing: true, assert: true
                 sh.cmd "sudo apt-get install -qq mono-complete mono-vbnc fsharp nuget #{'referenceassemblies-pcl' if !is_mono_3_8_0}", timing: true, assert: true
                                                                                       # PCL Assemblies only supported on mono 3.10 and greater
               end
@@ -148,7 +148,7 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
               sh.else do
                 sh.failure "The version of this operating system is not supported by .NET Core. View valid versions at https://docs.travis-ci.com/user/languages/csharp/"
               end
-              sh.cmd 'sudo apt-get update -qq', timing: true, assert: true
+              sh.cmd 'travis_apt_get_update', retry: true, timing: true, assert: true
               sh.cmd "sudo apt-get install -qq dotnet-#{dotnet_package_prefix}-#{dotnet_package_version}", timing: true, assert: true
             when 'osx'
               min_osx_minor = 11

--- a/lib/travis/build/script/dart.rb
+++ b/lib/travis/build/script/dart.rb
@@ -57,7 +57,7 @@ MESSAGE
               # Enable Multiverse Packages:
               sh.cmd "sudo sh -c 'echo \"deb http://gce_debian_mirror.storage.googleapis.com precise contrib non-free\" >> /etc/apt/sources.list'"
               sh.cmd "sudo sh -c 'echo \"deb http://gce_debian_mirror.storage.googleapis.com precise-updates contrib non-free\" >> /etc/apt/sources.list'"
-              sh.cmd "sudo sh -c 'apt-get update'"
+              sh.cmd 'travis_apt_get_update'
 
               # Pre-accepts MSFT Fonts EULA:
               sh.cmd "sudo sh -c 'echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections'"

--- a/lib/travis/build/script/haxe.rb
+++ b/lib/travis/build/script/haxe.rb
@@ -49,7 +49,7 @@ module Travis
             # Install dependencies
             case config[:os]
             when 'linux'
-              sh.cmd 'sudo apt-get update -qq', retry: true
+              sh.cmd 'travis_apt_get_update', retry: true
               sh.cmd 'sudo apt-get install libgc1c2 -qq', retry: true # required by neko
             when 'osx'
               # pass

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -151,7 +151,7 @@ module Travis
               end
 
               sh.cmd 'sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94'
-              sh.cmd 'sudo apt-get update -qq'
+              sh.cmd 'travis_apt_get_update'
               sh.cmd "sudo apt-get install -y hhvm", timing: true, echo: true, assert: true
             end
           end
@@ -159,7 +159,7 @@ module Travis
 
         def install_hhvm_nightly
           sh.echo 'Installing HHVM nightly', ansi: :yellow
-          sh.cmd 'sudo apt-get update -qq'
+          sh.cmd 'travis_apt_get_update'
           sh.cmd 'sudo apt-get install hhvm-nightly -y 2>&1 >/dev/null'
           sh.cmd 'test -d ${TRAVIS_BUILD_HOME}/.phpenv/versions/hhvm-nightly || cp -r ${TRAVIS_BUILD_HOME}/.phpenv/versions/hhvm{,-nightly}', echo: false
         end

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -89,7 +89,7 @@ module Travis
 
                 # Update after adding all repositories. Retry several
                 # times to work around flaky connection to Launchpad PPAs.
-                sh.cmd 'sudo apt-get update -qq', retry: true
+                sh.cmd 'travis_apt_get_update', retry: true
 
                 # Install precompiled R
                 # Install only the dependencies for an R development environment except for

--- a/lib/travis/build/script/smalltalk.rb
+++ b/lib/travis/build/script/smalltalk.rb
@@ -140,7 +140,7 @@ module Travis
                 sh.cmd 'sudo dpkg --add-architecture i386'
               end
 
-              sh.cmd 'sudo apt-get update -qq', retry: true
+              sh.cmd 'travis_apt_get_update', retry: true
               sh.cmd "sudo apt-get install -y --no-install-recommends #{deps_32bit}", retry: true
             end
           end
@@ -227,7 +227,7 @@ module Travis
             sh.fold 'gemstone_dependencies' do
               sh.echo 'Installing GemStone dependencies', ansi: :yellow
 
-              sh.cmd 'sudo apt-get update -qq', retry: true
+              sh.cmd 'travis_apt_get_update', retry: true
               sh.cmd 'sudo apt-get install -y --no-install-recommends ' +
                      'libpam0g:i386 libssl1.0.0:i386 gcc-multilib ' +
                      'libstdc++6:i386 libfreetype6:i386 pstack ' +

--- a/script/validate-bash-syntax
+++ b/script/validate-bash-syntax
@@ -27,7 +27,6 @@ main() {
       export TRAVIS_BUILD_ROOT=${fake_root}
       export TRAVIS_BUILD_HOME=${fake_homedir}
       export TRAVIS_BUILD_DIR=${fake_homedir}/build
-      export TRAVIS_DISABLE_INFRA_DETECTION=1
 
       $(cat "${top}/lib/travis/build/bash/travis_setup_env.bash")
       travis_setup_env

--- a/script/validate-bash-syntax
+++ b/script/validate-bash-syntax
@@ -27,6 +27,7 @@ main() {
       export TRAVIS_BUILD_ROOT=${fake_root}
       export TRAVIS_BUILD_HOME=${fake_homedir}
       export TRAVIS_BUILD_DIR=${fake_homedir}/build
+      export TRAVIS_DISABLE_INFRA_DETECTION=1
 
       $(cat "${top}/lib/travis/build/bash/travis_setup_env.bash")
       travis_setup_env

--- a/spec/build/addons/mariadb_spec.rb
+++ b/spec/build/addons/mariadb_spec.rb
@@ -22,7 +22,7 @@ describe Travis::Build::Addons::Mariadb, :sexp do
   it { should include_sexp [:cmd, "service mysql stop", sudo: true] }
   it { should include_sexp [:cmd, "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 #{Travis::Build::Addons::Mariadb::MARIADB_GPG_KEY_OLD}", sudo: true] }
   it { should include_sexp [:cmd, 'add-apt-repository "deb http://%p/mariadb/repo/%p/ubuntu $(lsb_release -cs) main"' % [Travis::Build::Addons::Mariadb::MARIADB_MIRROR, config], sudo: true] }
-  it { should include_sexp [:cmd, "apt-get update -qq", sudo: true] }
+  it { should include_sexp [:cmd, 'travis_apt_get_update', retry: true, echo: true] }
   it { should include_sexp [:cmd, "PACKAGES='mariadb-server mariadb-server-10.0'", echo: true] }
   it { should include_sexp [:cmd, "apt-get install -y -o Dpkg::Options::='--force-confnew' $PACKAGES", sudo: true, echo: true, timing: true] }
   it { should include_sexp [:cmd, "service mysql start", sudo: true, echo: true, timing: true] }

--- a/spec/build/addons/rethinkdb_spec.rb
+++ b/spec/build/addons/rethinkdb_spec.rb
@@ -26,7 +26,7 @@ describe Travis::Build::Addons::Rethinkdb, :sexp do
   it { should include_sexp [:cmd, "service rethinkdb stop", sudo: true] }
   it { should include_sexp [:cmd, "wget -qO- https://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -v -''", echo: true] }
   it { should include_sexp [:cmd, 'echo -e "\ndeb http://download.rethinkdb.com/apt $(lsb_release -cs) main" | sudo tee -a /etc/apt/sources.list > /dev/null'] }
-  it { should include_sexp [:cmd, "apt-get update -qq", sudo: true] }
+  it { should include_sexp [:cmd, 'travis_apt_get_update', sudo: true] }
   it { should include_sexp [:cmd, "apt-get install -y -o Dpkg::Options::='--force-confnew' rethinkdb=$package_version", sudo: true, echo: true, timing: true] }
   it { should include_sexp [:cmd, "cp /etc/rethinkdb/default.conf.sample /etc/rethinkdb/instances.d/default.conf", sudo: true] }
   it { should include_sexp [:cmd, "service rethinkdb start", sudo: true, echo: true, timing: true] }

--- a/spec/build/script/csharp_spec.rb
+++ b/spec/build/script/csharp_spec.rb
@@ -16,21 +16,21 @@ describe Travis::Build::Script::Csharp, :sexp do
     it 'sets up package repository for mono' do
       should include_sexp [:cmd, 'sudo mv /tmp/mono.gpg /etc/apt/trusted.gpg.d/', assert: true]
       should include_sexp [:cmd, "sudo sh -c \"echo 'deb http://download.mono-project.com/repo/ubuntu stable-trusty main' > /etc/apt/sources.list.d/mono-official.list\"", assert: true]
-      should include_sexp [:cmd, 'sudo apt-get update -qq', timing: true, assert: true]
+      should include_sexp [:cmd, 'travis_apt_get_update', retry: true, timing: true, assert: true]
     end
 
     it 'sets up package repository for dotnet 1.1.5' do
       data[:config][:dotnet] = '1.1.5'
       should include_sexp [:cmd, 'sudo mv /tmp/dotnet.gpg /etc/apt/trusted.gpg.d/', assert: true]
       should include_sexp [:cmd, "sudo sh -c \"echo 'deb [arch=amd64] https://packages.microsoft.com/ubuntu/14.04/prod trusty main' > /etc/apt/sources.list.d/dotnet-official.list\"", assert: true]
-      should include_sexp [:cmd, 'sudo apt-get update -qq', timing: true, assert: true]
+      should include_sexp [:cmd, 'travis_apt_get_update', retry: true, timing: true, assert: true]
     end
 
     it 'sets up package repository for dotnet 2.0.0 and above' do
       data[:config][:dotnet] = '2.0.0'
       should include_sexp [:cmd, 'sudo mv /tmp/dotnet.gpg /etc/apt/trusted.gpg.d/', assert: true]
       should include_sexp [:cmd, "sudo sh -c \"echo 'deb [arch=amd64] https://packages.microsoft.com/ubuntu/14.04/prod trusty main' > /etc/apt/sources.list.d/dotnet-official.list\"", assert: true]
-      should include_sexp [:cmd, 'sudo apt-get update -qq', timing: true, assert: true]
+      should include_sexp [:cmd, 'travis_apt_get_update', retry: true, timing: true, assert: true]
     end
 
     it 'installs mono' do

--- a/spec/build/script/php_spec.rb
+++ b/spec/build/script/php_spec.rb
@@ -100,14 +100,14 @@ describe Travis::Build::Script::Php, :sexp do
 
   describe 'installs hhvm-nightly' do
     before { data[:config][:php] = 'hhvm-nightly' }
-    it { should include_sexp [:cmd, 'sudo apt-get update -qq'] }
+    it { should include_sexp [:cmd, 'travis_apt_get_update'] }
     it { should include_sexp [:cmd, 'sudo apt-get install hhvm-nightly -y 2>&1 >/dev/null'] }
     it { store_example "hhvm-nightly" }
   end
 
   describe 'installs specific hhvm version' do
     before { data[:config][:php] = 'hhvm-3.12' }
-    it { should include_sexp [:cmd, 'sudo apt-get update -qq'] }
+    it { should include_sexp [:cmd, 'travis_apt_get_update'] }
     it { should include_sexp [:cmd, 'sudo apt-get install -y hhvm', timing: true, assert: true, echo: true] }
     it { should include_sexp [:raw, "echo \"deb [ arch=amd64 ] http://dl.hhvm.com/ubuntu $(lsb_release -sc)-lts-3.12 main\" | sudo tee -a /etc/apt/sources.list >&/dev/null"] }
   end

--- a/spec/build/script/shared/appliances/update_glibc.rb
+++ b/spec/build/script/shared/appliances/update_glibc.rb
@@ -1,9 +1,8 @@
 shared_examples_for 'update libc6' do
-  let(:command) { [:cmd, 'travis_apt_get_update'] }
+  let(:command) { [:echo, 'Forcing update of libc6', ansi: :yellow] }
 
   context "when update_glibc is unset" do
     it 'updates libc6' do
-      skip 'spec requires less generic assertion' 
       should_not include_sexp(command)
     end
   end
@@ -14,13 +13,12 @@ shared_examples_for 'update libc6' do
     end
 
     it 'updates libc6' do
-      skip 'spec requires less generic assertion' 
       should_not include_sexp(command)
     end
   end
 
   context "when update_glibc is unset" do
-    let(:sexp) { sexp_find(subject, [:if, "-n $(command -v lsb_release) && $(lsb_release -cs) = 'precise'"]) }
+    let(:sexp) { sexp_find(subject, [:if, '${TRAVIS_OS_NAME} == linux && ${TRAVIS_DIST} == precise']) }
 
     before :each do
       Travis::Build.config.update_glibc = '1'
@@ -28,7 +26,6 @@ shared_examples_for 'update libc6' do
     end
 
     it 'updates libc6' do
-      skip 'spec requires less generic assertion' 
       should include_sexp(command)
     end
 

--- a/spec/build/script/shared/appliances/update_glibc.rb
+++ b/spec/build/script/shared/appliances/update_glibc.rb
@@ -1,14 +1,9 @@
 shared_examples_for 'update libc6' do
-  let(:command) { [:cmd, <<-EOF
-if [ ! $(uname|grep Darwin) ]; then
-  sudo -E apt-get -yq update 2>&1 >> ~/apt-get-update.log
-  sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install libc6
-fi
-  EOF
-  ]}
+  let(:command) { [:cmd, 'travis_apt_get_update'] }
 
   context "when update_glibc is unset" do
     it 'updates libc6' do
+      skip 'spec requires less generic assertion' 
       should_not include_sexp(command)
     end
   end
@@ -19,18 +14,21 @@ fi
     end
 
     it 'updates libc6' do
+      skip 'spec requires less generic assertion' 
       should_not include_sexp(command)
     end
   end
 
   context "when update_glibc is unset" do
-    let(:sxep) { sexp_find(subject, [:if, "-n $(command -v lsb_release) && $(lsb_release -cs) = 'precise'"]) }
+    let(:sexp) { sexp_find(subject, [:if, "-n $(command -v lsb_release) && $(lsb_release -cs) = 'precise'"]) }
+
     before :each do
       Travis::Build.config.update_glibc = '1'
       data[:paranoid] = true
     end
 
     it 'updates libc6' do
+      skip 'spec requires less generic assertion' 
       should include_sexp(command)
     end
 

--- a/spec/build/script_spec.rb
+++ b/spec/build/script_spec.rb
@@ -93,13 +93,6 @@ describe Travis::Build::Script, :sexp do
   context 'apt-get update' do
     context 'with APT_GET_UPDATE_OPT_IN not enabled' do
       before { ENV.delete('APT_GET_UPDATE_OPT_IN') }
-      context 'with running on osx' do
-        before { payload[:config][:os] = 'osx' }
-        before { payload[:config].delete(:apt) }
-        after { payload[:config][:os] = 'linux' }
-        it { expect(code).to_not include 'sudo apt-get update' }
-        it { expect(code).to_not include 'Running apt-get by default has been disabled' }
-      end
 
       context 'with config[:apt][:update] not given' do
         before { payload[:config].delete(:apt) }
@@ -142,7 +135,7 @@ describe Travis::Build::Script, :sexp do
     context 'with APT_GET_UPDATE_OPT_IN enabled' do
       before { ENV['APT_GET_UPDATE_OPT_IN'] = 'true' }
       after { ENV.delete('APT_GET_UPDATE_OPT_IN') }
-      
+
       context 'with running on osx' do
         before { payload[:config][:os] = 'osx' }
         after { payload[:config][:os] = 'linux' }

--- a/spec/build/script_spec.rb
+++ b/spec/build/script_spec.rb
@@ -97,37 +97,37 @@ describe Travis::Build::Script, :sexp do
       context 'with config[:apt][:update] not given' do
         before { payload[:config].delete(:apt) }
         before { payload[:config][:os] = 'linux' }
-        it { expect(code).to include 'sudo apt-get update' }
+        it { expect(code).to include 'travis_apt_get_update' }
         it { expect(code).to_not include 'Running apt-get update by default has been disabled' }
       end
 
       context 'with config[:apt][:update] not given and apt-get update used in before_install' do
         before { payload[:config][:install] = ['apt-get -s install foo'] }
-        it { expect(code).to_not include 'sudo apt-get update' }
+        it { expect(code).to_not match(/\s*travis_apt_get_update$/) }
         it { expect(code).to_not include 'Running apt-get update by default has been disabled' }
       end
 
       context 'with config[:apt][:update] being true' do
         before { payload[:config][:apt] = { update: true } }
-        it { expect(code).to include 'sudo apt-get update' }
+        it { expect(code).to include 'travis_apt_get_update' }
         it { expect(code).to_not include 'Running apt-get update by default has been disabled' }
       end
 
       context 'with config[:apt][:update] being false' do
         before { payload[:config][:apt] = { update: false } }
-        it { expect(code).to_not include 'sudo apt-get update' }
+        it { expect(code).to_not match(/\s*travis_apt_get_update$/) }
         it { expect(code).to_not include 'Running apt-get update by default has been disabled' }
       end
 
       context 'with config[:addons][:apt][:update] being true' do
         before { payload[:config][:addons][:apt] = { update: true } }
-        it { expect(code).to include 'sudo apt-get update' }
+        it { expect(code).to_not match(/\s*travis_apt_get_update$/) }
         it { expect(code).to_not include 'Running apt-get update by default has been disabled' }
       end
 
       context 'with config[:addons][:apt][:update] being false' do
         before { payload[:config][:addons][:apt] = { update: false } }
-        it { expect(code).to_not include 'sudo apt-get update' }
+        it { expect(code).to_not match(/\s*travis_apt_get_update$/) }
         it { expect(code).to_not include 'Running apt-get update by default has been disabled' }
       end
     end
@@ -139,42 +139,42 @@ describe Travis::Build::Script, :sexp do
       context 'with running on osx' do
         before { payload[:config][:os] = 'osx' }
         after { payload[:config][:os] = 'linux' }
-        it { expect(code).to_not include 'sudo apt-get update' }
+        it { expect(code).to_not match(/\s*travis_apt_get_update$/) }
         it { expect(code).to_not include 'Running apt-get by default has been disabled' }
       end
 
       context 'with config[:apt][:update] not given' do
         before { payload[:config].delete(:apt) }
-        it { expect(code).to_not include 'sudo apt-get update' }
+        it { expect(code).to_not match(/\s*travis_apt_get_update$/) }
       end
 
       context 'with config[:apt][:update] not given and apt-get update used in before_install' do
         before { payload[:config][:install] = ['apt-get -s install foo'] }
         it { code }
-        it { expect(code).to include 'sudo apt-get update' }
+        it { expect(code).to include 'travis_apt_get_update' }
         it { expect(code).to_not include 'Running apt-get update by default has been disabled' }
       end
 
       context 'with config[:apt][:update] being true' do
         before { payload[:config][:apt] = { update: true } }
-        it { expect(code).to include 'sudo apt-get update' }
+        it { expect(code).to include 'travis_apt_get_update' }
         it { expect(code).to_not include 'Running apt-get update by default has been disabled' }
       end
 
       context 'with config[:apt][:update] being false' do
         before { payload[:config][:apt] = { update: false } }
-        it { expect(code).to_not include 'sudo apt-get update' }
+        it { expect(code).to_not match(/\s*travis_apt_get_update$/) }
       end
 
       context 'with config[:addons][:apt][:update] being true' do
         before { payload[:config][:addons][:apt] = { update: true } }
-        it { expect(code).to include 'sudo apt-get update' }
+        it { expect(code).to include 'travis_apt_get_update' }
         it { expect(code).to_not include 'Running apt-get update by default has been disabled' }
       end
 
       context 'with config[:addons][:apt][:update] being false' do
         before { payload[:config][:addons][:apt] = { update: false } }
-        it { expect(code).to_not include 'sudo apt-get update' }
+        it { expect(code).to_not match(/\s*travis_apt_get_update$/) }
       end
     end
   end


### PR DESCRIPTION
which also introduces infrastructure detection via a `travis_whereami` function.  Please note that this PR targets the branch for #1476.