### PR TITLE
Return early for the update RubyGems hook for TruffleRuby

### DIFF
--- a/lib/travis/build/appliances/update_rubygems.rb
+++ b/lib/travis/build/appliances/update_rubygems.rb
@@ -8,6 +8,10 @@ module Travis
         def apply
           sh.file '${TRAVIS_HOME}/.rvm/hooks/after_use', <<~RVMHOOK
             #!/bin/bash
+            if [[ "${rvm_ruby_string}" =~ "truffleruby" ]]; then
+              # TruffleRuby always has a more recent RubyGems than 2.6.13.
+              return 0
+            fi
             gem --help &>/dev/null || return 0
 
             #{bash('travis_vers2int')}


### PR DESCRIPTION
* TruffleRuby always has a more recent RubyGems than 2.6.13.
  The first release had RubyGems 2.6.14.1.
* This hook takes a significant time out of "rvm install" by shelling out
  to `gem` many times: https://github.com/oracle/truffleruby/issues/1576

cc @BanzaiMan 