### PR TITLE
Exit early when running on Windows + unsupported language

### DIFF
--- a/lib/travis/build/appliances.rb
+++ b/lib/travis/build/appliances.rb
@@ -1,3 +1,4 @@
+require 'travis/build/appliances/check_unsupported'
 require 'travis/build/appliances/checkout'
 require 'travis/build/appliances/clean_up_path'
 require 'travis/build/appliances/redefine_curl'

--- a/lib/travis/build/appliances/check_unsupported.rb
+++ b/lib/travis/build/appliances/check_unsupported.rb
@@ -28,8 +28,10 @@ module Travis
 
         def windows_unsupported_msg(lang)
           [
-            "#{lang} is currently unsupported on Windows",
-            ""
+            "",
+            "The language '#{lang}' is currently unsupported on the Windows Build Environment.",
+            "",
+            "Let us know if you'd like to see it: https://travis-ci.community/c/windows. Thanks for understanding!",
           ]
         end
 

--- a/lib/travis/build/appliances/check_unsupported.rb
+++ b/lib/travis/build/appliances/check_unsupported.rb
@@ -1,0 +1,39 @@
+require 'travis/build/appliances/base'
+
+module Travis
+  module Build
+    module Appliances
+      class CheckUnsupported < Base
+        def apply
+          lang_name = config[:language]
+          unless windows_supports?(lang_name)
+            sh.if '"$TRAVIS_OS_NAME" = windows' do
+              windows_unsupported_msg(lang_name).each do |line|
+                sh.echo line, ansi: :yellow
+              end
+              sh.raw 'travis_terminate 0'
+            end
+          end
+        end
+
+        def apply?
+          true
+        end
+
+        private
+
+        def windows_supports?(lang)
+          Travis::Build.config.windows_langs.include?(lang)
+        end
+
+        def windows_unsupported_msg(lang)
+          [
+            "#{lang} is currently unsupported on Windows",
+            ""
+          ]
+        end
+
+      end
+    end
+  end
+end

--- a/lib/travis/build/appliances/check_unsupported.rb
+++ b/lib/travis/build/appliances/check_unsupported.rb
@@ -11,7 +11,7 @@ module Travis
               windows_unsupported_msg(lang_name).each do |line|
                 sh.echo line, ansi: :yellow
               end
-              sh.raw 'travis_terminate 0'
+              sh.raw 'travis_terminate 1'
             end
           end
         end

--- a/lib/travis/build/config.rb
+++ b/lib/travis/build/config.rb
@@ -112,6 +112,20 @@ module Travis
           'TRAVIS_BUILD_UPDATE_GLIBC',
           ENV.fetch('TRAVIS_UPDATE_GLIBC', ENV.fetch('UPDATE_GLIBC', ''))
         ),
+        windows_langs: ENV.fetch(
+          'TRAVIS_WINDOWS_LANGS',
+          %w(
+            bash
+            csharp
+            go
+            node_js
+            powershell
+            rust
+            script
+            sh
+            shell
+          ).join(",")
+        ).split(/,/),
         dump_backtrace: ENV.fetch(
           'TRAVIS_BUILD_DUMP_BACKTRACE', ENV.fetch('DUMP_BACKTRACE', '')
         )

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -180,17 +180,6 @@ module Travis
         Travis::Build.config.enable_debug_tools == '1'
       end
 
-      def setup
-        unless windows_supports?(lang_name)
-          sh.if '$"TRAVIS_OS_NAME" = windows' do
-            windows_unsupported_msg(lang_name).each do |line|
-              sh.echo line, ansi: :yellow
-            end
-            sh.raw 'travis_terminate 0'
-          end
-        end
-      end
-
       private
 
         def debug
@@ -247,6 +236,7 @@ module Travis
         end
 
         def configure
+          apply :check_unsupported
           apply :set_x
           apply :show_system_info
           apply :rm_riak_source
@@ -392,17 +382,6 @@ module Travis
 
         def lang_name
           self.class.name.split('::').last.downcase
-        end
-
-        def windows_supports?(lang)
-          Travis::Build.config.windows_langs.include?(lang)
-        end
-
-        def windows_unsupported_msg(lang)
-          [
-            "#{lang} is currently unsupported on Windows",
-            ""
-          ]
         end
     end
   end

--- a/spec/build/script/ruby_spec.rb
+++ b/spec/build/script/ruby_spec.rb
@@ -18,6 +18,8 @@ describe Travis::Build::Script::Ruby, :sexp do
     let(:cmds) { ['bundle install', 'bundle exec rake'] }
   end
 
+  it_behaves_like 'checks language support'
+
   it_behaves_like 'a build script sexp'
 
   describe 'using a jdk' do

--- a/spec/build/script/shared/appliances/check_unsupported.rb
+++ b/spec/build/script/shared/appliances/check_unsupported.rb
@@ -1,6 +1,6 @@
 shared_examples_for 'checks language support' do
   it "terminates early on windows" do
     sexp = sexp_find(subject, [:if, '"$TRAVIS_OS_NAME" = windows'])
-    expect(sexp).to include_sexp([:raw, 'travis_terminate 0'])
+    expect(sexp).to include_sexp([:raw, 'travis_terminate 1'])
   end
 end

--- a/spec/build/script/shared/appliances/check_unsupported.rb
+++ b/spec/build/script/shared/appliances/check_unsupported.rb
@@ -1,0 +1,6 @@
+shared_examples_for 'checks language support' do
+  it "terminates early on windows" do
+    sexp = sexp_find(subject, [:if, '"$TRAVIS_OS_NAME" = windows'])
+    expect(sexp).to include_sexp([:raw, 'travis_terminate 0'])
+  end
+end

--- a/spec/build/script_spec.rb
+++ b/spec/build/script_spec.rb
@@ -190,7 +190,7 @@ describe Travis::Build::Script, :sexp do
         before { payload[:config][:language] = 'node_js' }
         it "terminates early on windows" do
           sexp = sexp_find(subject, [:if, '$(uname | tr \'[:upper:]\' \'[:lower:]\') = msys*'])
-          expect(sexp).to include_sexp([:raw, 'travis_terminate 0'])
+          expect(sexp).to include_sexp([:raw, 'travis_terminate 1'])
         end
 
         it { store_example(name: 'windows-unsupported-lang') }

--- a/spec/build/script_spec.rb
+++ b/spec/build/script_spec.rb
@@ -183,7 +183,12 @@ describe Travis::Build::Script, :sexp do
     context 'with windows and only ruby is supported' do
       before do
         payload[:config][:os] = 'windows'
+        @langs_before = Travis::Build.config.windows_langs.dup
         Travis::Build.config.windows_langs = 'ruby'
+      end
+
+      after do
+        Travis::Build.config.windows_langs = @langs_before
       end
 
       context 'when building node_js' do

--- a/spec/build/script_spec.rb
+++ b/spec/build/script_spec.rb
@@ -189,7 +189,7 @@ describe Travis::Build::Script, :sexp do
       context 'when building node_js' do
         before { payload[:config][:language] = 'node_js' }
         it "terminates early on windows" do
-          sexp = sexp_find(subject, [:if, '$(uname | tr \'[:upper:]\' \'[:lower:]\') = msys*'])
+          sexp = sexp_find(subject, [:if, '"$TRAVIS_OS_NAME" = windows'])
           expect(sexp).to include_sexp([:raw, 'travis_terminate 1'])
         end
 

--- a/spec/build/script_spec.rb
+++ b/spec/build/script_spec.rb
@@ -179,5 +179,22 @@ describe Travis::Build::Script, :sexp do
         it { expect(code).to_not match(/\s*travis_apt_get_update$/) }
       end
     end
+
+    context 'with windows and only ruby is supported' do
+      before do
+        payload[:config][:os] = 'windows'
+        Travis::Build.config.windows_langs = 'ruby'
+      end
+
+      context 'when building node_js' do
+        before { payload[:config][:language] = 'node_js' }
+        it "terminates early on windows" do
+          sexp = sexp_find(subject, [:if, '$"TRAVIS_OS_NAME" = windows'])
+          expect(sexp).to include_sexp([:raw, 'travis_terminate 0', assert: true])
+        end
+
+        it { store_example(name: 'windows-unsupported-lang') }
+      end
+    end
   end
 end

--- a/spec/build/script_spec.rb
+++ b/spec/build/script_spec.rb
@@ -189,8 +189,8 @@ describe Travis::Build::Script, :sexp do
       context 'when building node_js' do
         before { payload[:config][:language] = 'node_js' }
         it "terminates early on windows" do
-          sexp = sexp_find(subject, [:if, '$"TRAVIS_OS_NAME" = windows'])
-          expect(sexp).to include_sexp([:raw, 'travis_terminate 0', assert: true])
+          sexp = sexp_find(subject, [:if, '$(uname | tr \'[:upper:]\' \'[:lower:]\') = msys*'])
+          expect(sexp).to include_sexp([:raw, 'travis_terminate 0'])
         end
 
         it { store_example(name: 'windows-unsupported-lang') }


### PR DESCRIPTION
This introduces env var `TRAVIS_WINDOWS_LANGS`, which is a comma-separated list of language names that are allowed to run on Windows.