### PR TITLE
Retrieve all binaries directly from the PPA rather than the CRAN mirror

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -65,11 +65,6 @@ module Travis
               sh.echo 'Installing R', ansi: :yellow
               case config[:os]
               when 'linux'
-                # Set up our CRAN mirror.
-                sh.cmd 'sudo add-apt-repository '\
-                  "\"deb #{repos[:CRAN]}/bin/linux/ubuntu "\
-                  "$(lsb_release -cs)/\""
-
                 # This key is added implicitly by the marutter PPA below
                 #sh.cmd 'apt-key adv --keyserver ha.pool.sks-keyservers.net '\
                   #'--recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9', sudo: true


### PR DESCRIPTION
This should fix authentication errors due to the removal of the explicit key, e.g.
https://travis-ci.community/t/there-were-unauthenticated-packages-and-y-was-used-without-allow-unauthenticated/1447