### PR TITLE
Change default arguments of pip install in python.rb 

### DIFF
--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -58,10 +58,10 @@ module Travis
 
         def install
           sh.if '-f Requirements.txt' do
-            sh.cmd 'pip install -r Requirements.txt', fold: 'install', retry: true
+            sh.cmd 'pip install --progress-bar off -r Requirements.txt', fold: 'install', retry: true
           end
           sh.elif '-f requirements.txt' do
-            sh.cmd 'pip install -r requirements.txt', fold: 'install', retry: true
+            sh.cmd 'pip install --progress-bar off -r requirements.txt', fold: 'install', retry: true
           end
           sh.else do
             sh.echo REQUIREMENTS_MISSING # , ansi: :red

--- a/spec/build/script/python_spec.rb
+++ b/spec/build/script/python_spec.rb
@@ -160,12 +160,12 @@ describe Travis::Build::Script::Python, :sexp do
 
     it 'installs with pip if Requirements.txt exists' do
       branch = sexp_find(sexp, [:then])
-      expect(branch).to include_sexp [:cmd,  'pip install -r Requirements.txt', assert: true, echo: true, retry: true, timing: true]
+      expect(branch).to include_sexp [:cmd,  'pip install --progress-bar off -r Requirements.txt', assert: true, echo: true, retry: true, timing: true]
     end
 
     it 'installs with pip if requirements.txt exists' do
       branch = sexp_find(sexp, [:elif, '-f requirements.txt'])
-      expect(branch).to include_sexp [:cmd,  'pip install -r requirements.txt', assert: true, echo: true, retry: true, timing: true]
+      expect(branch).to include_sexp [:cmd,  'pip install --progress-bar off -r requirements.txt', assert: true, echo: true, retry: true, timing: true]
     end
 
     it 'errors if no requirements file exists' do


### PR DESCRIPTION
Set default of pip install arguments to '''pip install --progress-bar off -r''' to mitigate issues raised in https://travis-ci.community/t/large-pip-installs-exceed-maximum-log-length/1599/8