### PR TITLE
We don't need to explicitly add the marutter key anymore

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -69,8 +69,10 @@ module Travis
                 sh.cmd 'sudo add-apt-repository '\
                   "\"deb #{repos[:CRAN]}/bin/linux/ubuntu "\
                   "$(lsb_release -cs)/\""
-                sh.cmd 'apt-key adv --keyserver ha.pool.sks-keyservers.net '\
-                  '--recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9', sudo: true
+
+                # This key is added implicitly by the marutter PPA below
+                #sh.cmd 'apt-key adv --keyserver ha.pool.sks-keyservers.net '\
+                  #'--recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9', sudo: true
 
                 # Add marutter's c2d4u plus ppa dependencies as listed on launchpad
                 if r_version_less_than('3.5.0')


### PR DESCRIPTION
Because it is retrieved implicitly when adding the marutter PPAs

Fixes https://travis-ci.community/t/ubuntu-keyserver-is-still-failing-builds/648

See also the discussion in https://github.com/travis-ci/travis-build/pull/1618

I left the old line commented, mainly for future reference, because otherwise adding a new repository without the key looks weird.