### PR TITLE
Only use Git V2 protocol on xcode10.2 image

### DIFF
--- a/lib/travis/build/appliances/git_v2.rb
+++ b/lib/travis/build/appliances/git_v2.rb
@@ -9,7 +9,7 @@ module Travis
         end
 
         def apply?
-          config[:os] == 'osx' && config[:osx_image] && config[:osx_image].start_with?('xcode10')
+          config[:os] == 'osx' && config[:osx_image] && config[:osx_image] == 'xcode10.2'
         end
       end
     end


### PR DESCRIPTION
Older images have a new enough Git in `/usr/local/bin/git`, but not in `/usr/bin/git` (which is provided by Apple).

Some tools, particularly Homebrew, need to use the system Git in `/usr/bin/git`, so that one needs to be new enough to use the new protocol as well.