### PR TITLE
Allow gradual rollout of Bash-based casher

### DIFF
--- a/lib/travis/build/config.rb
+++ b/lib/travis/build/config.rb
@@ -61,6 +61,7 @@ module Travis
         ),
         apt_safelist_skip: ENV.fetch('TRAVIS_BUILD_APT_SAFELIST_SKIP', '').to_bool,
         auth_disabled: ENV.fetch('TRAVIS_BUILD_AUTH_DISABLED', '').to_bool,
+        bash_casher_pct: ENV.fetch('TRAVIS_BASH_CACHER_PCT', '0'),
         cabal_default: ENV.fetch('TRAVIS_BUILD_CABAL_DEFAULT', '2.0'),
         enable_debug_tools: ENV.fetch(
           'TRAVIS_BUILD_ENABLE_DEBUG_TOOLS',

--- a/lib/travis/build/script/shared/directory_cache/base.rb
+++ b/lib/travis/build/script/shared/directory_cache/base.rb
@@ -280,7 +280,7 @@ module Travis
               if branch = data.cache[:branch]
                 branch
               else
-                edge? ? 'master' : 'production'
+                edge? ? 'master' : use_bash? ? 'bash' : 'production'
               end
             end
 
@@ -307,8 +307,15 @@ module Travis
                   sh.cmd curl_cmd(flags, location, remote_location), cmd_opts
                 end
               else
+                if casher_branch == 'bash'
+                  cmd_opts[:echo] = 'Installing caching utilities, bash version'
+                end
                 sh.cmd curl_cmd(flags, location, (CASHER_URL % casher_branch)), cmd_opts
               end
+            end
+
+            def use_bash?
+              rand * 100 < Travis::Build.config.bash_casher_pct.to_i
             end
 
             def curl_cmd(flags, location, remote_location)

--- a/spec/build/script/directory_cache_spec.rb
+++ b/spec/build/script/directory_cache_spec.rb
@@ -105,4 +105,20 @@ describe Travis::Build::Script::DirectoryCache, :sexp do
       end
     end
   end
+
+  context 'when using Bash casher' do
+    before :each do
+      Travis::Build.config.bash_casher_pct = '100'
+    end
+
+    after :each do
+      Travis::Build.config.bash_casher_pct = '0'
+    end
+
+    let(:config) { { cache: 'bundler' } }
+
+    it "fetches bash casher" do
+      expect(sexp).to include_sexp [:cmd, "curl -sf  -o $CASHER_DIR/bin/casher https://raw.githubusercontent.com/travis-ci/casher/bash/bin/casher", echo: "Installing caching utilities, bash version", timing: true, retry: true]
+    end
+  end
 end


### PR DESCRIPTION
By use of env var `TRAVIS_BASH_CACHER_PCT`. If `rand` yields less than
this, we use the bash version.