### PR TITLE
Slim down the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,24 @@
-FROM ruby:2.5.3
-LABEL maintainer Travis CI GmbH <support+travis-app-docker-images@travis-ci.com>
+FROM ruby:2.5.3 as builder
 WORKDIR /usr/src/app
 
 ARG GITHUB_OAUTH_TOKEN=notset
+
+RUN bundle config --global frozen 1
+
+COPY . .
+
+RUN bundle install
+RUN bundle exec rake assets:precompile GITHUB_OAUTH_TOKEN=$GITHUB_OAUTH_TOKEN
+
+FROM ruby:2.5.3-slim
+LABEL maintainer Travis CI GmbH <support+travis-app-docker-images@travis-ci.com>
+WORKDIR /usr/src/app
+
 ENV TRAVIS_BUILD_DUMP_BACKTRACE true
 ENV PORT 4000
 
-COPY . .
-RUN bundle config --global frozen 1
-RUN bundle install
-RUN bundle exec rake assets:precompile GITHUB_OAUTH_TOKEN=$GITHUB_OAUTH_TOKEN
+COPY --from=builder /usr/src/app /usr/src/app
+COPY --from=builder /usr/local/bundle /usr/local/bundle
+COPY --from=builder /root/.bundle /root/.bundle
 
 CMD ["script/server"]

--- a/script/server
+++ b/script/server
@@ -14,7 +14,7 @@ main() {
   )
 
   if [[ "${RACK_ENV}" == development && ! "${DISABLE_RERUN}" ]]; then
-    cmd=(rerun -p '**/*.{rb,ru}' -- "${cmd[@]}")
+    cmd=(bundle exec rerun -p '**/*.{rb,ru}' -- "${cmd[@]}")
   fi
 
   echo "----> ${cmd[*]}"


### PR DESCRIPTION
by building on a full ruby image and then copying into a slim image. On
my machine this resulted in a 365MB image (down from ~1.1GB, or ~66%
reduced).