### PR TITLE
Set haskell cache slug based on ghc version

### DIFF
--- a/lib/travis/build/script/haskell.rb
+++ b/lib/travis/build/script/haskell.rb
@@ -74,6 +74,10 @@ module Travis
         def cabal_version
           Array(config[:cabal]).first.to_s
         end
+
+        def cache_slug
+          super << '--ghc-' << version
+        end
       end
     end
   end


### PR DESCRIPTION
See https://travis-ci.community/t/travis-haskell-version-is-not-included-in-cache-url-hash/146.