### PR TITLE
WIP: Create a $TRAVIS_TOXENV environment variable in Python jobs

### DIFF
--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -89,6 +89,10 @@ module Travis
             Array(config[:python]).first.to_s
           end
 
+          def toxenv
+            'py' + version.gsub('.', '')
+          end
+
           def virtualenv_activate
             "~/virtualenv/#{virtualenv}#{system_site_packages}/bin/activate"
           end

--- a/lib/travis/build/script/python.rb
+++ b/lib/travis/build/script/python.rb
@@ -24,6 +24,7 @@ module Travis
         def export
           super
           sh.export 'TRAVIS_PYTHON_VERSION', version, echo: false
+          sh.export 'TRAVIS_TOXENV', toxenv, echo: false
         end
 
         def configure

--- a/spec/build/script/python_spec.rb
+++ b/spec/build/script/python_spec.rb
@@ -28,7 +28,7 @@ describe Travis::Build::Script::Python, :sexp do
 
   it 'sets TRAVIS_PYTHON_VERSION' do
     should include_sexp [:export,  ['TRAVIS_PYTHON_VERSION', '3.6']]
-    should include_sexp [:export,  ['TRAVIS_TOXENV', 'py' + ENV['TRAVIS_PYTHON_VERSION'].gsub('.', '')]]
+    should include_sexp [:export,  ['TRAVIS_TOXENV', 'py36']]
   end
 
   it 'sets up the python version (pypy)' do

--- a/spec/build/script/python_spec.rb
+++ b/spec/build/script/python_spec.rb
@@ -28,6 +28,7 @@ describe Travis::Build::Script::Python, :sexp do
 
   it 'sets TRAVIS_PYTHON_VERSION' do
     should include_sexp [:export,  ['TRAVIS_PYTHON_VERSION', '3.6']]
+    should include_sexp [:export,  ['TRAVIS_TOXENV', 'py' + ENV['TRAVIS_PYTHON_VERSION'].gsub('.', '')]]
   end
 
   it 'sets up the python version (pypy)' do


### PR DESCRIPTION
Simplify the lives of [__tox__](https://tox.readthedocs.io) users by creating a __$TRAVIS_TOXENV__ [environment variable](https://docs.travis-ci.com/user/environment-variables) based off of __$TRAVIS_PYTHON_VERSION__:

| __$TRAVIS_PYTHON_VERSION__ |  __$TRAVIS_TOXENV__ |
|:--------------------------------:|:-----------------------:|
| 2.7 | py27 |
| 3.5 | py35 |
| 3.6 | py36 |
| 3.7 | py37 |

[__$TOXENV in tox docs__](https://tox.readthedocs.io/en/latest/example/general.html?highlight=toxenv#selecting-one-or-more-environments-to-run-tests-against)

The presence of a __$TRAVIS_TOXENV__ environment variable would simplify situations such as:
* https://docs.travis-ci.com/user/multi-os/#python-example-unsupported-languages
* https://docs.travis-ci.com/user/languages/python/#using-tox-as-the-build-script
* https://travis-ci.community/t/dbus-python-dependency-any-version-does-not-work/2146

---

__Before:__
```yaml
language: python
dist: xenial  # required for Python >= 3.7

matrix:
    include:
        - python: "2.7"
          env: TOXENV=py27
        - python: "3.5"
          env: TOXENV=py35
        - python: "3.6"
          env: TOXENV=py36
        - python: "3.7"
          env: TOXENV=py37
        - python: "3.7"
          env: TOXENV=lint
        - python: "3.7"
          env: TOXENV=docs

install: pip install tox
script: tox -e $TOXENV
```
__After:__
```yaml
language: python
dist: xenial  # required for Python >= 3.7

python:
  - "2.7"
  - "3.5"
  - "3.6"
  - "3.7"

matrix:
    include:
        - python: "3.7"
          env: TOXENV=lint
        - python: "3.7"
          env: TOXENV=docs

install: pip install tox
script: tox -e ${TOXENV:-$TRAVIS_TOXENV}
```