### PR TITLE
Make ffmpeg-dev install dependent on distribution

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -82,7 +82,7 @@ module Travis
 
                 # Both c2d4u and c2d4u3.5 depend on this ppa for ffmpeg
                 if config[:os] == 'trusty'
-                sh.cmd 'sudo add-apt-repository -y "ppa:kirillshkrogalev/ffmpeg-next"'
+                  sh.cmd 'sudo add-apt-repository -y "ppa:kirillshkrogalev/ffmpeg-next"'
 
                 # Update after adding all repositories. Retry several
                 # times to work around flaky connection to Launchpad PPAs.

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -81,6 +81,7 @@ module Travis
                 end
 
                 # Both c2d4u and c2d4u3.5 depend on this ppa for ffmpeg
+                if config[:os] == 'trusty'
                 sh.cmd 'sudo add-apt-repository -y "ppa:kirillshkrogalev/ffmpeg-next"'
 
                 # Update after adding all repositories. Retry several

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -81,7 +81,7 @@ module Travis
                 end
 
                 # Both c2d4u and c2d4u3.5 depend on this ppa for ffmpeg
-                if config[:os] == 'trusty'
+                sh.if "$(lsb_release -cs) = 'trusty'" do
                   sh.cmd 'sudo add-apt-repository -y "ppa:kirillshkrogalev/ffmpeg-next"'
                 end
 

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -83,6 +83,7 @@ module Travis
                 # Both c2d4u and c2d4u3.5 depend on this ppa for ffmpeg
                 if config[:os] == 'trusty'
                   sh.cmd 'sudo add-apt-repository -y "ppa:kirillshkrogalev/ffmpeg-next"'
+                end
 
                 # Update after adding all repositories. Retry several
                 # times to work around flaky connection to Launchpad PPAs.


### PR DESCRIPTION
When running `dist: xenial` the travis build was failing because the ppa for ffmpeg-dev doesn't have a xenial version. This PR adds a conditional check so it will only run that code if the distribution is trusty.