### PR TITLE
Export TRAVIS_DEBUG_MODE for debug sessions

### DIFF
--- a/lib/travis/build/appliances/debug_tools.rb
+++ b/lib/travis/build/appliances/debug_tools.rb
@@ -49,6 +49,7 @@ module Travis
             sh.raw 'travis_debug_install'
             sh.echo "Preparing debug sessions."
             sh.raw 'TRAVIS_CMD=travis_debug'
+            sh.raw 'export TRAVIS_DEBUG_MODE=true'
             sh.raw 'travis_debug.sh "$@"'
           sh.raw '}'
         end


### PR DESCRIPTION
This came from a user request and I found it a quite interesting one!

Having `TRAVIS_DEBUG_MODE` env var, or similar, that can be checked during build time could allow users to have a way to change the behavior of their scripts/tests to immediately be more verbose as soon as someone restarts the job in debug mode, as an example.

If we decide to go ahead with this, it'd require some small docs updates as well - I'll take care of these.