### PR TITLE
Hardcode RubyGems version (< 3.0.0) to update to

### DIFF
--- a/lib/travis/build/appliances/update_rubygems.rb
+++ b/lib/travis/build/appliances/update_rubygems.rb
@@ -17,7 +17,11 @@ module Travis
               echo -e "\\033[32;1m** Updating RubyGems to the latest version for security reasons. **\\033[0m"
               echo -e "\\033[32;1m** If you need an older version, you can downgrade with 'gem update --system OLD_VERSION'. **\\033[0m"
               echo ""
-              gem update --system &>/dev/null
+              if [[ "$(travis_vers2int "$(ruby -e 'puts RUBY_VERSION')")" -lt "$(travis_vers2int "2.3.0")" ]]; then
+                gem update --system 2.7.8 &>/dev/null
+              else
+                gem update --system &>/dev/null
+              fi
             fi
           RVMHOOK
 

--- a/lib/travis/build/appliances/update_rubygems.rb
+++ b/lib/travis/build/appliances/update_rubygems.rb
@@ -14,7 +14,7 @@ module Travis
 
             if [[ "$(travis_vers2int "$(gem --version)")" -lt "$(travis_vers2int "#{RUBYGEMS_BASELINE_VERSION}")" ]]; then
               echo ""
-              echo -e "\\033[32;1m** Updating RubyGems to the latest version for security reasons. **\\033[0m"
+              echo -e "\\033[32;1m** Updating RubyGems to the latest compatible version for security reasons. **\\033[0m"
               echo -e "\\033[32;1m** If you need an older version, you can downgrade with 'gem update --system OLD_VERSION'. **\\033[0m"
               echo ""
               if [[ "$(travis_vers2int "$(ruby -e 'puts RUBY_VERSION')")" -lt "$(travis_vers2int "2.3.0")" ]]; then


### PR DESCRIPTION
RubyGems 3.0.0 now requires Ruby 2.3.0, breaking many on-demand
installations of Rubies older than that.
So if our Ruby is older than 2.3.0, we stop at the last 2.7.x.