### PR TITLE
.travis.yml: The 'sudo' tag is now deprecated in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: required
 dist: xenial
 rvm: 2.5.3
 


### PR DESCRIPTION
[Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo: false__ in your __.travis.yml__, we recommend removing that configuration_"