### PR TITLE
using -r instead of * fixes issues when files don't exist

### DIFF
--- a/lib/travis/build/appliances/fix_rwky_redis.rb
+++ b/lib/travis/build/appliances/fix_rwky_redis.rb
@@ -7,7 +7,7 @@ module Travis
         def apply
           command = <<-EOF
           if [[ -d /var/lib/apt/lists && -n $(command -v apt-get) ]]; then
-            for f in $(grep -l rwky/redis /etc/apt/sources.list.d/*); do
+            for f in $(grep -l -r rwky/redis /etc/apt/sources.list.d); do
               sed 's,rwky/redis,rwky/ppa,g' $f > /tmp/${f##**/}
               sudo mv /tmp/${f##**/} /etc/apt/sources.list.d
             done


### PR DESCRIPTION
eg. grep: /etc/apt/sources.list.d/*: No such file or directory