### PR TITLE
 Add double quotes to return tag

### DIFF
--- a/lib/travis/build/git/clone.rb
+++ b/lib/travis/build/git/clone.rb
@@ -102,7 +102,7 @@ module Travis
 
           def checkout_ref
             return 'FETCH_HEAD' if data.pull_request
-            return data.tag     if data.tag
+            return tag if data.tag
             data.commit
           end
 


### PR DESCRIPTION
Fix issue with git checkout when tag contains special characters