### PR TITLE
Dynamic compiler installation for Linux C/C++ builds

### DIFF
--- a/lib/travis/build/script/c.rb
+++ b/lib/travis/build/script/c.rb
@@ -57,9 +57,9 @@ module Travis
             pkgs = [ compiler, 'libstdc++6' ]
 
             case compiler
-            when /^gcc(-\d+(\.\d+)*)?/
+            when /^gcc(-\d+(\.\d+)*)?/i
               apt_repo_command = "sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test"
-            when /^clang(-\d+(\.\d+)*)?/
+            when /^clang(-\d+(\.\d+)*)?/i
               sh.if "$(lsb_release -cs) = trusty" do
                 sh.cmd "sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test"
               end

--- a/lib/travis/build/script/c.rb
+++ b/lib/travis/build/script/c.rb
@@ -60,7 +60,7 @@ module Travis
             when /^gcc(-\d+(\.\d+)*)?/i
               apt_repo_command = "sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test"
             when /^clang(-\d+(\.\d+)*)?/i
-              sh.if "$(lsb_release -cs) = trusty" do
+              sh.if "$(command -v lsb_release) && $(lsb_release -cs) = trusty" do
                 sh.cmd "sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test"
               end
               apt_key_command = "wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -"
@@ -70,7 +70,7 @@ module Travis
               return
             end
 
-            sh.if "! $(command -v #{compiler})" do
+            sh.if "$(command -v lsb_release) && ! $(command -v #{compiler})" do
               sh.newline
               sh.fold "compiler.install" do
                 sh.echo "#{compiler} is not found. Installing"

--- a/lib/travis/build/script/c.rb
+++ b/lib/travis/build/script/c.rb
@@ -16,6 +16,11 @@ module Travis
           end
         end
 
+        def configure
+          super
+          install_compiler(compiler)
+        end
+
         def announce
           super
           sh.cmd "#{compiler} --version"
@@ -46,6 +51,39 @@ module Travis
 
           def compiler
             config[:compiler].to_s
+          end
+
+          def install_compiler(compiler)
+            pkgs = [ compiler, 'libstdc++6' ]
+
+            case compiler
+            when /^gcc(-\d+(\.\d+)*)?/
+              apt_repo_command = "sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test"
+            when /^clang(-\d+(\.\d+)*)?/
+              sh.if "$(lsb_release -cs) = trusty" do
+                sh.cmd "sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test"
+              end
+              apt_key_command = "wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -"
+              apt_repo_command = "echo \"deb https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)#{$1} main\"  | sudo tee /etc/apt/sources.list.d/llvm.list >/dev/null"
+            else
+              sh.echo "Unknown compiler: #{compiler}", ansi: :yellow
+              return
+            end
+
+            sh.if "! $(command -v #{compiler})" do
+              sh.newline
+              sh.fold "compiler.install" do
+                sh.echo "#{compiler} is not found. Installing"
+                sh.if "$(lsb_release -cs) = trusty && #{compiler} =~ ^clang" do
+                  sh.cmd "sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test"
+                end
+
+                sh.cmd apt_key_command if apt_key_command
+                sh.cmd apt_repo_command
+                sh.cmd "sudo apt-get update >& /dev/null"
+                sh.cmd "sudo apt-get install -y #{pkgs.join(' ')}"
+              end
+            end
           end
       end
     end

--- a/lib/travis/build/script/cpp.rb
+++ b/lib/travis/build/script/cpp.rb
@@ -81,7 +81,7 @@ module Travis
           end
 
           def install_compiler(compiler)
-            pkgs = [ compiler, 'libstdc++6' ]
+            pkgs = [ cc, 'libstdc++6' ]
 
             case compiler
             when GCC_REGEXP

--- a/lib/travis/build/script/cpp.rb
+++ b/lib/travis/build/script/cpp.rb
@@ -87,7 +87,7 @@ module Travis
             when GCC_REGEXP
               apt_repo_command = "sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test"
             when CLANG_REGEXP
-              sh.if "$(lsb_release -cs) = trusty" do
+              sh.if "$(command -v lsb_release) && $(lsb_release -cs) = trusty" do
                 sh.cmd "sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test"
               end
               apt_key_command = "wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -"
@@ -101,7 +101,7 @@ module Travis
               sh.newline
               sh.fold "compiler.install" do
                 sh.echo "#{compiler} is not found. Installing"
-                sh.if "$(lsb_release -cs) = trusty && #{compiler} =~ ^clang" do
+                sh.if "$(command -v lsb_release) && $(lsb_release -cs) = trusty && #{compiler} =~ ^clang" do
                   sh.cmd "sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test"
                 end
 

--- a/lib/travis/build/script/cpp.rb
+++ b/lib/travis/build/script/cpp.rb
@@ -6,6 +6,9 @@ module Travis
           compiler: 'g++'
         }
 
+        GCC_REGEXP   = /^g(?:cc|\+\+)(-\d+(\.\d+)*)?/i
+        CLANG_REGEXP = /^clang(?:\+\+)?(-\d+(\.\d+)*)?/i
+
         def export
           super
           sh.export 'TRAVIS_COMPILER', compiler
@@ -57,9 +60,9 @@ module Travis
 
           def cxx
             case compiler
-            when /^g(?:cc|\+\+)(-\d+(\.\d+)*)?/i then
+            when GCC_REGEXP then
               "g++#{$1}"
-            when /^clang(?:\+\+)?(-\d+(\.\d+)*)?/i then
+            when CLANG_REGEXP then
               "clang++#{$1}"
             else
               'g++'
@@ -68,9 +71,9 @@ module Travis
 
           def cc
             case compiler
-            when /^g(?:cc|\+\+)(-\d+(\.\d+)*)?/i then
+            when GCC_REGEXP then
               "gcc#{$1}"
-            when /^clang(?:\+\+)?(-\d+(\.\d+)*)?/i then
+            when CLANG_REGEXP then
               "clang#{$1}"
             else
               'gcc'
@@ -81,9 +84,9 @@ module Travis
             pkgs = [ compiler, 'libstdc++6' ]
 
             case compiler
-            when /^gcc(?:\+\+)?(-\d(\.\d)*)?/
+            when GCC_REGEXP
               apt_repo_command = "sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test"
-            when /^clang(?:\+\+)?(-\d(\.\d)*)?/
+            when CLANG_REGEXP
               sh.if "$(lsb_release -cs) = trusty" do
                 sh.cmd "sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test"
               end

--- a/spec/build/script/cpp_spec.rb
+++ b/spec/build/script/cpp_spec.rb
@@ -90,6 +90,27 @@ describe Travis::Build::Script::Cpp, :sexp do
     should include_sexp [:cmd, 'gcc --version', echo: true]
   end
 
+  describe 'clang++-7 given as compiler' do
+    before :each do
+      data[:config][:compiler] = 'clang++-7'
+    end
+
+    it { store_example( name: 'clang++-7' )}
+
+    it 'sets CC to clang-7' do
+      should include_sexp [:export, ['CC', 'clang-7'], echo: true]
+    end
+
+    it 'sets CXX to clang++-7' do
+      should include_sexp [:export, ['CXX', 'clang++-7'], echo: true]
+    end
+  end
+
+  it 'runs gcc --version' do
+    data[:config][:compiler] = 'gcc'
+    should include_sexp [:cmd, 'gcc --version', echo: true]
+  end
+
   it 'runs ./configure && make && make test' do
     should include_sexp [:cmd, './configure && make && make test', echo: true, timing: true]
   end


### PR DESCRIPTION
This PR adds the ability to install gcc and clang on the fly _**for Linux builds**_.

# How is compiler versions found?

In `language: c` and `language: cpp` builds, we detect gcc and clang versions using the following regular expressions:

|  | C | C++ |
|--|--|--|
| gcc | `/^gcc(-\d+(\.\d+)*)?/i` | `/^g(?:cc\|\+\+)(-\d+(\.\d+)*)?/i`  |
| clang | `/^clang(-\d+(\.\d+)*)?/i` | `/^clang(?:\+\+)?(-\d+(\.\d+)*)?/i` |

And use `$1` in the match to drive package installations.

# How do we decide to trigger package installation?

The compiler command is assumed to be given in the `compiler` value in the configuration. For example, given:

```yaml
language: c
compiler:
  - gcc-6
```

and the command `gcc-6` is not available, we proceed to install APT packages.

## Which packages are installed?

First, appropriate apt repository is added.
* for GCC, ppa:ubuntu-toolchain-r/test
* for clang, see https://apt.llvm.org/

Then, the following packages will be installed:
* for C builds, value given by `compiler`
* for C++ builds, value computed for `CC` (e.g., `gcc-6` for gcc, `clang-7` for clang), even when `compiler` looks different (e.g., `g++-6` or `clang++-7`).

In all cases, `libstdc++-6` is also installed (if necessary).