### PR TITLE
Eradicate all known warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ cache:
 env:
   global:
   - COVERAGE=1
-  - RUBYOPT=-W0
   matrix:
   - INTEGRATION_SPECS=0
   - INTEGRATION_SPECS=1

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ end
 
 group :test do
   gem 'codeclimate-test-reporter', require: nil
-  gem 'mocha', '~> 0.10.0'
+  gem 'mocha'
   gem 'pry'
   gem 'rspec', '~> 3.0'
   gem 'simplecov', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
       hitimes (~> 1.1)
     minitar (0.6.1)
     minitest (5.10.1)
-    mocha (0.10.5)
+    mocha (1.7.0)
       metaclass (~> 0.0.1)
     multi_json (1.12.1)
     multipart-post (2.0.0)
@@ -185,7 +185,7 @@ DEPENDENCIES
   metriks (= 0.9.9.6)
   metriks-librato_metrics!
   minitar
-  mocha (~> 0.10.0)
+  mocha
   pry
   puma
   rack-ssl (~> 1.4)
@@ -203,4 +203,4 @@ DEPENDENCIES
   travis-support!
 
 BUNDLED WITH
-   1.16.1
+   1.16.4

--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -107,6 +107,10 @@ module Travis
             sh.cmd "sudo mv #{tmp_dest} ${TRAVIS_ROOT}/etc/apt/apt.conf.d"
           end
         end
+        
+        def config
+          @config ||= Hash(super)
+        end
 
         private
 
@@ -199,10 +203,6 @@ module Travis
                 sh.raw "travis_assert $result"
               end
             end
-          end
-
-          def config
-            @config ||= Hash(super)
           end
 
           def config_sources

--- a/lib/travis/build/addons/base.rb
+++ b/lib/travis/build/addons/base.rb
@@ -19,7 +19,7 @@ module Travis
 
         def normalize_config(config)
           case config
-          when Fixnum, Float, String, Array, Hash
+          when Integer, Float, String, Array, Hash
             config
           else
             {}

--- a/lib/travis/build/addons/homebrew.rb
+++ b/lib/travis/build/addons/homebrew.rb
@@ -22,11 +22,11 @@ module Travis
           end
         end
 
-        private
-
         def config
           @config ||= Hash(super)
         end
+
+        private
 
         def update_homebrew?
           config[:update].to_s.downcase == 'true'

--- a/lib/travis/build/appliances/apt_get_update.rb
+++ b/lib/travis/build/appliances/apt_get_update.rb
@@ -13,6 +13,10 @@ module Travis
           true
         end
 
+        def config
+          apt_config || {}
+        end
+
         private
 
           def update?
@@ -70,10 +74,6 @@ module Travis
             repo_slug.split('/').first
           end
 
-          def config
-            apt_config || {}
-          end
-
           def mirrors
             (Travis::Build.config[:apt_mirrors] || {}).to_hash
           end
@@ -85,4 +85,3 @@ module Travis
     end
   end
 end
-

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -167,11 +167,19 @@ module Travis
         ! data.debug_options.empty?
       end
 
-      private
+      def config
+        data.config
+      end
 
-        def config
-          data.config
-        end
+      def app_host
+        @app_host ||= Travis::Build.config.app_host.to_s.strip.untaint
+      end
+
+      def debug_enabled?
+        Travis::Build.config.enable_debug_tools == '1'
+      end
+      
+      private
 
         def debug
           if debug_build_via_api?
@@ -328,14 +336,6 @@ module Travis
 
         def debug_quiet?
           debug_build_via_api? && data.debug_options[:quiet]
-        end
-
-        def debug_enabled?
-          Travis::Build.config.enable_debug_tools == '1'
-        end
-
-        def app_host
-          @app_host ||= Travis::Build.config.app_host.to_s.strip.untaint
         end
 
         def error_message_ary(exception, event)


### PR DESCRIPTION
Currently, they are suppressed in the build via `RUBYOPT=-W0`, but this is not done in production, so the logs are littered with many, many warnings, drowning other, more useful, output.

* Make previously private methods public, so they can be the target for forwarding
* Use `Integer` instead of `Fixnum`
* Update `mocha` (see https://github.com/freerange/mocha/issues/321)