### PR TITLE
Install Bundler if not found

### DIFF
--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -25,6 +25,8 @@ module Travis
           pkuczynski
         )
 
+        BUNDLER2_RUBY = '2.3.0'
+
         def export
           super
           sh.export 'TRAVIS_RUBY_VERSION', version, echo: false if rvm?
@@ -77,6 +79,8 @@ module Travis
             sh.cmd('type rvm &>/dev/null || source ~/.rvm/scripts/rvm', echo: false, assert: false, timing: false)
             sh.file '$rvm_path/user/db', CONFIG.join("\n")
             send rvm_strategy
+
+            install_bundler
           end
 
           def rvm_strategy
@@ -185,6 +189,18 @@ module Travis
 
           def without_teeny?(version)
             version =~ /\A(\d+)(\.\d+)\z/
+          end
+
+          def install_bundler
+            sh.if "! $(command -v bundler)" do
+              sh.echo "Installing Bundler", ansi: :yellow
+              sh.if "$(travis_vers2int \"$(ruby -e 'puts RUBY_VERSION')\") -lt $(travis_vers2int #{BUNDLER2_RUBY})" do
+                sh.cmd "gem install bundler -v '< 2'"
+              end
+              sh.else do
+                sh.cmd "gem install bundler"
+              end
+            end
           end
       end
     end

--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -193,12 +193,13 @@ module Travis
 
           def install_bundler
             sh.if "! $(command -v bundler)" do
-              sh.echo "Installing Bundler", ansi: :yellow
-              sh.if "$(travis_vers2int \"$(ruby -e 'puts RUBY_VERSION')\") -lt $(travis_vers2int #{BUNDLER2_RUBY})" do
-                sh.cmd "gem install bundler -v '< 2'"
-              end
-              sh.else do
-                sh.cmd "gem install bundler"
+              sh.fold "install_bundler" do                
+                sh.if "$(travis_vers2int \"$(ruby -e 'puts RUBY_VERSION')\") -lt $(travis_vers2int #{BUNDLER2_RUBY})" do
+                  sh.cmd "gem install bundler -v '< 2'"
+                end
+                sh.else do
+                  sh.cmd "gem install bundler"
+                end
               end
             end
           end


### PR DESCRIPTION
We add `bundler` to RVM's "global" gemset: https://github.com/travis-ci/travis-build/blob/5caec04f7f6a411c55093c9ffafbff705824a6e6/lib/travis/build/script/shared/rvm.rb#L169 This means that during the on-demand installation of Ruby, we attempt to install the latest Bundler.

As of this writing, the latest version of Bundler is [2.0.1](https://rubygems.org/gems/bundler/versions/2.0.1), and it requires Ruby 2.3.0. On older Rubies which do not have Bundler _within_ the archives, the installation fails (though there is a warning), and the users are left with a Ruby installation without Bundler, even though we do invoke `bundle` by default.

This is not ideal.

This PR attempts to install an appropriate version of Bundler when the command is not found.