### PR TITLE
Improvments for Windows support

### DIFF
--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -111,18 +111,6 @@ module Travis
           end
         end
 
-        def default_version
-          DEFAULT_VERSION
-        end
-
-        def yarn_required_node_version
-          YARN_REQUIRED_NODE_VERSION
-        end
-
-        def npm_ci_cmd_version
-          NPM_CI_CMD_VERSION
-        end
-
         def node_js_given_in_config?
           !!config[:node_js]
         end
@@ -210,7 +198,7 @@ module Travis
             sh.if "-f yarn.lock" do
               sh.if yarn_req_not_met do
                 sh.echo "Node.js version $(node --version) does not meet requirement for yarn." \
-                  " Please use Node.js #{yarn_required_node_version} or later.", ansi: :red
+                  " Please use Node.js #{YARN_REQUIRED_NODE_VERSION} or later.", ansi: :red
                 npm_install config[:npm_args]
               end
               sh.else do
@@ -236,7 +224,7 @@ module Travis
           end
 
           def yarn_req_not_met
-            "$(travis_vers2int $(echo `node --version` | tr -d 'v')) -lt $(travis_vers2int #{yarn_required_node_version})"
+            "$(travis_vers2int $(echo `node --version` | tr -d 'v')) -lt $(travis_vers2int #{YARN_REQUIRED_NODE_VERSION})"
           end
 
           def is_win?

--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -36,7 +36,7 @@ module Travis
 
         def announce
           super
-          if iojs_3_plus?
+          if iojs_3_plus? && !is_win?
             sh.cmd 'echo -e "#include <array>\nstd::array<int, 1> arr = {0}; int main() {return 0;}" > /tmp/foo-$$.cpp', echo: false
             sh.raw "if ! ($CXX -std=c++11 -o /dev/null /tmp/foo-$$.cpp >&/dev/null || g++ -std=c++11 -o /dev/null /tmp/foo-$$.cpp >&/dev/null); then"
             sh.echo "Starting with io.js 3 and Node.js 4, building native extensions requires C++11-compatible compiler, which seems unavailable on this VM. Please read https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements.", ansi: :yellow

--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -20,6 +20,8 @@ module Travis
         def setup
           super
 
+          sh.newline
+          sh.newline
           sh.fold "#{version_manager.name}.setup" do
             setup_os
 
@@ -236,8 +238,6 @@ module Travis
 
           def setup_os
             if is_win?
-              sh.newline
-              sh.newline
               sh.echo "Using NVS for managing Node.js versions on Windows (BETA)", ansi: :yellow
               sh.export 'NVS_HOME', '$ProgramData/nvs', echo: false
               sh.cmd 'git clone --single-branch -b joshk-msys_nt https://github.com/joshk/nvs $NVS_HOME'

--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -20,12 +20,15 @@ module Travis
         def setup
           super
 
-          setup_os
+          sh.fold "#{version_manager.name}.setup" do
+            setup_os
 
-          prepend_path './node_modules/.bin'
-          convert_legacy_nodejs_config
-          version_manager.update unless app_host.empty?
-          version_manager.install
+            prepend_path './node_modules/.bin'
+            convert_legacy_nodejs_config
+            version_manager.update unless app_host.empty?
+            version_manager.install
+          end
+
           npm_disable_prefix
           npm_disable_spinner
           npm_disable_progress
@@ -233,6 +236,9 @@ module Travis
 
           def setup_os
             if is_win?
+              sh.newline
+              sh.newline
+              sh.echo "Using NVS for managing Node.js versions on Windows (BETA)", ansi: :yellow
               sh.export 'NVS_HOME', '$ProgramData/nvs', echo: false
               sh.cmd 'git clone --single-branch -b joshk-msys_nt https://github.com/joshk/nvs $NVS_HOME'
               sh.cmd 'source $NVS_HOME/nvs.sh'

--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -240,7 +240,7 @@ module Travis
             if is_win?
               sh.echo "Using NVS for managing Node.js versions on Windows (BETA)", ansi: :yellow
               sh.export 'NVS_HOME', '$ProgramData/nvs', echo: false
-              sh.cmd 'git clone --single-branch -b joshk-msys_nt https://github.com/joshk/nvs $NVS_HOME'
+              sh.cmd 'git clone --single-branch https://github.com/jasongin/nvs $NVS_HOME'
               sh.cmd 'source $NVS_HOME/nvs.sh'
             end
           end

--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -1,3 +1,5 @@
+require 'travis/build/script/node_js/manager'
+
 module Travis
   module Build
     class Script
@@ -17,10 +19,13 @@ module Travis
 
         def setup
           super
+
+          setup_os
+
           prepend_path './node_modules/.bin'
           convert_legacy_nodejs_config
-          update_nvm
-          nvm_install
+          version_manager.update unless app_host.empty?
+          version_manager.install
           npm_disable_prefix
           npm_disable_spinner
           npm_disable_progress
@@ -40,7 +45,7 @@ module Travis
           end
           sh.cmd 'node --version'
           sh.cmd 'npm --version'
-          sh.cmd 'nvm --version'
+          version_manager.show_version
           sh.if "-f yarn.lock" do
              sh.cmd 'yarn --version'
              sh.cmd 'hash -d yarn', echo: false
@@ -99,7 +104,37 @@ module Travis
           super || data.cache?(:yarn)
         end
 
+        def version
+          @version ||= begin
+            version = Array(config[:node_js]).first
+            version == 0.1 ? '0.10' : version.to_s
+          end
+        end
+
+        def default_version
+          DEFAULT_VERSION
+        end
+
+        def yarn_required_node_version
+          YARN_REQUIRED_NODE_VERSION
+        end
+
+        def npm_ci_cmd_version
+          NPM_CI_CMD_VERSION
+        end
+
+        def node_js_given_in_config?
+          !!config[:node_js]
+        end
+
         private
+          def version_manager
+            @version_manager ||= if is_win?
+              Travis::Build::NodeJs::Manager.nvs(self)
+            else
+              Travis::Build::NodeJs::Manager.nvm(self)
+            end
+          end
 
           def convert_legacy_nodejs_config
             # TODO deprecate :nodejs
@@ -107,66 +142,6 @@ module Travis
             if config[:nodejs] && !config[:node_js]
               config[:node_js] = config[:nodejs]
             end
-          end
-
-          def node_js_given_in_config?
-            !!config[:node_js]
-          end
-
-          def version
-            @version ||= begin
-              version = Array(config[:node_js]).first
-              version == 0.1 ? '0.10' : version.to_s
-            end
-          end
-
-          def nvm_install
-            if node_js_given_in_config?
-              use_nvm_version
-            else
-              use_nvm_default
-            end
-          end
-
-          def use_nvm_default
-            sh.if '-f .nvmrc' do
-              sh.echo "Using nodejs version from .nvmrc", ansi: :yellow
-              install_version '$(< .nvmrc)'
-            end
-            sh.else do
-              install_version DEFAULT_VERSION
-            end
-          end
-
-          def use_nvm_version
-            install_version version
-          end
-
-          def install_version(ver)
-            sh.fold "nvm.install" do
-              sh.cmd "nvm install #{ver}", assert: false, timing: true
-              sh.if '$? -ne 0' do
-                sh.echo "Failed to install #{ver}. Remote repository may not be reachable.", ansi: :red
-                sh.echo "Using locally available version #{ver}, if applicable."
-                sh.cmd "nvm use #{ver}", assert: false, timing: false
-                sh.if '$? -ne 0' do
-                  sh.echo "Unable to use #{ver}", ansi: :red
-                  sh.cmd "false", assert: true, echo: false, timing: false
-                end
-              end
-              sh.export 'TRAVIS_NODE_VERSION', ver, echo: false
-            end
-          end
-
-          def update_nvm
-            return if app_host.empty?
-            sh.echo "Updating nvm", ansi: :yellow, timing: false
-            nvm_dir = "${TRAVIS_HOME}/.nvm"
-            sh.raw "mkdir -p #{nvm_dir}"
-            sh.raw "curl -s -o #{nvm_dir}/nvm.sh   https://#{app_host}/files/nvm.sh".untaint,   assert: false
-            sh.raw "curl -s -o #{nvm_dir}/nvm-exec https://#{app_host}/files/nvm-exec".untaint, assert: false
-            sh.raw "chmod 0755 #{nvm_dir}/nvm.sh #{nvm_dir}/nvm-exec", assert: true
-            sh.raw "source #{nvm_dir}/nvm.sh", assert: false
           end
 
           def npm_disable_prefix
@@ -235,7 +210,7 @@ module Travis
             sh.if "-f yarn.lock" do
               sh.if yarn_req_not_met do
                 sh.echo "Node.js version $(node --version) does not meet requirement for yarn." \
-                  " Please use Node.js #{YARN_REQUIRED_NODE_VERSION} or later.", ansi: :red
+                  " Please use Node.js #{yarn_required_node_version} or later.", ansi: :red
                 npm_install config[:npm_args]
               end
               sh.else do
@@ -261,7 +236,19 @@ module Travis
           end
 
           def yarn_req_not_met
-            "$(travis_vers2int $(echo `node --version` | tr -d 'v')) -lt $(travis_vers2int #{YARN_REQUIRED_NODE_VERSION})"
+            "$(travis_vers2int $(echo `node --version` | tr -d 'v')) -lt $(travis_vers2int #{yarn_required_node_version})"
+          end
+
+          def is_win?
+            config[:os].downcase.strip == 'windows'
+          end
+
+          def setup_os
+            if is_win?
+              sh.export 'NVS_HOME', '$ProgramData/nvs', echo: false
+              sh.cmd 'git clone --single-branch -b joshk-msys_nt https://github.com/joshk/nvs $NVS_HOME'
+              sh.cmd 'source $NVS_HOME/nvs.sh'
+            end
           end
       end
     end

--- a/lib/travis/build/script/node_js/manager.rb
+++ b/lib/travis/build/script/node_js/manager.rb
@@ -1,0 +1,19 @@
+require_relative 'manager/base'
+require_relative 'manager/nvm'
+require_relative 'manager/nvs'
+
+module Travis
+  module Build
+    class NodeJs
+      class Manager
+        def self.nvm(node_js)
+          Manager::Nvm.new(node_js)
+        end
+
+        def self.nvs(node_js)
+          Manager::Nvs.new(node_js)
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/build/script/node_js/manager/base.rb
+++ b/lib/travis/build/script/node_js/manager/base.rb
@@ -1,0 +1,37 @@
+require 'forwardable'
+
+module Travis
+  module Build
+    class NodeJs
+      class Manager
+        class Base
+          attr_reader :node_js
+
+          extend Forwardable
+          def_delegators :node_js,
+            :sh, :config, :version, :default_version, :node_js_given_in_config?
+
+          def initialize(node_js)
+            @node_js = node_js
+          end
+
+          def setup
+
+          end
+
+          def update
+
+          end
+
+          def install
+
+          end
+
+          def show_version
+
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/build/script/node_js/manager/base.rb
+++ b/lib/travis/build/script/node_js/manager/base.rb
@@ -20,19 +20,15 @@ module Travis
           end
 
           def setup
-
           end
 
           def update
-
           end
 
           def install
-
           end
 
           def show_version
-
           end
         end
       end

--- a/lib/travis/build/script/node_js/manager/base.rb
+++ b/lib/travis/build/script/node_js/manager/base.rb
@@ -9,7 +9,7 @@ module Travis
 
           extend Forwardable
           def_delegators :node_js,
-            :sh, :config, :version, :default_version, :node_js_given_in_config?
+            :sh, :config, :version, :app_host, :default_version, :node_js_given_in_config?
 
           def initialize(node_js)
             @node_js = node_js

--- a/lib/travis/build/script/node_js/manager/base.rb
+++ b/lib/travis/build/script/node_js/manager/base.rb
@@ -15,6 +15,10 @@ module Travis
             @node_js = node_js
           end
 
+          def name
+            self.class.to_s.sub(/.*::/,'').downcase
+          end
+
           def setup
 
           end

--- a/lib/travis/build/script/node_js/manager/nvm.rb
+++ b/lib/travis/build/script/node_js/manager/nvm.rb
@@ -12,7 +12,7 @@ module Travis
 
           end
 
-          def update_nvm
+          def update
             sh.echo "Updating nvm", ansi: :yellow, timing: false
             nvm_dir = "${TRAVIS_HOME}/.nvm"
             sh.raw "mkdir -p #{nvm_dir}"

--- a/lib/travis/build/script/node_js/manager/nvm.rb
+++ b/lib/travis/build/script/node_js/manager/nvm.rb
@@ -42,7 +42,7 @@ module Travis
               install_version '$(< .nvmrc)'
             end
             sh.else do
-              install_version default_version
+              install_version Travis::Build::Script::NodeJs::DEFAULT_VERSION
             end
           end
 

--- a/lib/travis/build/script/node_js/manager/nvm.rb
+++ b/lib/travis/build/script/node_js/manager/nvm.rb
@@ -1,0 +1,73 @@
+require_relative 'base'
+module Travis
+  module Build
+    class NodeJs
+      class Manager
+        class Nvm < Base
+          def initialize(node_js)
+            super
+          end
+
+          def setup
+
+          end
+
+          def update_nvm
+            sh.echo "Updating nvm", ansi: :yellow, timing: false
+            nvm_dir = "${TRAVIS_HOME}/.nvm"
+            sh.raw "mkdir -p #{nvm_dir}"
+            sh.raw "curl -s -o #{nvm_dir}/nvm.sh   https://#{app_host}/files/nvm.sh".untaint,   assert: false
+            sh.raw "curl -s -o #{nvm_dir}/nvm-exec https://#{app_host}/files/nvm-exec".untaint, assert: false
+            sh.raw "chmod 0755 #{nvm_dir}/nvm.sh #{nvm_dir}/nvm-exec", assert: true
+            sh.raw "source #{nvm_dir}/nvm.sh", assert: false
+          end
+
+          def install
+            if node_js_given_in_config?
+              use_version node_js.version
+            else
+              use_default
+            end
+          end
+
+          def show_version
+            sh.cmd 'nvm --version'
+          end
+
+          private
+
+          def use_default
+            sh.if '-f .nvmrc' do
+              sh.echo "Using nodejs version from .nvmrc", ansi: :yellow
+              install_version '$(< .nvmrc)'
+            end
+            sh.else do
+              install_version default_version
+            end
+          end
+
+          def use_version version
+            install_version version
+          end
+
+          def install_version(ver)
+            sh.fold "nvm.install" do
+              sh.cmd "nvm install #{ver}", assert: false, timing: true
+              sh.if '$? -ne 0' do
+                sh.echo "Failed to install #{ver}. Remote repository may not be reachable.", ansi: :red
+                sh.echo "Using locally available version #{ver}, if applicable."
+                sh.cmd "nvm use #{ver}", assert: false, timing: false
+                sh.if '$? -ne 0' do
+                  sh.echo "Unable to use #{ver}", ansi: :red
+                  sh.cmd "false", assert: true, echo: false, timing: false
+                end
+              end
+              sh.export 'TRAVIS_NODE_VERSION', ver, echo: false
+            end
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/build/script/node_js/manager/nvs.rb
+++ b/lib/travis/build/script/node_js/manager/nvs.rb
@@ -1,0 +1,32 @@
+require_relative 'base'
+module Travis
+  module Build
+    class NodeJs
+      class Manager
+        class Nvs < Base
+          def initialize(node_js)
+            super
+
+          end
+
+          def install
+            install_version version
+            use_version version
+          end
+
+          def show_version
+            sh.cmd 'nvs --version'
+          end
+
+          def install_version(version)
+            sh.cmd "nvs add #{version}"
+          end
+
+          def use_version(version)
+            sh.cmd "nvs use #{version}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/build/script/node_js/manager/nvs.rb
+++ b/lib/travis/build/script/node_js/manager/nvs.rb
@@ -18,6 +18,8 @@ module Travis
           end
 
           def install
+            sh.echo ''
+            sh.echo ''
             sh.fold "nvs" do
               sh.echo "Using NVS for managing Node.js versions on Windows (BETA)", ansi: :yellow
               install_version version

--- a/lib/travis/build/script/node_js/manager/nvs.rb
+++ b/lib/travis/build/script/node_js/manager/nvs.rb
@@ -9,6 +9,14 @@ module Travis
 
           end
 
+          def setup
+
+          end
+
+          def update
+
+          end
+
           def install
             install_version version
             use_version version

--- a/lib/travis/build/script/node_js/manager/nvs.rb
+++ b/lib/travis/build/script/node_js/manager/nvs.rb
@@ -18,13 +18,8 @@ module Travis
           end
 
           def install
-            sh.echo ''
-            sh.echo ''
-            sh.fold "nvs" do
-              sh.echo "Using NVS for managing Node.js versions on Windows (BETA)", ansi: :yellow
-              install_version version
-              use_version version
-            end
+            install_version version
+            use_version version
           end
 
           def show_version

--- a/lib/travis/build/script/node_js/manager/nvs.rb
+++ b/lib/travis/build/script/node_js/manager/nvs.rb
@@ -18,8 +18,11 @@ module Travis
           end
 
           def install
-            install_version version
-            use_version version
+            sh.fold "nvs" do
+              sh.echo "Using NVS for managing Node.js versions on Windows (BETA)", ansi: :yellow
+              install_version version
+              use_version version
+            end
           end
 
           def show_version

--- a/lib/travis/build/script/shared/directory_cache.rb
+++ b/lib/travis/build/script/shared/directory_cache.rb
@@ -11,7 +11,12 @@ module Travis
         def directory_cache
           @directory_cache ||= begin
             cache = cache_class.new(sh, data, cache_slug, Time.now)
-            cache = Noop.new(sh, data, cache_slug) unless cache.valid? && use_directory_cache?
+            if config[:os].to_s.downcase.strip == 'windows'
+              sh.echo "Caching is not supported on #{config[:os].to_s.capitalize}"
+              cache = Noop.new(sh, data, cache_slug)
+            elsif !cache.valid? || !use_directory_cache?
+              cache = Noop.new(sh, data, cache_slug)
+            end
             cache
           end
         end

--- a/lib/travis/build/script/shared/directory_cache.rb
+++ b/lib/travis/build/script/shared/directory_cache.rb
@@ -11,10 +11,10 @@ module Travis
         def directory_cache
           @directory_cache ||= begin
             cache = cache_class.new(sh, data, cache_slug, Time.now)
-            if config[:os].to_s.downcase.strip == 'windows'
-              sh.echo "Caching is not supported on #{config[:os].to_s.capitalize}"
+            if !cache.valid? || !use_directory_cache?
               cache = Noop.new(sh, data, cache_slug)
-            elsif !cache.valid? || !use_directory_cache?
+            elsif config[:os].to_s.downcase.strip == 'windows'
+              sh.echo "Caching is not supported on #{config[:os].to_s.capitalize}"
               cache = Noop.new(sh, data, cache_slug)
             end
             cache

--- a/lib/travis/build/script/shared/directory_cache.rb
+++ b/lib/travis/build/script/shared/directory_cache.rb
@@ -14,7 +14,8 @@ module Travis
             if !cache.valid? || !use_directory_cache?
               cache = Noop.new(sh, data, cache_slug)
             elsif config[:os].to_s.downcase.strip == 'windows'
-              sh.echo "Caching is not supported on #{config[:os].to_s.capitalize}"
+              sh.echo "Caching is not supported on #{config[:os].to_s.capitalize}", ansi: :yellow
+              sh.newline
               cache = Noop.new(sh, data, cache_slug)
             end
             cache

--- a/spec/build/script/node_js_spec.rb
+++ b/spec/build/script/node_js_spec.rb
@@ -159,4 +159,16 @@ describe Travis::Build::Script::NodeJs, :sexp do
     data[:config][:node_js] = 0.1
     expect(script.send(:version)).to eql('0.10')
   end
+
+  context "when os is windows" do
+    before :each do
+      data[:config][:os] = 'windows'
+    end
+
+    describe 'nvs install' do
+      it "runs nvs add" do
+        expect(subject).to include_sexp [:cmd, "nvs add 0.10", assert: true, echo: true, timing: true]
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a couple of improvements for the upcoming Windows support.

1. It extracts Node.js version managers to separate classes, so that different ones can be used based on some criteria, in particular, the OS. For the present purposes, we use `nvs` for Windows, `nvm` for everything else (Linux and macOS).
1. Disables caching when it the job runs on Windows. (This needs a separate investigation and fix.)