### PR TITLE
Hide "Disabling Gradle daemon" from log output

### DIFF
--- a/lib/travis/build/script/shared/jdk.rb
+++ b/lib/travis/build/script/shared/jdk.rb
@@ -34,8 +34,7 @@ module Travis
             sh.export 'TERM', 'dumb'
           end
 
-          sh.echo "Disabling Gradle daemon", ansi: :yellow
-          sh.cmd 'mkdir -p ~/.gradle && echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties', echo: true, timing: false
+          sh.cmd 'mkdir -p ~/.gradle && echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties', echo: false, timing: false
 
         end
 


### PR DESCRIPTION
As far as I can tell, we display that line on almost every job. Yet it is not really that useful imo. This change would clean up the job output a bit.

FWIW, if there are good reasons to keep it, I'm totally fine with that too!