### PR TITLE
Skip running `npm install` when yarn requirement is not met

### DIFF
--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -64,7 +64,7 @@ module Travis
                 npm_install config[:npm_args]
               end
               sh.else do
-                sh.cmd "yarn", retry: true, fold: 'install'
+                npm_install config[:npm_args]
               end
             end
             sh.else do
@@ -204,7 +204,6 @@ module Travis
               sh.if yarn_req_not_met do
                 sh.echo "Node.js version $(node --version) does not meet requirement for yarn." \
                   " Please use Node.js #{YARN_REQUIRED_NODE_VERSION} or later.", ansi: :red
-                npm_install config[:npm_args]
               end
               sh.else do
                 sh.fold "install.yarn" do

--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -64,7 +64,7 @@ module Travis
                 npm_install config[:npm_args]
               end
               sh.else do
-                npm_install config[:npm_args]
+                sh.cmd "yarn", retry: true, fold: 'install'
               end
             end
             sh.else do


### PR DESCRIPTION
I have a case of:

1. I have Node.js project with Yarn
2. I must test Node 10, 8, 6, 4, 0.12, 0.8.
3. Since most of the test tools don’t work on Node.js 0.12-0.8 I have custom [install script](https://github.com/ai/nanoid/blob/783ba0ca2ed7d45fb3dc3db8645a7306d4c49a93/test/ci-install) which install dependencies only for Node 10-6.

Unfortunately, right now this case [will not work with Travis](https://travis-ci.org/ai/nanoid/builds/441120983) since if Yarn doesn’t meet the requirement, Travis CI ignore custom `install` script and run `npm install`.

This PR should fix it and make this logic more predictable.