### PR TITLE
Homebrew: discard `brew update` output

### DIFF
--- a/lib/travis/build/addons/homebrew.rb
+++ b/lib/travis/build/addons/homebrew.rb
@@ -44,7 +44,7 @@ module Travis
 
         def update_homebrew
           sh.echo "Updating Homebrew", ansi: :yellow
-          sh.cmd "rvm $brew_ruby do brew update", echo: true, timing: true
+          sh.cmd "rvm $brew_ruby do brew update 1>/dev/null", echo: true, timing: true
         end
 
         def config_packages

--- a/spec/build/addons/homebrew_spec.rb
+++ b/spec/build/addons/homebrew_spec.rb
@@ -117,7 +117,7 @@ tap 'heroku/brew'
 
     let(:brew_config) { { update: true } }
 
-    it { should include_sexp [:cmd, 'rvm $brew_ruby do brew update', echo: true, timing: true] }
+    it { should include_sexp [:cmd, 'rvm $brew_ruby do brew update 1>/dev/null', echo: true, timing: true] }
   end
 
   context 'when providing a custom Brewfile' do
@@ -171,7 +171,7 @@ cask 'google-chrome'
 cask 'java8'
     BREWFILE
 
-    it { should include_sexp [:cmd, 'rvm $brew_ruby do brew update', echo: true, timing: true] }
+    it { should include_sexp [:cmd, 'rvm $brew_ruby do brew update 1>/dev/null', echo: true, timing: true] }
     it { should include_sexp [:file, ['~/.Brewfile', brewfile]] }
     it { should include_sexp [:cmd, 'rvm $brew_ruby do brew bundle --verbose --global', echo: true, timing: true] }
     it { should include_sexp [:cmd, 'rvm $brew_ruby do brew bundle --verbose', echo: true, timing: true] }


### PR DESCRIPTION
`brew update` adds 700+ lines to the log.

Make it possible to silence that output via following config:

```
addons:
  homebrew:
    update: silent
```

(If you're in favor of this change, I'll make a PR for the docs as well.)