### PR TITLE
Stop disabling the gradle daemon

### DIFF
--- a/lib/travis/build/script/shared/jdk.rb
+++ b/lib/travis/build/script/shared/jdk.rb
@@ -42,8 +42,6 @@ module Travis
           sh.if '-f build.gradle || -f build.gradle.kts' do
             sh.export 'TERM', 'dumb'
           end
-
-          sh.cmd 'mkdir -p ~/.gradle && echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties', echo: false, timing: false
         end
 
         def announce


### PR DESCRIPTION
It's been more than a year since this has stopped being the recommendation: https://github.com/gradle/gradle/issues/2824