### PR TITLE
Add delimiters to build log dumps after failure

### DIFF
--- a/lib/travis/build/rake_tasks.rb
+++ b/lib/travis/build/rake_tasks.rb
@@ -501,9 +501,11 @@ module Travis
       task :dump_examples_logs do
         (top + 'tmp/examples-build-logs').glob('*.log') do |log_file|
           logger.info "dumping #{log_file}"
+          logger.info "---"
           $stdout.write(
             log_file.read.sub(/.+Network availability confirmed\./m, '')
           )
+          logger.info "---"
         end
       end
 


### PR DESCRIPTION
To tell apart the dumps and the real build logs.