### PR TITLE
Require OTP/Release 20.0 for Elixir 18.0+

### DIFF
--- a/lib/travis/build/script/elixir.rb
+++ b/lib/travis/build/script/elixir.rb
@@ -91,7 +91,9 @@ export MIX_ARCHIVES=#{KIEX_MIX_HOME}elixir-#{elixir_version}' > #{KIEX_ELIXIR_HO
         end
 
         def required_otp_version
-          if elixir_1_6_0_or_higher?
+          if elixir_1_8_0_or_higher?
+            '20.0'
+          elsif elixir_1_6_0_or_higher?
             '19.0'
           elsif elixir_1_2_0_or_higher?
             '18.0'


### PR DESCRIPTION
https://github.com/elixir-lang/elixir/releases/tag/v1.7.0

> Elixir v1.7 is the last release to support Erlang/OTP 19. We recommend everyone to migrate to Erlang/OTP 20+.