### PR TITLE
Fetch language archives from GCS

### DIFF
--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -189,7 +189,7 @@ module Travis
       def lang_archive_prefix(lang, bucket)
         custom_archive = ENV["TRAVIS_BUILD_LANG_ARCHIVES_#{lang}".upcase]
 
-        custom_archive.to_s.empty? ? "s3.amazonaws.com/#{bucket}" : custom_archive.output_safe
+        custom_archive.to_s.empty? ? "storage.googleapis.com/travis-ci-language-archives/#{lang}" : custom_archive.output_safe
       end
 
       def debug_build_via_api?

--- a/lib/travis/build/script/shared/rvm.rb
+++ b/lib/travis/build/script/shared/rvm.rb
@@ -9,9 +9,9 @@ module Travis
         }
 
         CONFIG = %w(
-          rvm_remote_server_url3=https://s3.amazonaws.com/travis-rubies/binaries
-          rvm_remote_server_type3=rubies
-          rvm_remote_server_verify_downloads3=1
+          rvm_remote_server_url2=https://storage.googleapis.com/travis-ci-language-archives/ruby/binaries
+          rvm_remote_server_type2=rubies
+          rvm_remote_server_verify_downloads2=1
         )
 
         RVM_VERSION_ALIASES = {
@@ -207,6 +207,10 @@ module Travis
                 end
               end
             end
+          end
+
+          def eradicate_travis_rubies
+            sh.cmd "sed -i -e 'rubies\.travis-ci\.org' $rvm_path/config/db", echo: false
           end
       end
     end

--- a/spec/build/script/elixir_spec.rb
+++ b/spec/build/script/elixir_spec.rb
@@ -61,7 +61,7 @@ describe Travis::Build::Script::Elixir, :sexp do
           describe "wanted OTP release #{otp_release_wanted}" do
             it "is installed" do
               sexp = sexp_find(subject, [:if, "! -f ${TRAVIS_HOME}/otp/#{otp_release_wanted}/activate"], [:then])
-              expect(sexp).to include_sexp([:raw, "archive_url=https://s3.amazonaws.com/travis-otp-releases/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/erlang-#{otp_release_wanted}-nonroot.tar.bz2", assert: true])
+              expect(sexp).to include_sexp([:raw, "archive_url=https://storage.googleapis.com/travis-ci-language-archives/erlang/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/erlang-#{otp_release_wanted}-nonroot.tar.bz2", assert: true])
               expect(sexp).to include_sexp([:cmd, "wget -o ${TRAVIS_HOME}/erlang.tar.bz2 ${archive_url}", assert: true, echo: true, timing: true])
             end
           end
@@ -69,7 +69,7 @@ describe Travis::Build::Script::Elixir, :sexp do
           describe "required OTP release #{otp_release_required}" do
             it "is installed" do
               sexp = sexp_find(subject, [:if, "! -f ${TRAVIS_HOME}/otp/#{otp_release_required}/activate"], [:then])
-              expect(sexp).to include_sexp([:raw, "archive_url=https://s3.amazonaws.com/travis-otp-releases/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/erlang-#{otp_release_required}-nonroot.tar.bz2", assert: true])
+              expect(sexp).to include_sexp([:raw, "archive_url=https://storage.googleapis.com/travis-ci-language-archives/erlang/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/erlang-#{otp_release_required}-nonroot.tar.bz2", assert: true])
               expect(sexp).to include_sexp([:cmd, "wget -o ${TRAVIS_HOME}/erlang.tar.bz2 ${archive_url}", assert: true, echo: true, timing: true])
             end
           end
@@ -92,4 +92,3 @@ describe Travis::Build::Script::Elixir, :sexp do
   installs_required_otp_release('1.0.5', '18.0', '17.4')
   installs_required_otp_release('1.0.5', 'R16B03-1', '17.4')
 end
-

--- a/spec/build/script/erlang_spec.rb
+++ b/spec/build/script/erlang_spec.rb
@@ -26,7 +26,7 @@ describe Travis::Build::Script::Erlang, :sexp do
 
     it 'downloads OTP archive on demand when the desired release is not pre-installed' do
       branch = sexp_find(subject, [:if, '! -f ${TRAVIS_HOME}/otp/R14B04/activate'])
-      expect(branch).to include_sexp [:raw, 'archive_url=https://s3.amazonaws.com/travis-otp-releases/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/erlang-R14B04-nonroot.tar.bz2', assert: true]
+      expect(branch).to include_sexp [:raw, 'archive_url=https://storage.googleapis.com/travis-ci-language-archives/erlang/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/erlang-R14B04-nonroot.tar.bz2', assert: true]
       expect(branch).to include_sexp [:cmd, 'wget -o ${TRAVIS_HOME}/erlang.tar.bz2 ${archive_url}', assert: true, echo: true, timing: true]
     end
   end
@@ -74,4 +74,3 @@ describe Travis::Build::Script::Erlang, :sexp do
     it { is_expected.to eq("cache-#{CACHE_SLUG_EXTRAS}--otp-R14B04") }
   end
 end
-

--- a/spec/build/script/php_spec.rb
+++ b/spec/build/script/php_spec.rb
@@ -149,7 +149,7 @@ describe Travis::Build::Script::Php, :sexp do
     let(:sexp) { sexp_find(sexp_filter(subject, [:if, "$? -ne 0"])[1], [:then]) }
 
     it 'installs PHP version on demand' do
-      expect(sexp).to include_sexp [:raw, "archive_url=https://s3.amazonaws.com/travis-php-archives/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/php-#{version}.tar.bz2", assert: true]
+      expect(sexp).to include_sexp [:raw, "archive_url=https://storage.googleapis.com/travis-ci-language-archives/php/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/php-#{version}.tar.bz2", assert: true]
       expect(sexp).to include_sexp [:cmd, "curl -s -o archive.tar.bz2 $archive_url && tar xjf archive.tar.bz2 --directory /", echo: true, timing: true]
     end
   end

--- a/spec/build/script/python_spec.rb
+++ b/spec/build/script/python_spec.rb
@@ -79,7 +79,7 @@ describe Travis::Build::Script::Python, :sexp do
 
     it "downloads archive" do
       branch = sexp_find(sexp, [:then])
-      expect(branch).to include_sexp [:raw, "archive_url=https://s3.amazonaws.com/travis-python-archives/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/python-#{version}.tar.bz2"]
+      expect(branch).to include_sexp [:raw, "archive_url=https://storage.googleapis.com/travis-ci-language-archives/python/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/python-#{version}.tar.bz2"]
     end
 
     context 'and using a custom archive url' do


### PR DESCRIPTION
* Modify language archive URLs
* Configure RVM's remote server

The build image's `$rvm_path/config/db` has `rubies.travis-ci.org` hard
coded, and it takes precedence (brilliant, eh?) over user configuration,
(perhaps because its `N` is smaller; more on this below)
so we need to remove that before adding ours.
RVM is *very* picky about the configuration; we need to define
`$rvm_remote_server_urlN` for integers N *without gaps*, or RVM will not
use the configuration.
This is a potential source of future problems when the build images
change the underlying configuration.