### PR TITLE
Fix docker local image name for publication to Docker Hub

### DIFF
--- a/script/docker-build-and-push
+++ b/script/docker-build-and-push
@@ -3,7 +3,7 @@
 set -ev
 
 app_name="web"
-local_image="travisbuild_${app_name}" # Docker Compose removes dashes and expects the name to end with the build app name
+local_image="travis-build_${app_name}"
 quay_image=quay.io/travisci/travis-build
 
 unset DOCKER_CERT_PATH


### PR DESCRIPTION
Starting with 18.06.0, the old naming convention no longer applies.