### PR TITLE
[R] Remove quote escapes when installing BiocManager

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -418,7 +418,7 @@ module Travis
                   ' );'\
                   'cat(append = TRUE, file = "~/.Rprofile.site", "options(repos = BiocInstaller::biocinstallRepos());")'
                 else
-                  'if (!requireNamespace(\"BiocManager\", quietly=TRUE))'\
+                  'if (!requireNamespace("BiocManager", quietly=TRUE))'\
                   '  install.packages("BiocManager");'\
                   "if (#{as_r_boolean(config[:bioc_use_devel])})"\
                   ' BiocManager::install(version = "devel");'\


### PR DESCRIPTION
I currently get the error `Error: unexpected input in "if (!requireNamespace(\"` on all builds requiring BioConductor e.g. https://travis-ci.org/grimbough/biomaRt/builds/451374478

This occurs during the step to install the BiocManager package, specifically 
```
if (!requireNamespace(\"BiocManager\", quietly=TRUE))  
    install.packages("BiocManager"); 
```

Based on the rest of the code, it seems like these quotes do not need to be escaped, although I don't know how to test this, so please ignore if this is spam.

@jeroen @jimhester @LiNk-NY 