### PR TITLE
C#: Shellescape solution name

### DIFF
--- a/lib/travis/build/script/csharp.rb
+++ b/lib/travis/build/script/csharp.rb
@@ -193,12 +193,12 @@ View valid versions of \"dotnet\" at https://docs.travis-ci.com/user/languages/c
         end
 
         def install
-          sh.cmd "nuget restore #{config_solution}", retry: true if is_mono_enabled && config_solution && !is_mono_2_10_8 && !is_mono_3_2_8
+          sh.cmd "nuget restore #{config_solution.shellescape}", retry: true if is_mono_enabled && config_solution && !is_mono_2_10_8 && !is_mono_3_2_8
         end
 
         def script
           if config_solution && is_mono_enabled
-            sh.cmd "#{mono_build_cmd} /p:Configuration=Release #{config_solution}", timing: true
+            sh.cmd "#{mono_build_cmd} /p:Configuration=Release #{config_solution.shellescape}", timing: true
           else
             sh.failure 'No solution or script defined, exiting'
           end

--- a/spec/build/script/csharp_spec.rb
+++ b/spec/build/script/csharp_spec.rb
@@ -209,6 +209,12 @@ describe Travis::Build::Script::Csharp, :sexp do
       data[:config][:os] = 'linux'
       should include_sexp [:cmd, 'nuget restore foo.sln', assert: true, echo: true, timing: true, retry: true]
     end
+
+    it 'correctly shellescapes solutions' do
+      data[:config][:solution] = 'test shellescape.sln'
+      data[:config][:os] = 'linux'
+      should include_sexp [:cmd, 'nuget restore test\ shellescape.sln', assert: true, echo: true, timing: true, retry: true]
+    end
   end
 
   describe 'script' do
@@ -219,6 +225,12 @@ describe Travis::Build::Script::Csharp, :sexp do
     it 'builds specified solution' do
       data[:config][:solution] = 'foo.sln'
       should include_sexp [:cmd, 'msbuild /p:Configuration=Release foo.sln', echo: true, timing: true]
+    end
+
+    it 'correctly shellescapes solutions' do
+      data[:config][:solution] = 'test shellescape.sln'
+      data[:config][:os] = 'linux'
+      should include_sexp [:cmd, 'msbuild /p:Configuration=Release test\ shellescape.sln', assert: true, echo: true, timing: true]
     end
   end
 

--- a/spec/build/script/csharp_spec.rb
+++ b/spec/build/script/csharp_spec.rb
@@ -230,7 +230,7 @@ describe Travis::Build::Script::Csharp, :sexp do
     it 'correctly shellescapes solutions' do
       data[:config][:solution] = 'test shellescape.sln'
       data[:config][:os] = 'linux'
-      should include_sexp [:cmd, 'msbuild /p:Configuration=Release test\ shellescape.sln', assert: true, echo: true, timing: true]
+      should include_sexp [:cmd, 'msbuild /p:Configuration=Release test\ shellescape.sln', echo: true, timing: true]
     end
   end
 


### PR DESCRIPTION
Fixes issue raised on the [Travis-CI community](https://travis-ci.community/t/visual-basic-build-failing-if-there-is-a-space-in-a-solution-file/498)

This shell escapes the solution name to support solutions with spaces in the filename or other reserved characters.