### PR TITLE
Handle case where trace name first line is nil

### DIFF
--- a/lib/travis/shell/generator/bash.rb
+++ b/lib/travis/shell/generator/bash.rb
@@ -121,7 +121,7 @@ module Travis
         def handle_trace(name, body, options = {})
           span_id = rand 1..MAX_SPAN_ID
           span_id = span_id.to_s(16).rjust(16, "0")
-          name = name.to_s.lines.first.gsub(/<<.*/, '...')
+          name = (name.to_s.lines.first || '').gsub(/<<.*/, '...')
 
           start_span = {
             id: span_id,


### PR DESCRIPTION
I'm not sure this is the right action if `name.strip` is `''`.  I would think that _not_ emitting anything would be better than emitting trace nodes with no name (???).