### PR TITLE
Adopt latest Mozilla Release Engineering logic

### DIFF
--- a/lib/travis/build/addons/firefox.rb
+++ b/lib/travis/build/addons/firefox.rb
@@ -18,8 +18,8 @@ module Travis
               sh.echo "Invalid version '#{raw_version}' given.", ansi: :red
             end
 
-            export_source_url
             sh.echo "Installing Firefox #{version}", ansi: :yellow
+            export_source_url
             sh.mkdir install_dir, echo: false, recursive: true
             sh.chown 'travis', install_dir, recursive: true
             sh.cd install_dir, echo: false, stack: true

--- a/lib/travis/build/addons/firefox.rb
+++ b/lib/travis/build/addons/firefox.rb
@@ -57,8 +57,8 @@ module Travis
             "${TRAVIS_HOME}/firefox-#{version}"
           end
 
-          def filename(ext = 'bz2')
-            "firefox-#{version}.tar.#{ext}"
+          def filename(ext = 'tar.bz2')
+            "firefox-#{version}.#{ext}"
           end
 
           def export_source_url

--- a/spec/build/addons/firefox_spec.rb
+++ b/spec/build/addons/firefox_spec.rb
@@ -53,6 +53,16 @@ describe Travis::Build::Addons::Firefox, :sexp do
     it { should include_sexp [:export, ['PATH', "${TRAVIS_HOME}/firefox-latest-beta/firefox:$PATH"], echo: true] }
   end
 
+  context 'given a valid version "latest-dev"' do
+    let(:config) { 'latest-dev' }
+
+    it 'copies correct Mac app dir to the destination' do
+      expect(sexp_find(subject, [:if, "$(uname) = \"Linux\""], [:elif, "$(uname) = \"Darwin\""])).to include_sexp(
+        [:cmd, "sudo cp -a 'firefox/Firefox Developer Edition.app' /Applications"]
+      )
+    end
+  end
+
   context 'given a valid version "latest-esr"' do
     let(:config) { 'latest-esr' }
     it { should include_sexp [:export, ['PATH', "${TRAVIS_HOME}/firefox-latest-esr/firefox:$PATH"], echo: true] }
@@ -62,7 +72,7 @@ describe Travis::Build::Addons::Firefox, :sexp do
     let(:config) { 'latest-unsigned' }
     it "exports latest-unsigned source URL" do
       expect(sexp_find(subject, [:if, "$(uname) = 'Linux'"])).to include_sexp(
-        [:export, ['FIREFOX_SOURCE_URL', "\"https://index.taskcluster.net/v1/task/gecko.v2.mozilla-release.latest.firefox.linux64-add-on-devel/artifacts/public/build/firefox-$(curl -sfL https://index.taskcluster.net/v1/task/gecko.v2.mozilla-release.latest.firefox.linux64-add-on-devel/artifacts/public/build/buildbot_properties.json | jq -r .properties.appVersion).en-US.linux-x86_64-add-on-devel.tar.bz2\""], echo: true]
+        [:export, ['FIREFOX_SOURCE_URL', "\"https://index.taskcluster.net/v1/task/gecko.v2.mozilla-release.latest.firefox.linux64-add-on-devel/artifacts/public/build/target.tar.bz2\""], echo: true]
       )
     end
     it { should include_sexp [:export, ['PATH', "${TRAVIS_HOME}/firefox-latest-unsigned/firefox:$PATH"], echo: true] }
@@ -79,4 +89,3 @@ describe Travis::Build::Addons::Firefox, :sexp do
     it { should_not include_sexp [:export, ['PATH', "${TRAVIS_HOME}/firefox-20.0/firefox:$PATH"], echo: true] }
   end
 end
-


### PR DESCRIPTION
Mozilla's release engineering changed naming practices, which affects
only Mac logic.

Based on IRC chat on 2018-11-08
https://mozilla.logbot.info/ci/20181108#c15582845
and additional leg work
(downloading 
https://download.mozilla.org/?product=firefox-nightly-latest&lang=en-US&os=osx,
etc.), we adapt to the new logic.

Tested [here](https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/731424) for all combination of `firefox: latest*` and `os` values.