### PR TITLE
Use `rvm` for deployment only when available

### DIFF
--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -147,11 +147,21 @@ module Travis
               if edge_changed?(last_deploy, config)
                 cmd "gem uninstall -aIx dpl", echo: true
               end
-              sh.if "$(rvm use $(travis_internal_ruby) do ruby -e \"puts RUBY_VERSION\") = 1.9*" do
-                cmd(dpl_install_command(WANT_18), echo: true, assert: !allow_failure, timing: true)
+              sh.if "-f $HOME/.rvm/scripts/rvm" do
+                sh.if "$(rvm use $(travis_internal_ruby) do ruby -e \"puts RUBY_VERSION\") = 1.9*" do
+                  cmd(dpl_install_command(WANT_18), echo: true, assert: !allow_failure, timing: true)
+                end
+                sh.else do
+                  cmd(dpl_install_command, echo: true, assert: !allow_failure, timing: true)
+                end
               end
               sh.else do
-                cmd(dpl_install_command, echo: true, assert: !allow_failure, timing: true)
+                sh.if "$(ruby -e \"puts RUBY_VERSION\") = 1.9*" do
+                  cmd(dpl_install_command(WANT_18), echo: true, assert: !allow_failure, timing: true)
+                end
+                sh.else do
+                  cmd(dpl_install_command, echo: true, assert: !allow_failure, timing: true)
+                end
               end
               sh.cmd "rm -f $TRAVIS_BUILD_DIR/dpl-*.gem", echo: false, assert: false, timing: false
             end
@@ -181,8 +191,13 @@ module Travis
             end
 
             def cmd(cmd, *args)
-              sh.cmd('type rvm &>/dev/null || source ~/.rvm/scripts/rvm', echo: false, assert: false)
-              sh.cmd("rvm $(travis_internal_ruby) --fuzzy do ruby -S #{cmd}", *args)
+              sh.if "-e $HOME/.rvm/scripts/rvm" do
+                sh.cmd('type rvm &>/dev/null || source ~/.rvm/scripts/rvm', echo: false, assert: false)
+                sh.cmd("rvm $(travis_internal_ruby) --fuzzy do ruby -S #{cmd}", *args)
+              end
+              sh.else do
+                sh.cmd("ruby -S #{cmd}", *args)
+              end
             end
 
             def dpl_install_command(want_pre_19 = false)

--- a/spec/build/addons/deploy_spec.rb
+++ b/spec/build/addons/deploy_spec.rb
@@ -36,13 +36,25 @@ describe Travis::Build::Addons::Deploy, :sexp do
     it { expect(sexp).to include_sexp [:cmd, './before_deploy_2.sh', assert: true, echo: true, timing: true] }
     it "installs dpl < 1.9 if travis_internal_ruby returns 1.9*" do
       expect(
-        sexp_find(sexp, [:if, "$(rvm use $(travis_internal_ruby) do ruby -e \"puts RUBY_VERSION\") = 1.9*"], [:then])
+        sexp_filter(
+          sexp_filter(
+            sexp,
+            [:if, "$(rvm use $(travis_internal_ruby) do ruby -e \"puts RUBY_VERSION\") = 1.9*"]
+          )[0],
+          [:if, "-e $HOME/.rvm/scripts/rvm"]
+        )[0]
       ).to include_sexp [:cmd, "rvm $(travis_internal_ruby) --fuzzy do ruby -S gem install dpl -v '< 1.9' ", echo: true, assert: true, timing: true]
     end
 
     it "installs latest dpl if travis_internal_ruby does not return 1.9*" do
       expect(
-        sexp_find(sexp, [:if, "$(rvm use $(travis_internal_ruby) do ruby -e \"puts RUBY_VERSION\") = 1.9*"], [:else])
+        sexp_filter(
+          sexp_filter(
+            sexp,
+            [:if, "$(rvm use $(travis_internal_ruby) do ruby -e \"puts RUBY_VERSION\") = 1.9*"]
+          )[0],
+          [:if, "-e $HOME/.rvm/scripts/rvm"]
+        )[1]
       ).to include_sexp [:cmd, "rvm $(travis_internal_ruby) --fuzzy do ruby -S gem install dpl", echo: true, assert: true, timing: true]
     end
     it { expect(sexp).to include_sexp [:cmd, 'rvm $(travis_internal_ruby) --fuzzy do ruby -S gem install dpl', echo: true, assert: true, timing: true] }
@@ -229,4 +241,3 @@ describe Travis::Build::Addons::Deploy, :sexp do
     end
   end
 end
-


### PR DESCRIPTION
Our Windows image does not have `rvm` installed, so the deployment
will fail. In such a case, we will try installing `dpl` with the one ruby we have.