### PR TITLE
Import new GPG key for RVM when necessary

### DIFF
--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -64,7 +64,7 @@ module Travis
           end
 
           def import_gpg_key
-            sh.cmd "command gpg2 --version &>/dev/null && gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys #{RVM_GPG_KEYS.join(" ")}",
+            sh.cmd "command gpg2 --version &>/dev/null && gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys #{RVM_GPG_KEYS.join(" ")}",
               echo: "Importing new GPG keys for RVM", assert: false
           end
 

--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -23,7 +23,7 @@ module Travis
         RVM_GPG_KEYS = %w(
           409B6B1796C275462A1703113804BB82D39DC0E3
           7D2BAF1CF37B13E2069D6956105BD0E739499BDB
-        ).join(" ")
+        )
 
         def export
           super
@@ -64,7 +64,7 @@ module Travis
           end
 
           def import_gpg_key
-            sh.cmd "command gpg2 --version &>/dev/null && gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys #{RVM_GPG_KEYS}",
+            sh.cmd "command gpg2 --version &>/dev/null && gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys #{RVM_GPG_KEYS.join(" ")}",
               echo: "Importing new GPG keys for RVM", assert: false
           end
 

--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -64,7 +64,7 @@ module Travis
           end
 
           def import_gpg_key
-            sh.cmd "command gpg2 && gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys #{RVM_GPG_KEYS}",
+            sh.cmd "command gpg2 --version &>/dev/null && gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys #{RVM_GPG_KEYS}",
               echo: "Importing new GPG keys for RVM", assert: false
           end
 

--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -20,9 +20,9 @@ module Travis
           '2.5' => '2.5.1'
         }
 
-        RVM_GPG_KEYS = %w(
-          409B6B1796C275462A1703113804BB82D39DC0E3
-          7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+        RVM_GPG_KEY_IDS = %w(
+          mpapis
+          pkuczynski
         )
 
         def export
@@ -64,8 +64,9 @@ module Travis
           end
 
           def import_gpg_key
-            sh.cmd "command gpg2 --version &>/dev/null && gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys #{RVM_GPG_KEYS.join(" ")}",
-              echo: "Importing new GPG keys for RVM", assert: false
+            RVM_GPG_KEY_IDS.each do |id|
+              sh.cmd "command curl -sSL https://rvm.io/#{id}.asc | gpg2 --import -", assert: false 
+            end
           end
 
           def setup_rvm

--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -20,6 +20,11 @@ module Travis
           '2.5' => '2.5.1'
         }
 
+        RVM_GPG_KEYS = %w(
+          409B6B1796C275462A1703113804BB82D39DC0E3
+          7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+        ).join(" ")
+
         def export
           super
           sh.export 'TRAVIS_RUBY_VERSION', version, echo: false if rvm?
@@ -58,6 +63,11 @@ module Travis
             force_187_p371 vers
           end
 
+          def import_gpg_key
+            sh.cmd "command gpg2 && gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys #{RVM_GPG_KEYS}",
+              echo: "Importing new GPG keys for RVM", assert: false
+          end
+
           def setup_rvm
             write_default_gems
             if without_teeny?(version)
@@ -77,6 +87,7 @@ module Travis
 
           def use_ruby_head
             sh.fold('rvm') do
+              import_gpg_key
               sh.echo MSGS[:setup_ruby_head] % ruby_version, ansi: :yellow
               sh.cmd "rvm get stable", assert: false if ruby_version == 'jruby-head'
               sh.export 'ruby_alias', "`rvm alias show #{ruby_version} 2>/dev/null`"
@@ -114,6 +125,7 @@ module Travis
             sh.fold('rvm') do
               # TruffleRuby has frequent (~monthly) releases,
               # use latest RVM to have the latest version available.
+              import_gpg_key
               sh.cmd "rvm get master"
               sh.cmd "rvm install #{ruby_version}"
               sh.cmd "rvm use #{ruby_version}"


### PR DESCRIPTION
For Rubies that require a recent version of RVM
(at the moment TruffleRuby and *ruby-head), we import a new
GPG key so that `rvm get *` succeeds.

The key was indicated by 
https://github.com/rvm/rvm/issues/4561#issuecomment-450552429