### PR TITLE
Fix perl6 build

### DIFF
--- a/lib/travis/build/script/perl6.rb
+++ b/lib/travis/build/script/perl6.rb
@@ -26,7 +26,7 @@ module Travis
           sh.echo 'and cc @paultcochrane, @hoelzro, @ugexe, and @tony-o', ansi: :red
 
           sh.echo 'Installing Rakudo (MoarVM)', ansi: :yellow
-          sh.cmd 'git clone https://github.com/tadzik/rakudobrew.git ${TRAVIS_HOME}/.rakudobrew'
+          sh.cmd 'git clone -b v1 https://github.com/tadzik/rakudobrew.git ${TRAVIS_HOME}/.rakudobrew'
           sh.export 'PATH', '${TRAVIS_HOME}/.rakudobrew/bin:$PATH', echo: false
         end
 


### PR DESCRIPTION
`rakudobrew` just had a major upgrade which breaks the way rakudobrew is used in travis-build. This change makes sure the old, still working, version of rakudobrew is used.
I did not test this, as this is a bit complex (docker-compose). This change is trivial enough that I'd be willing to just give it a try, especially as the perl6 build is broken at the moment.