### PR TITLE
Add support for TruffleRuby in TravisCI

### DIFF
--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -71,6 +71,7 @@ module Travis
           def rvm_strategy
             return :use_ruby_head    if ruby_version.include?('ruby-head')
             return :use_default_ruby if ruby_version == 'default'
+            return :use_truffleruby  if ruby_version.include?('truffleruby')
             :use_ruby_version
           end
 
@@ -105,6 +106,17 @@ module Travis
           def use_rvm_default_ruby
             sh.fold('rvm') do
               sh.cmd "rvm use default", timing: true
+            end
+          end
+
+          def use_truffleruby
+            skip_deps_install # Travis' LLVM 5.0 is not recognized by RVM
+            sh.fold('rvm') do
+              # TruffleRuby has frequent (~monthly) releases,
+              # use latest RVM to have the latest version available.
+              sh.cmd "rvm get master"
+              sh.cmd "rvm install #{ruby_version}"
+              sh.cmd "rvm use #{ruby_version}"
             end
           end
 

--- a/spec/build/script/ruby_spec.rb
+++ b/spec/build/script/ruby_spec.rb
@@ -199,4 +199,23 @@ describe Travis::Build::Script::Ruby, :sexp do
       should include_sexp [:cmd, "rvm autolibs disable", assert: true]
     end
   end
+
+  context 'when testing with truffleruby' do
+    before :each do
+      data[:config][:rvm] = 'truffleruby'
+    end
+
+    it 'uses latest rvm' do
+      should include_sexp [:cmd, "rvm get master", assert: true, echo: true, timing: true]
+    end
+
+    it 'sets autolibs to disable' do
+      should include_sexp [:cmd, "rvm autolibs disable", assert: true]
+    end
+
+    it 'uses rvm install and rvm use' do
+      should include_sexp [:cmd, "rvm install truffleruby", assert: true, echo: true, timing: true]
+      should include_sexp [:cmd, "rvm use truffleruby", assert: true, echo: true, timing: true]
+    end
+  end
 end


### PR DESCRIPTION
This should fix https://github.com/travis-ci/travis-ci/issues/9803
See the comments in the code as for why we need special handling in `travis-build` for TruffleRuby.

I added specs (they pass locally), and also successfully ran a Docker image with:
`.travis.yml`:
```yml
language: ruby
rvm: truffleruby
script:
- ruby -v -ropen-uri -e 'puts open("https://rubygems.org/") {|f| f.read(1024) }'
```
Steps:
```
# Augment Docker Base Device Size to 20GB
docker run --name travis-debug -dit travisci/ci-garnet:packer-1512502276-986baf0 /sbin/init
docker exec -it travis-debug bash -l
su - travis
git clone https://github.com/eregon/travis-build.git
cd travis-build/
bundle install
gem install travis
# Change .travis.yml to the above
bundle exec travis compile --no-interactive > ci.sh
# comment out travis_run_checkout at the end of ci.sh
bash ci.sh
```