### PR TITLE
Disable pip progress bar

### DIFF
--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -35,6 +35,7 @@ module Travis
           sh.cmd 'python --version'
           sh.cmd 'pip --version'
           sh.export 'PIP_DISABLE_PIP_VERSION_CHECK', '1', echo: false
+          sh.export 'PIP_PROGRESS_BAR', 'off', echo: false
         end
 
         def setup_cache
@@ -61,7 +62,7 @@ module Travis
         def script
           # This always fails the build, asking the user to provide a custom :script.
           # The Python ecosystem has no good default build command most of the
-          # community aggrees on. Per discussion with jezjez, josh-k and others. MK
+          # community agrees on. Per discussion with jezjez, josh-k and others. MK
           sh.failure SCRIPT_MISSING
         end
 


### PR DESCRIPTION
As discussed in https://github.com/pypa/pip/issues/6101, Travis's logs don't respect the terminal control characters that pip's download progress bar uses. This results in thousands of lines of cruft being added to the logs. In the extreme case of large downloads, like `torch`, this results in [job termination](https://travis-ci.community/t/large-pip-installs-exceed-maximum-log-length/1599). 

This PR disables the use of the progress bar on all pip downloads, at least when `language: python` is set.

@BanzaiMan @native-api