### PR TITLE
Ensure /etc/hosts ends with newline

### DIFF
--- a/lib/travis/build/appliances/put_localhost_first.rb
+++ b/lib/travis/build/appliances/put_localhost_first.rb
@@ -12,7 +12,7 @@ module Travis
           # reconstruct /etc/hosts
           sh.raw %q(cat /tmp/hosts_sans_127_0_0_1 | sudo tee /etc/hosts > /dev/null)
           sh.raw %q(echo -n "127.0.0.1 localhost " | sudo tee -a /etc/hosts > /dev/null)
-          sh.raw %q(cat /tmp/hosts_127_0_0_1 | sudo tee -a /etc/hosts > /dev/null)
+          sh.raw %q({ cat /tmp/hosts_127_0_0_1; echo; } | sudo tee -a /etc/hosts > /dev/null)
         end
       end
     end


### PR DESCRIPTION
Querying /etc/hosts from a job does not contain a line containing localhost and 127.0.0.1.

See e.g. https://staging.travis-ci.org/joepvd/travis-staging-test/builds/736810#L153

Ensuring that `/etc/hosts` ends with a newline magically makes the last line not disappear:

https://staging.travis-ci.org/joepvd/travis-staging-test/jobs/736823#L158