### PR TITLE
R: update R version to Bioc-devel 3.10

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -601,7 +601,8 @@ module Travis
           when 'bioc-devel'
             config[:bioc_required] = true
             config[:bioc_use_devel] = true
-            normalized_r_version('devel')
+            config[:r] = 'release'
+            normalized_r_version
           when 'bioc-release'
             config[:bioc_required] = true
             config[:bioc_use_devel] = false


### PR DESCRIPTION
Problem: 'bioc-devel' configuration should be using R release version `3.6.0`. 
Solution: Change hard-coded values in the `r.rb` file.

Potential alternative solution: Use version mapping at https://bioconductor.org/config.yaml

cc: @jimhester @BanzaiMan 