### PR TITLE
Add retrospective message for default change

### DIFF
--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -432,12 +432,20 @@ module Travis
         def check_deprecation
           return unless self.class.const_defined?("DEPRECATIONS")
           self.class.const_get("DEPRECATIONS").each do |cfg|
-            if data.language_default_p && DateTime.now < Date.parse(cfg[:cutoff_date])
-              sh.echo "Using the default #{cfg[:name] || self.class.name} version #{cfg[:current_default]}. " \
-                "Starting on #{cfg[:cutoff_date]} the default will change to #{cfg[:new_default]}. " \
-                "If you wish to keep using this version beyond this date, " \
-                "please explicitly set the #{cfg[:name]} value in configuration.",
-                ansi: :yellow
+            if data.language_default_p
+              if DateTime.now < Date.parse(cfg[:cutoff_date])
+                sh.echo "Using the default #{cfg[:name] || self.class.name} version #{cfg[:current_default]}. " \
+                  "Starting on #{cfg[:cutoff_date]} the default will change to #{cfg[:new_default]}. " \
+                  "If you wish to keep using this version beyond this date, " \
+                  "please explicitly set the #{cfg[:name]} value in configuration.",
+                  ansi: :yellow
+              else
+                sh.echo "Using the new default #{cfg[:name] || self.class.name} version #{cfg[:new_default]}. " \
+                  "Starting on #{cfg[:cutoff_date]} the default changed from #{cfg[:current_default]} to #{cfg[:new_default]}. " \
+                  "If you wish to revert to using the old version, " \
+                  "please explicitly set the #{cfg[:name]} value in configuration.",
+                  ansi: :yellow
+              end
             end
           end
         end

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -10,7 +10,7 @@ module Travis
         DEPRECATIONS = [
           {
             name: 'PHP',
-            current_default: DEFAULTS[:php],
+            current_default: '5.5',
             new_default: '7.2',
             cutoff_date: '2019-03-12',
           }

--- a/spec/build/script/php_spec.rb
+++ b/spec/build/script/php_spec.rb
@@ -54,14 +54,14 @@ describe Travis::Build::Script::Php, :sexp do
       before do
         DateTime.stubs(:now).returns(DateTime.parse("2018-01-01"))
       end
-      it { should include_sexp [:echo, /Using the default PHP version/, ansi: :yellow] }
+      it { should include_sexp [:echo, /default will change to 7.3/, ansi: :yellow] }
     end
 
     context "after default change cutoff date" do
       before do
         DateTime.stubs(:now).returns(DateTime.parse("2019-01-01"))
       end
-      it { should_not include_sexp [:echo, /Using the default PHP version/, ansi: :yellow] }
+      it { should include_sexp [:echo, /default changed from 5.5 to 7.3/, ansi: :yellow] }
     end
   end
 


### PR DESCRIPTION
So users who hadn't built during the warning period would see the message
after the fact.