### PR TITLE
Set filter strategy to :redirect_io on Windows

### DIFF
--- a/lib/travis/build/appliances/setup_filter.rb
+++ b/lib/travis/build/appliances/setup_filter.rb
@@ -85,7 +85,11 @@ module Travis
           end
 
           def strategy
-            @strategy ||= Rollout.new(data).matches? ? :redirect_io : :pty
+            @strategy ||= if config[:os] == 'windows' && config.key?(:filter_secrets) && config[:filter_secrets]
+              :redirect_io
+            else
+              Rollout.new(data).matches? ? :redirect_io : :pty
+            end
           end
 
           def url(host = nil)

--- a/lib/travis/build/appliances/setup_filter.rb
+++ b/lib/travis/build/appliances/setup_filter.rb
@@ -85,7 +85,13 @@ module Travis
           end
 
           def strategy
-            @strategy ||= if config[:os] == 'windows' && config.key?(:filter_secrets) && config[:filter_secrets]
+            @strategy ||= if config[:os] == 'windows' &&
+              (
+                !config.key?(:filter_secrets) ||
+                # if filter_secrets is undefined, we force :redirect_io
+                (config.key?(:filter_secrets) && config[:filter_secrets])
+                # if it is defined, and it is not `false`, force :redirect_io
+              )
               :redirect_io
             else
               Rollout.new(data).matches? ? :redirect_io : :pty


### PR DESCRIPTION
On Windows, PTY module is unavailable, so the filter will fail with the
:pty strategy.

This PR will set the filter strategy to `redirect_io`, which does not have this limitation.