### PR TITLE
Make preinstalled javas work on xenial and osx

### DIFF
--- a/lib/travis/build/bash/travis_find_jdk_path.bash
+++ b/lib/travis/build/bash/travis_find_jdk_path.bash
@@ -1,0 +1,19 @@
+travis_find_jdk_path() {
+  local vendor version jdkpath result jdk
+  jdk="$1"
+  vendor="$2"
+  version="$3"
+  if [[ "$vendor" == "openjdk" ]]; then
+    apt_glob="/usr/lib/jvm/java-1.${version}.*openjdk*"
+  elif [[ "$vendor" == "oracle" ]]; then
+    apt_glob="/usr*/lib/jvm/java-${version}-oracle"
+  fi
+  shopt -s nullglob
+  for jdkpath in /usr*/local/lib/jvm/"$jdk" $apt_glob; do
+    [[ ! -d "$jdkpath" ]] && continue
+    result="$jdkpath"
+    break
+  done
+  shopt -u nullglob
+  echo "$result"
+}

--- a/lib/travis/build/bash/travis_install_jdk.bash
+++ b/lib/travis/build/bash/travis_install_jdk.bash
@@ -10,9 +10,12 @@ travis_install_jdk() {
   fi
   mkdir -p ~/bin
   url="https://$TRAVIS_APP_HOST/files/install-jdk.sh"
-  if ! travis_cmd "curl -sLf $url >~/bin/install-jdk.sh" --echo; then
+  if ! travis_download "$url" ~/bin/install-jdk.sh; then
     url="https://raw.githubusercontent.com/sormuras/bach/master/install-jdk.sh"
-    travis_cmd curl\ -sLf\ $url\ \>\~/bin/install-jdk.sh --echo --assert
+    travis_download "$url" ~/bin/install-jdk.sh || {
+      echo "${ANSI_RED}Could not acquire install-jdk.sh. Stopping build.${ANSI_RESET}">/dev/stderr
+      travis_terminate 2
+    }
   fi
   chmod +x ~/bin/install-jdk.sh
   travis_cmd "export JAVA_HOME=~/$jdk" --echo

--- a/lib/travis/build/bash/travis_install_jdk.bash
+++ b/lib/travis/build/bash/travis_install_jdk.bash
@@ -1,0 +1,22 @@
+travis_install_jdk() {
+  local url vendor version license
+  vendor="$1"
+  version="$2"
+  if [[ "$vendor" == openjdk ]]; then
+    license=GPL
+  elif [[ "$vendor" == oracle ]]; then
+    license=BCL
+  fi
+  mkdir -p ~/bin
+  url="https://$TRAVIS_APP_HOST/files/install-jdk.sh"
+  if ! travis_cmd "curl -sLf $url >~/bin/install-jdk.sh" --echo; then
+    url="https://raw.githubusercontent.com/sormuras/bach/master/install-jdk.sh"
+    travis_cmd curl\ -sLf\ $url\ \>\~/bin/install-jdk.sh --echo --assert
+  fi
+  chmod +x ~/bin/install-jdk.sh
+  travis_cmd 'export JAVA_HOME=~/jdk' --echo
+  # shellcheck disable=SC2016
+  travis_cmd 'export PATH="$JAVA_HOME/bin:$PATH"' --echo
+  # shellcheck disable=2088
+  travis_cmd "~/bin/install-jdk.sh --target \"$JAVA_HOME\" --workspace \"$TRAVIS_HOME/.cache/install-jdk\" --feature \"$version\" --license \"$license\"" --echo --assert
+}

--- a/lib/travis/build/bash/travis_install_jdk.bash
+++ b/lib/travis/build/bash/travis_install_jdk.bash
@@ -13,7 +13,7 @@ travis_install_jdk() {
   if ! travis_download "$url" ~/bin/install-jdk.sh; then
     url="https://raw.githubusercontent.com/sormuras/bach/master/install-jdk.sh"
     travis_download "$url" ~/bin/install-jdk.sh || {
-      echo "${ANSI_RED}Could not acquire install-jdk.sh. Stopping build.${ANSI_RESET}">/dev/stderr
+      echo "${ANSI_RED}Could not acquire install-jdk.sh. Stopping build.${ANSI_RESET}" >/dev/stderr
       travis_terminate 2
     }
   fi

--- a/lib/travis/build/bash/travis_install_jdk.bash
+++ b/lib/travis/build/bash/travis_install_jdk.bash
@@ -1,7 +1,8 @@
 travis_install_jdk() {
-  local url vendor version license
-  vendor="$1"
-  version="$2"
+  local url vendor version license jdk
+  jdk="$1"
+  vendor="$2"
+  version="$3"
   if [[ "$vendor" == openjdk ]]; then
     license=GPL
   elif [[ "$vendor" == oracle ]]; then
@@ -14,7 +15,7 @@ travis_install_jdk() {
     travis_cmd curl\ -sLf\ $url\ \>\~/bin/install-jdk.sh --echo --assert
   fi
   chmod +x ~/bin/install-jdk.sh
-  travis_cmd 'export JAVA_HOME=~/jdk' --echo
+  travis_cmd "export JAVA_HOME=~/$jdk" --echo
   # shellcheck disable=SC2016
   travis_cmd 'export PATH="$JAVA_HOME/bin:$PATH"' --echo
   # shellcheck disable=2088

--- a/lib/travis/build/bash/travis_jinfo_file.bash
+++ b/lib/travis/build/bash/travis_jinfo_file.bash
@@ -1,0 +1,10 @@
+travis_jinfo_file() {
+  local vendor version
+  vendor="$1"
+  version="$2"
+  if [[ "$vendor" == oracle ]]; then
+    echo ".java-${version}-${vendor}.jinfo"
+  elif [[ "$vendor" == openjdk ]]; then
+    echo ".java-1.${version}.*-${vendor}-*.jinfo"
+  fi
+}

--- a/lib/travis/build/bash/travis_remove_from_path.bash
+++ b/lib/travis/build/bash/travis_remove_from_path.bash
@@ -1,0 +1,8 @@
+travis_remove_from_path() {
+  local target="$1"
+  PATH="$(echo "$PATH" |
+    sed -e "s,\\(:\\|^\\)$target\\(:\\|$\\),:,g" \
+      -e 's/::\+/:/g' \
+      -e 's/:$//' \
+      -e 's/^://')"
+}

--- a/lib/travis/build/bash/travis_setup_java.bash
+++ b/lib/travis/build/bash/travis_setup_java.bash
@@ -1,0 +1,22 @@
+travis_setup_java() {
+  local jdkpath jdk vendor version
+  jdk="$1"
+  vendor="$2"
+  version="$3"
+  jdkpath="$(travis_find_jdk_path "$jdk" "$vendor" "$version")"
+  if [[ -z "$jdkpath" ]]; then
+    travis_install_jdk "$vendor" "$version"
+  elif compgen -G "${jdkpath%/*}/$(travis_jinfo_file "$vendor" "$version")" &>/dev/null &&
+    declare -f jdk_switcher &>/dev/null; then
+    travis_cmd "jdk_switcher use \"$jdk\"" --echo --assert
+    if [[ -f ~/.bash_profile.d/travis_jdk.bash ]]; then
+      sed -i '/export \(PATH\|JAVA_HOME\)=/d' ~/.bash_profile.d/travis_jdk.bash
+    fi
+  else
+    export JAVA_HOME="$jdkpath"
+    export PATH="$JAVA_HOME/bin:$PATH"
+    if [[ -f ~/.bash_profile.d/travis_jdk.bash ]]; then
+      sed -i ",export JAVA_HOME=,s,=.\\+,=\"$JAVA_HOME\"," ~/.bash_profile.d/travis_jdk.bash
+    fi
+  fi
+}

--- a/lib/travis/build/bash/travis_setup_java.bash
+++ b/lib/travis/build/bash/travis_setup_java.bash
@@ -5,7 +5,12 @@ travis_setup_java() {
   version="$3"
   jdkpath="$(travis_find_jdk_path "$jdk" "$vendor" "$version")"
   if [[ -z "$jdkpath" ]]; then
-    travis_install_jdk "$vendor" "$version"
+    if [[ "$TRAVIS_OS_NAME" == osx ]]; then
+      [[ "$(java -version |& awk '/HotSpot/{print "oracle";exit};END{print "openjdk"}')" == "$vendor"]] &&
+        java -version |& awk -F"'" -v version=$version 'BEGIN{if(version<9)version = "1\."version}{if ($2~version){exit 0} else {exit 1}' &&
+        return
+    fi
+    travis_install_jdk "$jdk" "$vendor" "$version"
   elif compgen -G "${jdkpath%/*}/$(travis_jinfo_file "$vendor" "$version")" &>/dev/null &&
     declare -f jdk_switcher &>/dev/null; then
     travis_cmd "jdk_switcher use \"$jdk\"" --echo --assert

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -56,14 +56,19 @@ module Travis
         travis_cmd
         travis_decrypt
         travis_download
+        travis_find_jdk_path
         travis_fold
         travis_footer
+        travis_install_jdk
         travis_internal_ruby
         travis_jigger
+        travis_jinfo_file
         travis_nanoseconds
+        travis_remove_from_path
         travis_result
         travis_retry
         travis_setup_env
+        travis_setup_java
         travis_temporary_hacks
         travis_terminate
         travis_time_finish

--- a/lib/travis/build/script/shared/jdk.rb
+++ b/lib/travis/build/script/shared/jdk.rb
@@ -2,38 +2,33 @@ module Travis
   module Build
     class Script
       module Jdk
+
         OPENJDK_ALTERNATIVE = {
           'oraclejdk10' => 'openjdk10'
         }
 
         def configure
           super
+          return unless specifies_jdk?
 
           if jdk_deprecated?
             sh.terminate 2, "#{jdk} is deprecated. See https://www.oracle.com/technetwork/java/javase/eol-135779.html for more details. Consider using #{OPENJDK_ALTERNATIVE[jdk]} instead.", ansi: :red
           end
 
-          if uses_jdk?
-            if use_install_jdk?(config[:jdk])
-              download_install_jdk
+          return if jdk == 'default'
 
-              sh.if "-f install-jdk.sh" do
-                sh.export "JAVA_HOME", "${TRAVIS_HOME}/#{jdk}"
-                sh.cmd "bash install-jdk.sh #{install_jdk_args config[:jdk]} --target $JAVA_HOME --workspace #{cache_dir}", echo: true, assert: true
-                sh.export "PATH", "$JAVA_HOME/bin:$PATH"
-                sh.raw 'set +e', echo: false
-              end
-            else
-              sh.if '"$(command -v jdk_switcher &>/dev/null; echo $?)" == 0' do
-                sh.cmd "jdk_switcher use #{config[:jdk]}", assert: true, echo: true, timing: false
-              end
-            end
+          vendor, version = jdk_info(jdk)
+
+          sh.echo
+          sh.fold 'install_jdk' do
+            sh.echo "Installing #{jdk}", ansi: :yellow
+            sh.raw("travis_setup_java #{jdk} #{vendor} #{version}", timing: true)
           end
         end
 
         def export
           super
-          sh.export 'TRAVIS_JDK_VERSION', config[:jdk], echo: false if uses_jdk?
+          sh.export 'TRAVIS_JDK_VERSION', config[:jdk], echo: false if specifies_jdk?
         end
 
         def setup
@@ -49,7 +44,9 @@ module Travis
         end
         
         def disable_gradle_daemon
-          sh.cmd 'mkdir -p ~/.gradle && echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties', echo: false, timing: false
+          sh.if '"$TRAVIS_DIST" == precise || "$TRAVIS_DIST" == trusty' do
+            sh.cmd 'mkdir -p ~/.gradle && echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties', echo: false, timing: false
+          end
         end
 
         def announce
@@ -61,46 +58,31 @@ module Travis
         end
 
         def cache_slug
-          return super unless uses_jdk?
+          return super unless specifies_jdk?
           super << '--jdk-' << config[:jdk].to_s
         end
 
         private
+          def jdk
+            config[:jdk].gsub(/\s/,'')
+          end
 
           def uses_java?
             true
           end
 
-          def uses_jdk?
+          def specifies_jdk?
             !!config[:jdk]
           end
 
-          def jdk
-            config[:jdk].gsub(/\s/,'')
-          end
-
-          def use_install_jdk?(jdk)
-            ! install_jdk_args(jdk).empty?
-          end
-
-          def download_install_jdk
-            return if app_host.empty?
-            sh.cmd "curl -sf -O https://#{app_host}/files/install-jdk.sh"
-          end
-
-          def install_jdk_args(jdk)
-            args_for = {
-              # OpenJDK
-              'openjdk-ea'   => '-L GPL',
-              'openjdk9'     => '-F 9  -L GPL',
-              'openjdk10'    => '-F 10 -L GPL',
-              'openjdk11'    => '-F 11 -L GPL',
-              # OracleJDK
-              'oraclejdk-ea' => '-L BCL',
-              'oraclejdk10'  => '-F 10 -L BCL',
-              'oraclejdk11'  => '-F 11 -L BCL',
-            }
-            args_for.fetch(jdk, '')
+          def jdk_info(jdk)
+            m = jdk.match(/(?<vendor>[a-z]+)-?(?<version>.+)?/)
+            if m[:vendor]. start_with? 'oracle'
+              vendor = 'oracle'
+            elsif m[:vendor].start_with? 'openjdk'
+              vendor = 'openjdk'
+            end
+            [ vendor, m[:version] ]
           end
 
           def cache_dir
@@ -108,7 +90,7 @@ module Travis
           end
 
           def jdk_deprecated?
-            uses_jdk? && OPENJDK_ALTERNATIVE.keys.include?(jdk)
+            specifies_jdk? && OPENJDK_ALTERNATIVE.keys.include?(jdk)
           end
       end
     end

--- a/spec/build/script/shared/jdk.rb
+++ b/spec/build/script/shared/jdk.rb
@@ -27,44 +27,6 @@ shared_examples_for 'a jdk build sexp' do
     end
   end
 
-  describe 'if jdk is given' do
-    before :each do
-      data[:config][:jdk] = 'openjdk7'
-    end
-
-    it 'sets TRAVIS_JDK_VERSION' do
-      should include_sexp export_jdk_version
-    end
-
-    it 'runs jdk_switcher' do
-      if_jdk_switcher = sexp_find(subject, sexp)
-      expect(if_jdk_switcher).to include_sexp run_jdk_switcher
-    end
-  end
-
-  describe 'if jdk is deprecated' do
-    before :each do
-      data[:config][:jdk] = 'oraclejdk10'
-    end
-
-    it 'terminates with status 2' do
-      should include_sexp( [:raw, "travis_terminate 2"])
-    end
-  end
-
-  context "jdk is set to oraclejdk11" do
-    before :each do
-      data[:config][:jdk] = 'oraclejdk11'
-    end
-
-    it { store_example(name: 'oraclejdk11') }
-
-    it "downloads install-jdk.sh" do
-      should include_sexp( [:export, ["JAVA_HOME", "${TRAVIS_HOME}/oraclejdk11"], echo: true] )
-      should include_sexp( [:cmd, "curl -sf -O https://build.travis-ci.org/files/install-jdk.sh"])
-    end
-  end
-
   describe 'if build.gradle exists' do
     let(:sexp) { sexp_find(subject, [:if, '-f build.gradle || -f build.gradle.kts'], [:then]) }
 


### PR DESCRIPTION
- Use information on disk on linux to determine the existing jdks
- Use install-jdk whenever appropriate
- store the files on the same location as currently on master
- Ensure the installed jdks on osx are used if available (https://staging.travis-ci.org/joepvd/travis-staging-test/builds/736558)