### PR TITLE
Suppress message during Heroku CLI update

### DIFF
--- a/lib/travis/build/appliances/update_heroku.rb
+++ b/lib/travis/build/appliances/update_heroku.rb
@@ -5,7 +5,7 @@ module Travis
     module Appliances
       class UpdateHeroku < Base
         def apply
-          sh.if '"$TRAVIS_DIST" == trusty && "$(which heroku)" =~ heroku' do
+          sh.if '("$TRAVIS_DIST" != precise || "$TRAVIS_OS_NAME" == linux) && "$(which heroku)" =~ heroku' do
             update_heroku = <<~UPDATE_HEROKU
             bash -c '
               cd /usr/lib

--- a/lib/travis/build/appliances/update_heroku.rb
+++ b/lib/travis/build/appliances/update_heroku.rb
@@ -6,19 +6,27 @@ module Travis
       class UpdateHeroku < Base
         def apply
           sh.if '"$TRAVIS_DIST" == trusty && "$(which heroku)" =~ heroku' do
-            sh.fold "update_heroku" do
-              sh.echo "Updating Heroku", ansi: :yellow
-              shell = <<~UPDATE_HEROKU
-              bash -c '
-                rm -rf /usr/local/heroku
-                apt-get purge -y heroku-toolbelt heroku &>/dev/null
-                cd /usr/lib
-                curl -sSL https://cli-assets.heroku.com/heroku-linux-x64.tar.xz | tar Jx
-                ln -sf /usr/lib/heroku/bin/heroku /usr/bin/heroku
-              '
-              UPDATE_HEROKU
-              sh.cmd shell, sudo: true, echo: false
-              sh.cmd 'heroku version', echo: true
+            update_heroku = <<~UPDATE_HEROKU
+            bash -c '
+              cd /usr/lib
+              (curl -sfSL https://cli-assets.heroku.com/heroku-linux-x64.tar.xz | tar Jx) &&
+              ln -sf /usr/lib/heroku/bin/heroku /usr/bin/heroku
+            '
+            UPDATE_HEROKU
+
+            remove_heroku = <<~REMOVE_HEROKU
+            bash -c '
+              rm -rf /usr/local/heroku
+              apt-get purge -y heroku-toolbelt heroku &>/dev/null
+            '
+            REMOVE_HEROKU
+
+            sh.cmd update_heroku, sudo: true, echo: false
+            sh.if "$? -eq 0" do
+              sh.cmd remove_heroku, sudo: true, echo: false
+            end
+            sh.else do
+              sh.echo "Failed to update Heroku CLI", ansi: :red
             end
           end
         end


### PR DESCRIPTION
It is a bit noisy; alert only when something
goes wrong.