### PR TITLE
Accept brewfile: true passed as a string

### DIFF
--- a/lib/travis/build/addons/homebrew.rb
+++ b/lib/travis/build/addons/homebrew.rb
@@ -72,7 +72,7 @@ module Travis
         end
 
         def brew_bundle_args
-          if config[:brewfile] == true
+          if config[:brewfile].to_s.downcase == 'true'
             ''
           else
             " --file=#{Shellwords.escape(config[:brewfile])}"

--- a/spec/build/addons/homebrew_spec.rb
+++ b/spec/build/addons/homebrew_spec.rb
@@ -132,6 +132,13 @@ tap 'heroku/brew'
       it { should_not include_sexp [:cmd, 'brew bundle --verbose --global', echo: true, timing: true] }
     end
 
+    context 'when passing true as a string' do
+      let(:brew_config) { { brewfile: "true" } }
+
+      it { should include_sexp [:cmd, 'brew bundle --verbose', echo: true, timing: true] }
+      it { should_not include_sexp [:cmd, 'brew bundle --verbose --global', echo: true, timing: true] }
+    end
+
     context 'when using a custom Brewfile path' do
       let(:brew_config) { { brewfile: 'My Brewfile' } }
 


### PR DESCRIPTION
For now, we don't have a way to pass this as a boolean when using travis-yml (see https://github.com/travis-ci/travis-yml/issues/77), so we need to handle both true and "true".