### PR TITLE
For `cache: yarn`, consult `yarn` for cache dir

### DIFF
--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -204,8 +204,8 @@ module Travis
                   " Please use Node.js #{YARN_REQUIRED_NODE_VERSION} or later.", ansi: :red
               end
               sh.else do
-                sh.fold "install.yarn" do
-                  sh.if "-z \"$(command -v yarn)\"" do
+                sh.if "-z \"$(command -v yarn)\"" do
+                  sh.fold "install.yarn" do
                     sh.if "-z \"$(command -v gpg)\"" do
                       sh.export "YARN_GPG", "no"
                     end

--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -97,7 +97,7 @@ module Travis
           if data.cache?(:yarn)
             sh.fold 'cache.yarn' do
               sh.newline
-              directory_cache.add '${TRAVIS_HOME}/.cache/yarn'
+              directory_cache.add '$(dirname $(yarn cache dir))'
             end
           end
           if data.cache?(:npm)


### PR DESCRIPTION
On macOS, this command returns something like
`${TRAVIS_HOME}/Library/Caches/Yarn/v4`,
which is distinctly different from what it returns on Linux
`/home/travis/.cache/yarn/v1`.
This results in ineffective caching on the Mac.