### PR TITLE
Add back explicit APT https proxy disabling

### DIFF
--- a/lib/travis/build/bash/travis_setup_apt_proxy.bash
+++ b/lib/travis/build/bash/travis_setup_apt_proxy.bash
@@ -22,6 +22,10 @@ travis_setup_apt_proxy() {
     cat <<EOCONF
 Acquire::http::Proxy "${TRAVIS_APT_PROXY}";
 Acquire::https::Proxy false;
+Acquire::http::Proxy::download.oracle.com "DIRECT";
+Acquire::https::Proxy::download.oracle.com "DIRECT";
+Acquire::http::Proxy::*.java.net "DIRECT";
+Acquire::https::Proxy::*.java.net "DIRECT";
 EOCONF
   ) | sudo tee "${dest_dir}/99-travis-apt-proxy" &>/dev/null
 }

--- a/lib/travis/build/bash/travis_setup_apt_proxy.bash
+++ b/lib/travis/build/bash/travis_setup_apt_proxy.bash
@@ -21,6 +21,7 @@ travis_setup_apt_proxy() {
   (
     cat <<EOCONF
 Acquire::http::Proxy "${TRAVIS_APT_PROXY}";
+Acquire::https::Proxy false;
 EOCONF
   ) | sudo tee "${dest_dir}/99-travis-apt-proxy" &>/dev/null
 }


### PR DESCRIPTION
because this is how it is supposed to work and ~the problem with
oracle-java8-installer internal wget needs to be addressed separately~ the explicit `"DIRECT"` overrides work correctly when wget is run during oracle-java8-installer installation ([ref](https://github.com/hotice/oracle-java8-installer/blob/4b1ecee89aae4168844570fed3270b32e7230114/oracle-java8-installer.postinst#L111-L135)).