### PR TITLE
When `jdk` is given as an array, choose the first element

### DIFF
--- a/lib/travis/build/script/shared/jdk.rb
+++ b/lib/travis/build/script/shared/jdk.rb
@@ -28,7 +28,7 @@ module Travis
 
         def export
           super
-          sh.export 'TRAVIS_JDK_VERSION', config[:jdk], echo: false if specifies_jdk?
+          sh.export 'TRAVIS_JDK_VERSION', jdk, echo: false if specifies_jdk?
         end
 
         def setup
@@ -37,12 +37,12 @@ module Travis
           sh.if '-f build.gradle || -f build.gradle.kts' do
             sh.export 'TERM', 'dumb'
           end
-          
+
           # We disable the Gradle daemon because
           # it's causing out of memory issues otherwise.
           disable_gradle_daemon
         end
-        
+
         def disable_gradle_daemon
           sh.if '"$TRAVIS_DIST" == precise || "$TRAVIS_DIST" == trusty' do
             sh.cmd 'mkdir -p ~/.gradle && echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties', echo: false, timing: false
@@ -64,7 +64,7 @@ module Travis
 
         private
           def jdk
-            config[:jdk].gsub(/\s/,'')
+            Array(config[:jdk]).first.gsub(/\s/,'')
           end
 
           def uses_java?

--- a/spec/build/script/shared/jdk.rb
+++ b/spec/build/script/shared/jdk.rb
@@ -27,6 +27,16 @@ shared_examples_for 'a jdk build sexp' do
     end
   end
 
+  context "when jdk is an array" do
+    before :each do
+      data[:config][:jdk] = ['openjdk7']
+    end
+
+    it 'sets TRAVIS_JDK_VERSION' do
+      should include_sexp export_jdk_version
+    end
+  end
+
   describe 'if build.gradle exists' do
     let(:sexp) { sexp_find(subject, [:if, '-f build.gradle || -f build.gradle.kts'], [:then]) }
 


### PR DESCRIPTION
For

```yaml
language: java
jobs:
  include:
    jdk:
      - openjdk7
      - oraclejdk10
```

We choose the first one. This is consistent with the behavior of other languages, including Elixir, Erlang, Go, etc.