### PR TITLE
Capture TEENY when looking for first 2.3+ Ruby

### DIFF
--- a/lib/travis/build/addons/homebrew.rb
+++ b/lib/travis/build/addons/homebrew.rb
@@ -105,7 +105,7 @@ module Travis
         end
 
         def first_ruby_2_3_plus
-          %q($(rvm list | perl -ne '/ruby-(2\.[3-9][0-9]*)/ && print $1,"\n"'| head -1))
+          %q($(rvm list | perl -ne '/ruby-(2\.[3-9][0-9]*(\.[0-9]+)*)/ && print $1,"\n"'| head -1))
         end
       end
     end


### PR DESCRIPTION
Otherwise, we would try to install '2.3', which may be newer than
the one pre-installed on the image. This is kind of OK on Ruby jobs,
because we install whatever the alias 2.3 resolves to, but on non-Ruby
jobs, this causes the addon to fail entirely.