### PR TITLE
nix: also print channel version

### DIFF
--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -65,6 +65,7 @@ module Travis
           sh.echo 'Please open any issues at https://github.com/travis-ci/travis-ci/issues/new and cc @domenkozar @garbas @matthewbauer @grahamc', ansi: :green
 
           sh.cmd "nix-env --version"
+          sh.cmd "nix-instantiate --eval -E 'with import <nixpkgs> {}; lib.version or lib.nixpkgsVersion'"
         end
 
         def script


### PR DESCRIPTION
Using the hash from lib.version allows to locally
reproduce the exact same nixpkgs version,
which makes reproducing build failures a lot easier.