### PR TITLE
Suppress "Network availability" message

### DIFF
--- a/lib/travis/build/bash/travis_wait_for_network.bash
+++ b/lib/travis/build/bash/travis_wait_for_network.bash
@@ -13,7 +13,6 @@ travis_wait_for_network() {
     done
 
     if [[ "${#urls[@]}" -eq "${confirmed}" ]]; then
-      echo -e "${ANSI_GREEN}Network availability confirmed.${ANSI_RESET}"
       return
     fi
 


### PR DESCRIPTION
We should expect this to be the case, and not make a fuss when this
basic expectation is met.