### PR TITLE
Use tar for copying files to go_import_path

### DIFF
--- a/lib/travis/build/script/go.rb
+++ b/lib/travis/build/script/go.rb
@@ -46,7 +46,8 @@ module Travis
           sh.export 'PATH', "${TRAVIS_HOME}/gopath/bin:$PATH", echo: true
 
           sh.mkdir "${TRAVIS_HOME}/gopath/src/#{go_import_path}", recursive: true, assert: false, timing: false
-          sh.cmd "rsync -az ${TRAVIS_BUILD_DIR}/ ${TRAVIS_HOME}/gopath/src/#{go_import_path}/", assert: false, timing: false
+          # sh.cmd "rsync -az ${TRAVIS_BUILD_DIR}/ ${TRAVIS_HOME}/gopath/src/#{go_import_path}/", assert: false, timing: false
+          sh.cmd "tar -czf - ${TRAVIS_BUILD_DIR} | tar -xvf - -C ${TRAVIS_HOME}/gopath/src/#{go_import_path}", assert: false, timing: false
 
           sh.export "TRAVIS_BUILD_DIR", "${TRAVIS_HOME}/gopath/src/#{go_import_path}"
           sh.cd "${TRAVIS_HOME}/gopath/src/#{go_import_path}", assert: true


### PR DESCRIPTION
`rsync` appears to have problems on Windows.
![job__7_2_-_tianon_gosleep_-_travis_ci](https://user-images.githubusercontent.com/25666/46829426-cda2e680-cd6b-11e8-91e8-ab2fa6edc15c.png)
