### PR TITLE
Ensure GOPATH, PATH and go get flags work correctly

### DIFF
--- a/lib/travis/build/bash/travis_install_go_dependencies.bash
+++ b/lib/travis/build/bash/travis_install_go_dependencies.bash
@@ -2,7 +2,7 @@ travis_install_go_dependencies() {
   : "${GIMME_GO_VERSION:=${1}}"
   export GIMME_GO_VERSION
 
-  local gobuild_args="${2}"
+  local gobuild_args=("${2}")
 
   if __travis_go_supports_modules; then
     echo 'Using Go 1.11+ Modules'
@@ -25,6 +25,17 @@ travis_install_go_dependencies() {
   if travis_has_makefile; then
     echo 'Makefile detected'
   else
-    travis_cmd "go get ${gobuild_args} ./..." --retry
+    local has_t
+    for arg in "${gobuild_args[@]}"; do
+      if [[ "${arg}" == "-t" ]]; then
+        has_t=1
+      fi
+    done
+
+    if [[ ! "${has_t}" ]]; then
+      gobuild_args=("${gobuild_args[@]}" -t)
+    fi
+
+    travis_cmd "go get ${gobuild_args[*]} ./..." --retry
   fi
 }

--- a/lib/travis/build/bash/travis_install_go_dependencies.bash
+++ b/lib/travis/build/bash/travis_install_go_dependencies.bash
@@ -2,7 +2,8 @@ travis_install_go_dependencies() {
   : "${GIMME_GO_VERSION:=${1}}"
   export GIMME_GO_VERSION
 
-  local gobuild_args=("${2}")
+  local gobuild_args
+  IFS=" " read -r -a gobuild_args <<<"${2}"
 
   if __travis_go_supports_modules; then
     echo 'Using Go 1.11+ Modules'

--- a/lib/travis/build/bash/travis_setup_go.bash
+++ b/lib/travis/build/bash/travis_setup_go.bash
@@ -20,17 +20,17 @@ travis_setup_go() {
   # shellcheck source=/dev/null
   source "${gimme_env}"
 
-  if __travis_go_supports_modules; then
-    travis_cmd export\ GO111MODULE=on --echo
-    return 0
-  fi
-
   # NOTE: $GOPATH is a plural ":"-separated var a la $PATH.  We export
   # only a single path here, but users who want to treat $GOPATH as
   # singular *should* probably use "${GOPATH%%:*}" to take the first
   # entry.
   travis_cmd export\ GOPATH="${TRAVIS_HOME}/gopath" --echo
   travis_cmd export\ PATH="${TRAVIS_HOME}/gopath/bin:$PATH" --echo
+
+  if __travis_go_supports_modules; then
+    travis_cmd export\ GO111MODULE=on --echo
+    return 0
+  fi
 
   mkdir -p "${TRAVIS_HOME}/gopath/src/${go_import_path}"
   tar -Pczf "${TRAVIS_TMPDIR}/src_archive.tar.gz" -C "${TRAVIS_BUILD_DIR}" . &&

--- a/spec/build/bash/travis_install_go_dependencies_spec.rb
+++ b/spec/build/bash/travis_install_go_dependencies_spec.rb
@@ -106,6 +106,6 @@ describe 'travis_install_go_dependencies', integration: true do
     )
     out = result[:out].read
     expect(result[:err].read).to eq ''
-    expect(out).to include('----> go get')
+    expect(out).to include('----> go get -v -t ./...')
   end
 end


### PR DESCRIPTION
following the introduction of go 1.11+ module support