### PR TITLE
Adjust git logic for Windows

### DIFF
--- a/lib/travis/build/bash/travis_cleanup.bash
+++ b/lib/travis/build/bash/travis_cleanup.bash
@@ -1,0 +1,5 @@
+travis_cleanup() {
+  if [[ -n $SSH_AGENT_PID ]]; then
+    kill $SSH_AGENT_PID >&/dev/null
+  fi
+}

--- a/lib/travis/build/git/netrc.rb
+++ b/lib/travis/build/git/netrc.rb
@@ -4,15 +4,15 @@ module Travis
       class Netrc < Struct.new(:sh, :data)
         def apply
           sh.fold 'git.netrc' do
-            sh.echo "Using ${TRAVIS_HOME}/.netrc to clone repository.", ansi: :yellow
+            sh.echo "Using ${TRAVIS_HOME}/#{netrc_filename} to clone repository.", ansi: :yellow
             sh.newline
-            sh.raw "echo -e \"#{netrc_content}\" > ${TRAVIS_HOME}/.netrc"
-            sh.raw "chmod 0600 ${TRAVIS_HOME}/.netrc"
+            sh.raw "echo -e \"#{netrc_content}\" > ${TRAVIS_HOME}/#{netrc_filename}"
+            sh.raw "chmod 0600 ${TRAVIS_HOME}/#{netrc_filename}"
           end
         end
 
         def delete
-          sh.raw "rm -f ${TRAVIS_HOME}/.netrc"
+          sh.raw "rm -f ${TRAVIS_HOME}/#{netrc_filename}"
         end
 
         private
@@ -23,6 +23,10 @@ module Travis
             else
               "machine #{data.source_host}\\n  login #{data.token}\\n"
             end
+          end
+
+          def netrc_filename
+            data.config[:os].to_s.downcase == 'windows' ? '_netrc' : '.netrc'
           end
       end
     end

--- a/lib/travis/build/git/netrc.rb
+++ b/lib/travis/build/git/netrc.rb
@@ -6,7 +6,7 @@ module Travis
           sh.fold 'git.netrc' do
             sh.echo "Using ${TRAVIS_HOME}/.netrc to clone repository.", ansi: :yellow
             sh.newline
-            sh.raw "echo -e \"#{netrc}\" > ${TRAVIS_HOME}/.netrc"
+            sh.raw "echo -e \"#{netrc_content}\" > ${TRAVIS_HOME}/.netrc"
             sh.raw "chmod 0600 ${TRAVIS_HOME}/.netrc"
           end
         end
@@ -17,7 +17,7 @@ module Travis
 
         private
 
-          def netrc
+          def netrc_content
             if data.installation?
               "machine #{data.source_host}\\n  login travis-ci\\n  password #{data.token}\\n"
             else

--- a/lib/travis/build/git/ssh_key.rb
+++ b/lib/travis/build/git/ssh_key.rb
@@ -7,7 +7,7 @@ module Travis
             sh.echo messages
           end
 
-          sh.mkdir '~/.ssh', recursive: true
+          sh.mkdir '~/.ssh', recursive: true, echo: false
           sh.file '~/.ssh/id_rsa', key.value
           sh.chmod 600, '~/.ssh/id_rsa', echo: false
           sh.raw 'eval `ssh-agent` &> /dev/null'

--- a/lib/travis/build/git/ssh_key.rb
+++ b/lib/travis/build/git/ssh_key.rb
@@ -10,8 +10,8 @@ module Travis
           sh.mkdir '~/.ssh', recursive: true, echo: false
           sh.file '~/.ssh/id_rsa', key.value
           sh.chmod 600, '~/.ssh/id_rsa', echo: false
-          sh.raw 'eval `ssh-agent` &> /dev/null'
-          sh.raw 'ssh-add ~/.ssh/id_rsa &> /dev/null'
+          sh.cmd 'eval `ssh-agent`', assert: true
+          sh.cmd 'ssh-add ~/.ssh/id_rsa', assert: true
 
           # BatchMode - If set to 'yes', passphrase/password querying will be disabled.
           # TODO ... how to solve StrictHostKeyChecking correctly? deploy a known_hosts file?

--- a/lib/travis/build/git/ssh_key.rb
+++ b/lib/travis/build/git/ssh_key.rb
@@ -7,6 +7,7 @@ module Travis
             sh.echo messages
           end
 
+          sh.mkdir '~/.ssh', recursive: true
           sh.file '~/.ssh/id_rsa', key.value
           sh.chmod 600, '~/.ssh/id_rsa', echo: false
           sh.raw 'eval `ssh-agent` &> /dev/null'

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -51,6 +51,7 @@ module Travis
         travis_apt_get_update
         travis_assert
         travis_bash_qsort_numeric
+        travis_cleanup
         travis_cmd
         travis_decrypt
         travis_download
@@ -178,7 +179,7 @@ module Travis
       def debug_enabled?
         Travis::Build.config.enable_debug_tools == '1'
       end
-      
+
       private
 
         def debug
@@ -197,6 +198,7 @@ module Travis
 
         def run
           stages.run if apply :validate
+          sh.raw 'travis_cleanup'
           sh.raw 'travis_footer'
           # apply :deprecations
         end


### PR DESCRIPTION
This PR modifies git logic to work with Windows.

1. Ensure that `~/.ssh` exists before writing to files there.
1. It changes the name of the `netrc` configuration file: `_netrc` for Windows, `.netrc` for others.
1. Terminate `ssh-agent`, if PID is set. (Otherwise, Windows session may linger.)