### PR TITLE
With 270 days left until Python 2 EOL, it is time to upgrade default Python

### DIFF
--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -3,7 +3,7 @@ module Travis
     class Script
       class Python < Script
         DEFAULTS = {
-          python: '2.7',
+          python: '3.6',
           virtualenv: { system_site_packages: false }
         }
 

--- a/spec/build/script/python_spec.rb
+++ b/spec/build/script/python_spec.rb
@@ -27,7 +27,7 @@ describe Travis::Build::Script::Python, :sexp do
   end
 
   it 'sets TRAVIS_PYTHON_VERSION' do
-    should include_sexp [:export,  ['TRAVIS_PYTHON_VERSION', '2.7']]
+    should include_sexp [:export,  ['TRAVIS_PYTHON_VERSION', '3.6']]
   end
 
   it 'sets up the python version (pypy)' do
@@ -56,14 +56,14 @@ describe Travis::Build::Script::Python, :sexp do
     should include_sexp [:cmd,  'source ~/virtualenv/pypy3/bin/activate', assert: true, echo: true, timing: true]
   end
 
-  it 'sets up the python version (2.7)' do
-    should include_sexp [:cmd,  'source ~/virtualenv/python2.7/bin/activate', assert: true, echo: true, timing: true]
+  it 'sets up the python version (3.6)' do
+    should include_sexp [:cmd,  'source ~/virtualenv/python3.6/bin/activate', assert: true, echo: true, timing: true]
   end
 
   context "when python version is given as an array" do
-    before { data[:config][:python] = %w(2.7) }
-    it 'sets up the python version (2.7)' do
-      should include_sexp [:cmd,  'source ~/virtualenv/python2.7/bin/activate', assert: true, echo: true, timing: true]
+    before { data[:config][:python] = %w(3.6) }
+    it 'sets up the python version (3.6)' do
+      should include_sexp [:cmd,  'source ~/virtualenv/python3.6/bin/activate', assert: true, echo: true, timing: true]
     end
   end
 
@@ -74,7 +74,7 @@ describe Travis::Build::Script::Python, :sexp do
   end
 
   context 'when specified Python is not pre-installed' do
-    let(:version) { '2.7' }
+    let(:version) { '3.6' }
     let(:sexp) { sexp_find(subject, [:if, "! -f ~/virtualenv/python#{version}/bin/activate"]) }
 
     it "downloads archive" do

--- a/spec/build/script/python_spec.rb
+++ b/spec/build/script/python_spec.rb
@@ -149,6 +149,6 @@ describe Travis::Build::Script::Python, :sexp do
 
   it 'sets up python with system site packages enabled' do
     data[:config][:virtualenv] = { 'system_site_packages' => true }
-    should include_sexp [:cmd,  'source ~/virtualenv/python2.7_with_system_site_packages/bin/activate', assert: true, echo: true, timing: true]
+    should include_sexp [:cmd,  'source ~/virtualenv/python3.6_with_system_site_packages/bin/activate', assert: true, echo: true, timing: true]
   end
 end


### PR DESCRIPTION
…Python

Upgrade from Python 2.7 --> 3.6.  Python 3.7.3 is current but __dist: xenial__ is required for Python >= 3.7.