### PR TITLE
Export R_PROFILE during the configure step, rather than export

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -50,7 +50,6 @@ module Travis
           sh.export 'R_LIBS_SITE', '/usr/local/lib/R/site-library:/usr/lib/R/site-library', echo: false
           sh.export '_R_CHECK_CRAN_INCOMING_', 'false', echo: false
           sh.export 'NOT_CRAN', 'true', echo: false
-          sh.export 'R_PROFILE', "~/.Rprofile.site", echo: false
         end
 
         def configure
@@ -160,6 +159,7 @@ module Travis
               repos_str = repos.collect {|k,v| "#{k} = \"#{v}\""}.join(", ")
               options_repos = "options(repos = c(#{repos_str}))"
               sh.cmd %Q{echo '#{options_repos}' > ~/.Rprofile.site}
+              sh.export 'R_PROFILE', "~/.Rprofile.site", echo: false
 
               # PDF manual requires latex
               if config[:latex]


### PR DESCRIPTION
export is run after configure, and R_PROFILE needs to be set for
`setup_bioc`.

It looks to me like the export stage is always run after configure, which is why the repos were not being set https://github.com/travis-ci/travis-build/blob/4f580b238530108cdd08719c326cd571d4e7b99f/lib/travis/build/stages.rb#L15-L19

An example error this should fix is https://travis-ci.org/ropenscilabs/available/jobs/452418452#L913-L916

cc @LiNk-NY 