### PR TITLE
Update link to MacOS gfortran installer

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -517,7 +517,7 @@ module Travis
             sh.cmd 'sudo tar fvxz /tmp/gfortran.tar.bz2 -C /'
             sh.rm '/tmp/gfortran.tar.bz2'
           else
-            sh.cmd "curl -fLo /tmp/gfortran61.dmg http://coudert.name/software/gfortran-6.1-ElCapitan.dmg", retry: true
+            sh.cmd "curl -fLo /tmp/gfortran61.dmg https://cloud.r-project.org/contrib/extra/macOS/gfortran-6.1-ElCapitan.dmg", retry: true
             sh.cmd 'sudo hdiutil attach /tmp/gfortran61.dmg -mountpoint /Volumes/gfortran'
             sh.cmd 'sudo installer -pkg "/Volumes/gfortran/gfortran-6.1-ElCapitan/gfortran.pkg" -target /'
             sh.cmd 'sudo hdiutil detach /Volumes/gfortran'

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -517,7 +517,7 @@ module Travis
             sh.cmd 'sudo tar fvxz /tmp/gfortran.tar.bz2 -C /'
             sh.rm '/tmp/gfortran.tar.bz2'
           else
-            sh.cmd "curl -fLo /tmp/gfortran61.dmg https://cloud.r-project.org/contrib/extra/macOS/gfortran-6.1-ElCapitan.dmg", retry: true
+            sh.cmd "curl -fLo /tmp/gfortran61.dmg #{repos[:CRAN]}/contrib/extra/macOS/gfortran-6.1-ElCapitan.dmg", retry: true
             sh.cmd 'sudo hdiutil attach /tmp/gfortran61.dmg -mountpoint /Volumes/gfortran'
             sh.cmd 'sudo installer -pkg "/Volumes/gfortran/gfortran-6.1-ElCapitan/gfortran.pkg" -target /'
             sh.cmd 'sudo hdiutil detach /Volumes/gfortran'


### PR DESCRIPTION
This fixes issue: https://github.com/travis-ci/travis-ci/issues/10295

The url to the gfortran installer for MacOS is dead, this replaces it by the official R source.

@jimhester @romainfrancois