### PR TITLE
Skip specs for travis_internal_ruby()

### DIFF
--- a/spec/build/script/header_spec.rb
+++ b/spec/build/script/header_spec.rb
@@ -112,7 +112,7 @@ describe 'script header', integration: true do
         )
       end
 
-      it 'selects the latest valid version' do
+      xit 'selects the latest valid version' do
         expect(bash_output.strip).to match(/^2\.2\.5$/)
       end
     end
@@ -129,7 +129,7 @@ describe 'script header', integration: true do
         )
       end
 
-      it 'selects 1.9.3' do
+      xit 'selects 1.9.3' do
         expect(bash_output.strip).to match(/^1\.9\.3$/)
       end
     end
@@ -147,7 +147,7 @@ describe 'script header', integration: true do
         )
       end
 
-      it 'selects the highest version with a 2-digit patch level' do
+      xit 'selects the highest version with a 2-digit patch level' do
         expect(bash_output.strip).to match(/^2\.1\.10$/)
       end
     end


### PR DESCRIPTION
These specs depend on actual execution of `travis_internal_ruby`,
which may be influenced by factors outside of this code base,
which makes them very brittle.

These need to be re-framed.