### PR TITLE
Use CDN for language archives

### DIFF
--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -183,7 +183,7 @@ module Travis
       def lang_archive_prefix(lang, bucket)
         custom_archive = ENV["TRAVIS_BUILD_LANG_ARCHIVES_#{lang}".upcase]
         
-        !!custom_archive ? custom_archive.output_safe : "s3.amazonaws.com/#{bucket}"
+        custom_archive.to_s.empty? ? "s3.amazonaws.com/#{bucket}" : custom_archive.output_safe
       end
 
       def debug_build_via_api?

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -183,7 +183,7 @@ module Travis
       def lang_archive_prefix(lang, bucket)
         custom_archive = ENV["TRAVIS_BUILD_LANG_ARCHIVES_#{lang}".upcase]
         
-        custom_archive || "s3.amazonaws.com/#{bucket}"
+        custom_archive.output_safe || "s3.amazonaws.com/#{bucket}"
       end
 
       def debug_build_via_api?

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -183,7 +183,7 @@ module Travis
       def lang_archive_prefix(lang, bucket)
         custom_archive = ENV["TRAVIS_BUILD_LANG_ARCHIVES_#{lang}".upcase]
         
-        custom_archive.output_safe || "s3.amazonaws.com/#{bucket}"
+        !!custom_archive ? custom_archive.output_safe : "s3.amazonaws.com/#{bucket}"
       end
 
       def debug_build_via_api?

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -181,12 +181,9 @@ module Travis
       end
 
       def lang_archive_prefix(lang, bucket)
-        case lang
-        when 'python'
-          "travis-ci-python-archives.global.ssl.fastly.net"
-        else
-          "s3.amazonaws.com/#{bucket}"
-        end
+        custom_archive = ENV["TRAVIS_BUILD_LANG_ARCHIVES_#{lang}".upcase]
+        
+        custom_archive || "s3.amazonaws.com/#{bucket}"
       end
 
       def debug_build_via_api?

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -177,7 +177,16 @@ module Travis
           sh.raw "travis_rel=$(sw_vers -productVersion)"
           sh.raw "travis_rel_version=${travis_rel%*.*}"
         end
-        "archive_url=https://s3.amazonaws.com/#{bucket}/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/#{file_name}"
+        "archive_url=https://#{lang_archive_prefix(lang, bucket)}/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/#{file_name}"
+      end
+
+      def lang_archive_prefix(lang, bucket)
+        case lang
+        when 'python'
+          "travis-ci-python-archives.global.ssl.fastly.net"
+        else
+          "s3.amazonaws.com/#{bucket}"
+        end
       end
 
       def debug_build_via_api?

--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -110,11 +110,11 @@ module Travis
             sh.echo "Downloading archive: ${archive_url}", ansi: :yellow
             archive_basename = [lang, vers].compact.join("-")
             archive_filename = "#{archive_basename}.tar.bz2"
-            sh.cmd "curl -sSf -o #{archive_filename} ${archive_url}", echo: true, assert: false
+            sh.cmd "curl -sSf -o #{archive_filename} ${archive_url}", echo: true, assert: false, timing: true
             sh.if "$? != 0" do
               sh.failure "Unable to download #{version} archive. The archive may not exist. Please consider a different version."
             end
-            sh.cmd "sudo tar xjf #{archive_filename} --directory /", echo: true, assert: true
+            sh.cmd "sudo tar xjf #{archive_filename} --directory /", echo: true, assert: true, timing: true
             sh.cmd "rm #{archive_filename}", echo: false
           end
 
@@ -125,4 +125,3 @@ module Travis
     end
   end
 end
-

--- a/spec/build/script/python_spec.rb
+++ b/spec/build/script/python_spec.rb
@@ -33,26 +33,26 @@ describe Travis::Build::Script::Python, :sexp do
   it 'sets up the python version (pypy)' do
     data[:config][:python] = 'pypy'
     should include_sexp [:cmd,  'source ~/virtualenv/pypy/bin/activate', assert: true, echo: true, timing: true]
-    should include_sexp [:cmd,  "curl -sSf -o pypy.tar.bz2 ${archive_url}", echo: true]
+    should include_sexp [:cmd,  "curl -sSf -o pypy.tar.bz2 ${archive_url}", echo: true, timing: true]
   end
 
   it 'sets up the python version (pypy-5.3.1)' do
     data[:config][:python] = 'pypy-5.3.1'
     should include_sexp [:cmd,  'source ~/virtualenv/pypy-5.3.1/bin/activate', assert: true, echo: true, timing: true]
-    should include_sexp [:cmd,  "curl -sSf -o pypy-5.3.1.tar.bz2 ${archive_url}", echo: true]
+    should include_sexp [:cmd,  "curl -sSf -o pypy-5.3.1.tar.bz2 ${archive_url}", echo: true, timing: true]
     should include_sexp [:cmd,  "rm pypy-5.3.1.tar.bz2"]
   end
 
   it 'sets up the python version (pypy3.3-5.2-alpha1)' do
     data[:config][:python] = 'pypy3.3-5.2-alpha1'
     should include_sexp [:cmd,  'source ~/virtualenv/pypy3.3-5.2-alpha1/bin/activate', assert: true, echo: true, timing: true]
-    should include_sexp [:cmd,  "curl -sSf -o pypy3.3-5.2-alpha1.tar.bz2 ${archive_url}", echo: true]
+    should include_sexp [:cmd,  "curl -sSf -o pypy3.3-5.2-alpha1.tar.bz2 ${archive_url}", echo: true, timing: true]
     should include_sexp [:cmd,  "rm pypy3.3-5.2-alpha1.tar.bz2"]
   end
 
   it 'sets up the python version (pypy3)' do
     data[:config][:python] = 'pypy3'
-    should include_sexp [:cmd,  "curl -sSf -o pypy3.tar.bz2 ${archive_url}", echo: true]
+    should include_sexp [:cmd,  "curl -sSf -o pypy3.tar.bz2 ${archive_url}", echo: true, timing: true]
     should include_sexp [:cmd,  'source ~/virtualenv/pypy3/bin/activate', assert: true, echo: true, timing: true]
   end
 
@@ -69,7 +69,7 @@ describe Travis::Build::Script::Python, :sexp do
 
   it 'sets up the python version nightly' do
     data[:config][:python] = 'nightly'
-    should include_sexp [:cmd,  'sudo tar xjf python-nightly.tar.bz2 --directory /', echo: true, assert: true]
+    should include_sexp [:cmd,  'sudo tar xjf python-nightly.tar.bz2 --directory /', echo: true, assert: true, timing: true]
     should include_sexp [:cmd,  'source ~/virtualenv/pythonnightly/bin/activate', assert: true, echo: true, timing: true]
   end
 

--- a/spec/build/script/python_spec.rb
+++ b/spec/build/script/python_spec.rb
@@ -79,7 +79,18 @@ describe Travis::Build::Script::Python, :sexp do
 
     it "downloads archive" do
       branch = sexp_find(sexp, [:then])
-      expect(branch).to include_sexp [:raw, "archive_url=https://travis-ci-python-archives.global.ssl.fastly.net/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/python-#{version}.tar.bz2"]
+      expect(branch).to include_sexp [:raw, "archive_url=https://s3.amazonaws.com/travis-python-archives/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/python-#{version}.tar.bz2"]
+    end
+
+    context 'and using a custom archive url' do
+      before { ENV["TRAVIS_BUILD_LANG_ARCHIVES_PYTHON"] = "cdn.of.lots.of.python.stuff" }
+      after  { ENV.delete("TRAVIS_BUILD_LANG_ARCHIVES_PYTHON") }
+
+      it "downloads archive" do
+        ENV['']
+        branch = sexp_find(sexp, [:then])
+        expect(branch).to include_sexp [:raw, "archive_url=https://cdn.of.lots.of.python.stuff/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/python-#{version}.tar.bz2"]
+      end
     end
   end
 

--- a/spec/build/script/python_spec.rb
+++ b/spec/build/script/python_spec.rb
@@ -79,7 +79,7 @@ describe Travis::Build::Script::Python, :sexp do
 
     it "downloads archive" do
       branch = sexp_find(sexp, [:then])
-      expect(branch).to include_sexp [:raw, "archive_url=https://s3.amazonaws.com/travis-python-archives/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/python-#{version}.tar.bz2"]
+      expect(branch).to include_sexp [:raw, "archive_url=https://travis-ci-python-archives.global.ssl.fastly.net/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/python-#{version}.tar.bz2"]
     end
   end
 


### PR DESCRIPTION
This PR alters where we look for language archives from the S3 buckets to CDN.

By using CDN, we accomplish two things:

1. Speed up language archive downloads
1. Allow Enterprise users to sidestep the S3 requriement