### PR TITLE
Switch to http for hhvm (#1589)

### DIFF
--- a/lib/travis/build/appliances/fix_hhvm_source.rb
+++ b/lib/travis/build/appliances/fix_hhvm_source.rb
@@ -11,7 +11,7 @@ module Travis
               sudo sed -i /hhvm/d /etc/apt/sources.list
               if [[ $(lsb_release -cs) = trusty ]]; then
                 sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94
-                sudo add-apt-repository "deb [arch=amd64] https://dl.hhvm.com/ubuntu $(lsb_release -sc) main"
+                sudo add-apt-repository "deb [arch=amd64] http://dl.hhvm.com/ubuntu $(lsb_release -sc) main"
               fi
             fi &>/dev/null
           EOF


### PR DESCRIPTION
This is a backport for `enterprise-2.2` of #1589