### PR TITLE
[R] Add --no-manual to r_build_args when latex: false

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -163,6 +163,7 @@ module Travis
                 setup_latex
               else
                 config[:r_check_args] << " --no-manual"
+                config[:r_build_args] << " --no-manual"
               end
 
               setup_bioc if needs_bioc?


### PR DESCRIPTION
`R CMD build` usually doesn't build PDF manuals. But, if the manual contains `\Sexprs{}` macro, it does, and it will end up an error when `latex: false` (e.g. https://github.com/tidyverse/dplyr/pull/4085#issuecomment-451810489).

This PR adds `--no-manual` to `r_build_args` as well to avoid the error. (But, sorry, I don't know how to test this...)