### PR TITLE
R: Add new env var to r.rb

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -49,6 +49,7 @@ module Travis
           sh.export 'R_LIBS_USER', '~/R/Library', echo: false
           sh.export 'R_LIBS_SITE', '/usr/local/lib/R/site-library:/usr/lib/R/site-library', echo: false
           sh.export '_R_CHECK_CRAN_INCOMING_', 'false', echo: false
+          sh.export '_R_CHECK_LENGTH_1_LOGIC2_', 'true', echo: false
           sh.export 'NOT_CRAN', 'true', echo: false
         end
 


### PR DESCRIPTION
In September, [an "experimental" environment variable was added to the development version of R](https://github.com/wch/r-source/blob/060d5157ab3d5a49d87b69d16f6806f2fb41663d/doc/NEWS.Rd#L186-L189) to make package checks fail when the `&&` or `||` operator was used inappropriately. [CRAN](https://cran.r-project.org/) appears to have enabled this in their incoming package checks, a fact I discovered when a submission to them was rejected yesterday. [Setting this env var in my .travis.yml](https://github.com/Crunch-io/rcrunch/commit/617df6151d76d4c0a42e2096568336c0bca7f3ff#diff-354f30a63fb0907d4ad57269548329e3R13) reproduced the failure on Travis, and we were able to fix and successfully resubmit the package to CRAN. 

Since others may be affected by this policy change, I thought it would be good to add this environment variable to the standard R build configuration.

cc @jimhester @jeroen 