### PR TITLE
add adoptopenjdk support

### DIFF
--- a/lib/travis/build/bash/travis_install_jdk.bash
+++ b/lib/travis/build/bash/travis_install_jdk.bash
@@ -22,6 +22,11 @@ travis_install_jdk() {
   # shellcheck disable=SC2016
   travis_cmd 'export PATH="$JAVA_HOME/bin:$PATH"' --echo
   [[ "$TRAVIS_OS_NAME" == linux && "$vendor" == openjdk ]] && certlink=" --cacerts"
-  # shellcheck disable=2088
-  travis_cmd "~/bin/install-jdk.sh --target \"$JAVA_HOME\" --workspace \"$TRAVIS_HOME/.cache/install-jdk\" --feature \"$version\" --license \"$license\"$certlink" --echo --assert
+  if [[ "$vendor" == adoptopenjdk ]]; then
+    # shellcheck disable=2088
+    travis_cmd "~/bin/install-jdk.sh --url \"https://api.adoptopenjdk.net/v2/binary/releases/openjdk$version?openjdk_impl=hotspot&os=linux&arch=x64&type=jdk"\"
+  else
+    # shellcheck disable=2088
+    travis_cmd "~/bin/install-jdk.sh --target \"$JAVA_HOME\" --workspace \"$TRAVIS_HOME/.cache/install-jdk\" --feature \"$version\" --license \"$license\"$certlink" --echo --assert
+  fi
 }

--- a/lib/travis/build/bash/travis_install_jdk.bash
+++ b/lib/travis/build/bash/travis_install_jdk.bash
@@ -23,8 +23,13 @@ travis_install_jdk() {
   travis_cmd 'export PATH="$JAVA_HOME/bin:$PATH"' --echo
   [[ "$TRAVIS_OS_NAME" == linux && "$vendor" == openjdk ]] && certlink=" --cacerts"
   if [[ "$vendor" == adoptopenjdk ]]; then
+    if [[ "$TRAVIS_OS_NAME" == osx ]]; then
+      os="mac"
+    else
+      os="$TRAVIS_OS_NAME"
+    fi
     # shellcheck disable=2088
-    travis_cmd "~/bin/install-jdk.sh --url \"https://api.adoptopenjdk.net/v2/binary/releases/openjdk$version?openjdk_impl=hotspot&os=linux&arch=x64&type=jdk"\"
+    travis_cmd "~/bin/install-jdk.sh --url \"https://api.adoptopenjdk.net/v2/binary/releases/openjdk$version?openjdk_impl=hotspot&os=$os&arch=x64&type=jdk"\"
   else
     # shellcheck disable=2088
     travis_cmd "~/bin/install-jdk.sh --target \"$JAVA_HOME\" --workspace \"$TRAVIS_HOME/.cache/install-jdk\" --feature \"$version\" --license \"$license\"$certlink" --echo --assert

--- a/lib/travis/build/script/shared/jdk.rb
+++ b/lib/travis/build/script/shared/jdk.rb
@@ -81,6 +81,8 @@ module Travis
               vendor = 'oracle'
             elsif m[:vendor].start_with? 'openjdk'
               vendor = 'openjdk'
+            elsif m[:vendor].start_with? 'adoptopenjdk'
+              vendor = 'adoptopenjdk'
             end
             [ vendor, m[:version] ]
           end


### PR DESCRIPTION
I think that this is everything required to get an initial implementation of adoptopenjdk binaries in travis.