### PR TITLE
Update file location, fix https://github.com/travis-ci/travis-ci/issu…

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -517,7 +517,7 @@ module Travis
             sh.cmd 'sudo tar fvxz /tmp/gfortran.tar.bz2 -C /'
             sh.rm '/tmp/gfortran.tar.bz2'
           else
-            sh.cmd "curl -fLo /tmp/gfortran61.dmg http://coudert.name/software/gfortran-6.1-ElCapitan.dmg", retry: true
+            sh.cmd "curl -fLo /tmp/gfortran61.dmg https://github.com/fxcoudert/gfortran-for-macOS/releases/download/6.1/gfortran-6.1-ElCapitan.dmg", retry: true
             sh.cmd 'sudo hdiutil attach /tmp/gfortran61.dmg -mountpoint /Volumes/gfortran'
             sh.cmd 'sudo installer -pkg "/Volumes/gfortran/gfortran-6.1-ElCapitan/gfortran.pkg" -target /'
             sh.cmd 'sudo hdiutil detach /Volumes/gfortran'


### PR DESCRIPTION
[This example Travis build](https://travis-ci.org/tidyverse/dplyr/jobs/446154785#L72) gives the following error:

```
3.29s$ curl -fLo /tmp/gfortran61.dmg http://coudert.name/software/gfortran-6.1-ElCapitan.dmg
curl: (22) The requested URL returned error: 404 
The command "eval curl -fLo /tmp/gfortran61.dmg http://coudert.name/software/gfortran-6.1-ElCapitan.dmg " failed. Retrying, 2 of 3.
curl: (22) The requested URL returned error: 404 
The command "eval curl -fLo /tmp/gfortran61.dmg http://coudert.name/software/gfortran-6.1-ElCapitan.dmg " failed. Retrying, 3 of 3.
curl: (22) The requested URL returned error: 404 
The command "eval curl -fLo /tmp/gfortran61.dmg http://coudert.name/software/gfortran-6.1-ElCapitan.dmg " failed 3 times.
The command "curl -fLo /tmp/gfortran61.dmg http://coudert.name/software/gfortran-6.1-ElCapitan.dmg" failed and exited with 22 during .
Your build has been stopped.
```

This is caused by an incorrect file URL, as described at [This Issue](https://github.com/travis-ci/travis-ci/issues/10295). I took the liberty of submitting the described solution as well.