### PR TITLE
Set CFLAGS='-w', CCFLAGS='-w'

### DIFF
--- a/lib/travis/build/env.rb
+++ b/lib/travis/build/env.rb
@@ -1,4 +1,5 @@
 require 'travis/build/env/builtin'
+require 'travis/build/env/defaults'
 require 'travis/build/env/config'
 require 'travis/build/env/settings'
 require 'travis/build/env/var'
@@ -6,7 +7,7 @@ require 'travis/build/env/var'
 module Travis
   module Build
     class Env
-      GROUPS = [Builtin, Settings, Config]
+      GROUPS = [Builtin, Defaults, Settings, Config]
 
       attr_reader :data
 

--- a/lib/travis/build/env/defaults.rb
+++ b/lib/travis/build/env/defaults.rb
@@ -1,0 +1,24 @@
+require 'travis/build/env/base'
+
+module Travis
+  module Build
+    class Env
+      class Defaults < Base
+        DEFAULTS = {
+          CFLAGS:  '-w',
+          CCFLAGS: '-w',
+        }
+
+        def announce?
+          false
+        end
+
+        def vars
+          DEFAULTS.map do |var, val|
+            Var.new(var, val, type: :defaults)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/build/script/shared/appliances/env.rb
+++ b/spec/build/script/shared/appliances/env.rb
@@ -92,6 +92,10 @@ shared_examples_for 'a script with env vars sexp' do
     should include_sexp [:export, ['BRANCH', '$TRAVIS_BRANCH'], echo: true]
   end
 
+  it 'exports and echoes default values' do
+    should include_sexp [:export, ['CFLAGS', '-w'], echo: true]
+  end
+
   # TODO this is wrong. it only sets UNQUOTED=first
   # it 'sets the exact value of a given :env var, even if definition is unquoted' do
   #   data[:config][env_type] = 'UNQUOTED=first second third ... OTHER=ok'


### PR DESCRIPTION
To suppress compiler warnings.

This PR introduces a new environment variable type, `Defaults`, that are not strictly Travis built-ins, but are common environment variables that users may define and subsequently override with their configurations (be in Settings panel, or in `.travis.yml`).