### PR TITLE
Match only [0-9] and '.' in travis_vers2int()

### DIFF
--- a/lib/travis/build/bash/travis_vers2int.bash
+++ b/lib/travis/build/bash/travis_vers2int.bash
@@ -1,5 +1,5 @@
 travis_vers2int() {
   local args
-  read -r -a args <<<"$(echo "${1}" | tr '.' ' ')"
+  read -r -a args <<<"$(echo "${1}" | grep --only '^[0-9\.][0-9\.]*' | tr '.' ' ')"
   printf '1%03d%03d%03d%03d' "${args[@]}"
 }


### PR DESCRIPTION
Some tools such as `npm` may return unusual values such as 
`6.5.0-next.0`.