### PR TITLE
Add the ability to ignore APT source aliases defined in remote JSON file

### DIFF
--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -126,7 +126,22 @@ module Travis
             disallowed_while_sudo = []
 
             config_sources.each do |src|
-              if load_alias_list? && source = source_alias_lists[config_dist][src]
+              if !load_alias_list?
+                sh.echo "Skipping loading APT source aliases list", ansi: :yellow
+
+                if src.respond_to?(:has_key?)
+                  safelisted << {
+                    'sourceline' => src[:sourceline],
+                    'key_url' => src[:key_url]
+                  }
+                else
+                  sh.echo "'sourceline' key missing", ansi: :yellow
+                  sh.echo Shellwords.escape(src.inspect)
+                end
+                next
+              end
+
+              if source = source_alias_lists[config_dist][src]
                 if source.respond_to?(:[]) && source['sourceline']
                   safelisted << source.clone
                 else

--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -20,8 +20,8 @@ module Travis
             @package_safelists ||= load_package_safelists
           end
 
-          def source_safelists
-            @source_safelists ||= load_source_safelists
+          def source_alias_lists
+            @source_alias_lists ||= load_source_alias_lists
           end
 
           private
@@ -39,7 +39,7 @@ module Travis
             loaded
           end
 
-          def load_source_safelists(dists = SUPPORTED_DISTS)
+          def load_source_alias_lists(dists = SUPPORTED_DISTS)
             require 'faraday'
             loaded = { unset: {} }.merge(Hash[dists.map { |dist| [dist.to_sym, {}] }])
             dists.each do |dist|
@@ -107,7 +107,7 @@ module Travis
             sh.cmd "sudo mv #{tmp_dest} ${TRAVIS_ROOT}/etc/apt/apt.conf.d"
           end
         end
-        
+
         def config
           @config ||= Hash(super)
         end
@@ -122,7 +122,7 @@ module Travis
             disallowed_while_sudo = []
 
             config_sources.each do |src|
-              source = source_safelists[config_dist][src]
+              source = source_alias_lists[config_dist][src]
 
               if source.respond_to?(:[]) && source['sourceline']
                 safelisted << source.clone
@@ -233,8 +233,8 @@ module Travis
             ::Travis::Build::Addons::Apt.package_safelists
           end
 
-          def source_safelists
-            ::Travis::Build::Addons::Apt.source_safelists
+          def source_alias_lists
+            ::Travis::Build::Addons::Apt.source_alias_lists
           end
 
           def safelisted_source_key_url(source)

--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -43,7 +43,7 @@ module Travis
             require 'faraday'
             loaded = { unset: {} }.merge(Hash[dists.map { |dist| [dist.to_sym, {}] }])
             dists.each do |dist|
-              response = fetch_source_safelist(dist)
+              response = fetch_source_alias_list(dist)
               entries = JSON.parse(response)
               loaded[dist.to_sym] = Hash[entries.reject { |e| !e.key?('alias') }.map { |e| [e.fetch('alias'), e] }]
             end
@@ -57,16 +57,16 @@ module Travis
             Faraday.get(package_safelist_url(dist)).body.to_s
           end
 
-          def fetch_source_safelist(dist)
-            Faraday.get(source_safelist_url(dist)).body.to_s
+          def fetch_source_alias_list(dist)
+            Faraday.get(source_alias_list_url(dist)).body.to_s
           end
 
           def package_safelist_url(dist)
             Travis::Build.config.apt_package_safelist[dist.downcase].to_s
           end
 
-          def source_safelist_url(dist)
-            Travis::Build.config.apt_source_safelist[dist.downcase].to_s
+          def source_alias_list_url(dist)
+            Travis::Build.config.apt_source_alias_list[dist.downcase].to_s
           end
         end
 
@@ -238,7 +238,7 @@ module Travis
           end
 
           def safelisted_source_key_url(source)
-            tmpl = Travis::Build.config.apt_source_safelist_key_url_template.to_s.output_safe
+            tmpl = Travis::Build.config.apt_source_alias_list_key_url_template.to_s.output_safe
             if source['key_url'] && (!data.disable_sudo? || skip_safelist?)
               tmpl = source['key_url']
             end

--- a/lib/travis/build/appliances/update_apt_keys.rb
+++ b/lib/travis/build/appliances/update_apt_keys.rb
@@ -36,7 +36,7 @@ module Travis
         end
 
         def key_url(repo)
-          tmpl = Travis::Build.config.apt_source_safelist_key_url_template.to_s.output_safe
+          tmpl = Travis::Build.config.apt_source_alias_list_key_url_template.to_s.output_safe
           format(
             tmpl.to_s,
             source_alias: repo,

--- a/lib/travis/build/config.rb
+++ b/lib/travis/build/config.rb
@@ -51,12 +51,12 @@ module Travis
         },
         apt_proxy: ENV.fetch('TRAVIS_BUILD_APT_PROXY', ''),
         apt_source_alias_list: {
-          precise: ENV.fetch('TRAVIS_BUILD_APT_SOURCE_SAFELIST_PRECISE', ''),
-          trusty: ENV.fetch('TRAVIS_BUILD_APT_SOURCE_SAFELIST_TRUSTY', ''),
-          xenial: ENV.fetch('TRAVIS_BUILD_APT_SOURCE_SAFELIST_XENIAL', ''),
+          precise: ENV.fetch('TRAVIS_BUILD_APT_SOURCE_ALIAS_LIST_PRECISE', ''),
+          trusty: ENV.fetch('TRAVIS_BUILD_APT_SOURCE_ALIAS_LIST_TRUSTY', ''),
+          xenial: ENV.fetch('TRAVIS_BUILD_APT_SOURCE_ALIAS_LIST_XENIAL', ''),
         },
         apt_source_alias_list_key_url_template: ENV.fetch(
-          'TRAVIS_BUILD_APT_SOURCE_SAFELIST_KEY_URL_TEMPLATE',
+          'TRAVIS_BUILD_APT_SOURCE_ALIAS_LIST_KEY_URL_TEMPLATE',
           'https://%{app_host}/files/gpg/%{source_alias}.asc'
         ),
         apt_safelist_skip: ENV.fetch('TRAVIS_BUILD_APT_SAFELIST_SKIP', '').to_bool,

--- a/lib/travis/build/config.rb
+++ b/lib/travis/build/config.rb
@@ -50,12 +50,12 @@ module Travis
           xenial: ENV.fetch('TRAVIS_BUILD_APT_PACKAGE_SAFELIST_XENIAL', ''),
         },
         apt_proxy: ENV.fetch('TRAVIS_BUILD_APT_PROXY', ''),
-        apt_source_safelist: {
+        apt_source_alias_list: {
           precise: ENV.fetch('TRAVIS_BUILD_APT_SOURCE_SAFELIST_PRECISE', ''),
           trusty: ENV.fetch('TRAVIS_BUILD_APT_SOURCE_SAFELIST_TRUSTY', ''),
           xenial: ENV.fetch('TRAVIS_BUILD_APT_SOURCE_SAFELIST_XENIAL', ''),
         },
-        apt_source_safelist_key_url_template: ENV.fetch(
+        apt_source_alias_list_key_url_template: ENV.fetch(
           'TRAVIS_BUILD_APT_SOURCE_SAFELIST_KEY_URL_TEMPLATE',
           'https://%{app_host}/files/gpg/%{source_alias}.asc'
         ),

--- a/lib/travis/build/config.rb
+++ b/lib/travis/build/config.rb
@@ -60,6 +60,7 @@ module Travis
           'https://%{app_host}/files/gpg/%{source_alias}.asc'
         ),
         apt_safelist_skip: ENV.fetch('TRAVIS_BUILD_APT_SAFELIST_SKIP', '').to_bool,
+        apt_load_source_alias_list: ENV.fetch('TRAVIS_BUILD_APT_LOAD_SOURCE_ALIAS_LIST', 'true').to_bool,
         auth_disabled: ENV.fetch('TRAVIS_BUILD_AUTH_DISABLED', '').to_bool,
         cabal_default: ENV.fetch('TRAVIS_BUILD_CABAL_DEFAULT', '2.0'),
         enable_debug_tools: ENV.fetch(

--- a/spec/build/addons/apt_packages_spec.rb
+++ b/spec/build/addons/apt_packages_spec.rb
@@ -12,7 +12,7 @@ describe Travis::Build::Addons::AptPackages, :sexp do
 
   before :each do
     described_class.instance_variable_set(:@package_safelists, nil)
-    described_class.instance_variable_set(:@source_safelists, nil)
+    described_class.instance_variable_set(:@source_alias_lists, nil)
     addon.stubs(:skip_safelist?).returns(safelist_skip)
     addon.stubs(:package_safelists).returns(package_safelists)
     script.stubs(:bash).returns('')

--- a/spec/build/addons/apt_spec.rb
+++ b/spec/build/addons/apt_spec.rb
@@ -269,7 +269,8 @@ describe Travis::Build::Addons::Apt, :sexp do
       let(:apt_config) { { sources: ['packagecloud-xenial', 'deadsnakes-xenial', 'evilbadthings', 'ppa:archivematica/externals', { sourceline: 'foobar' }] } }
 
       it { should include_sexp [:echo, "Skipping loading APT source aliases list", ansi: :yellow] }
-      it { should_not include_sexp [:echo, /^Disallowing sources:/, ansi: :red] }
+      it { should_not include_sexp [:echo, /^Disallowing sources: foobar/, ansi: :red] }
+      it { should_not include_sexp [:echo, /^Disallowing sources: evilbadthings/, ansi: :red] }
       it { should include_sexp [:cmd, apt_sources_append_command('foobar'), echo: true, assert: true, timing: true] }
       it { should_not include_sexp [:cmd, apt_sources_append_command(packagecloud['sourceline']), echo: true, assert: true, timing: true] }
       it { should_not include_sexp [:cmd, apt_add_repository_command(deadsnakes['sourceline']), echo: true, assert: true, timing: true] }

--- a/spec/build/addons/apt_spec.rb
+++ b/spec/build/addons/apt_spec.rb
@@ -8,7 +8,7 @@ describe Travis::Build::Addons::Apt, :sexp do
   let(:addon)              { described_class.new(script, sh, Travis::Build::Data.new(data), apt_config) }
   let(:apt_config)         { {} }
   let(:dist)               { :xenial }
-  let(:source_safelists)  { { xenial: [{ alias: 'testing', sourceline: 'deb http://example.com/deb repo main' }] } }
+  let(:source_alias_lists)  { { xenial: [{ alias: 'testing', sourceline: 'deb http://example.com/deb repo main' }] } }
   let(:package_safelists) { { xenial: %w(git curl) } }
   let(:paranoid)           { true }
   let(:safelist_skip)     { false }
@@ -20,7 +20,7 @@ describe Travis::Build::Addons::Apt, :sexp do
 
   before :each do
     described_class.instance_variable_set(:@package_safelists, nil)
-    described_class.instance_variable_set(:@source_safelists, nil)
+    described_class.instance_variable_set(:@source_alias_lists, nil)
     script.stubs(:bash).returns('')
     addon.stubs(:skip_safelist?).returns(safelist_skip)
   end
@@ -74,17 +74,17 @@ describe Travis::Build::Addons::Apt, :sexp do
   context 'when the source safelist is provided' do
     before do
       described_class.stubs(:fetch_source_safelist)
-        .returns(JSON.dump(source_safelists[dist]))
+        .returns(JSON.dump(source_alias_lists[dist]))
       addon.before_prepare
     end
 
     it 'exposes a source safelist' do
-      expect(described_class.source_safelists).to_not be_empty
+      expect(described_class.source_alias_lists).to_not be_empty
     end
 
     it 'instances delegate source safelist to class' do
-      expect(described_class.source_safelists)
-        .to eql(addon.send(:source_safelists))
+      expect(described_class.source_alias_lists)
+        .to eql(addon.send(:source_alias_lists))
     end
   end
 
@@ -106,7 +106,7 @@ describe Travis::Build::Addons::Apt, :sexp do
     end
 
     it 'defaults source safelist to empty hash' do
-      expect(described_class.source_safelists)
+      expect(described_class.source_alias_lists)
         .to eql({ precise: {}, trusty: {}, xenial: {}, unset: {} })
     end
   end
@@ -189,7 +189,7 @@ describe Travis::Build::Addons::Apt, :sexp do
       }
     end
 
-    let(:source_safelists) do
+    let(:source_alias_lists) do
       {
         xenial: {
           'deadsnakes-xenial' => deadsnakes,
@@ -199,7 +199,7 @@ describe Travis::Build::Addons::Apt, :sexp do
     end
 
     before do
-      addon.stubs(:source_safelists).returns(source_safelists)
+      addon.stubs(:source_alias_lists).returns(source_alias_lists)
       addon.before_prepare
     end
 

--- a/spec/build/addons/apt_spec.rb
+++ b/spec/build/addons/apt_spec.rb
@@ -268,6 +268,9 @@ describe Travis::Build::Addons::Apt, :sexp do
       let(:apt_load_source_alias_list) { false }
       let(:apt_config) { { sources: ['packagecloud-xenial', 'deadsnakes-xenial', 'evilbadthings', 'ppa:archivematica/externals', { sourceline: 'foobar' }] } }
 
+      it { should include_sexp [:echo, "Skipping loading APT source aliases list", ansi: :yellow] }
+      it { should_not include_sexp [:echo, /^Disallowing sources:/, ansi: :red] }
+      it { should include_sexp [:cmd, apt_sources_append_command('foobar'), echo: true, assert: true, timing: true] }
       it { should_not include_sexp [:cmd, apt_sources_append_command(packagecloud['sourceline']), echo: true, assert: true, timing: true] }
       it { should_not include_sexp [:cmd, apt_add_repository_command(deadsnakes['sourceline']), echo: true, assert: true, timing: true] }
     end

--- a/spec/build/addons/apt_spec.rb
+++ b/spec/build/addons/apt_spec.rb
@@ -73,7 +73,7 @@ describe Travis::Build::Addons::Apt, :sexp do
 
   context 'when the source safelist is provided' do
     before do
-      described_class.stubs(:fetch_source_safelist)
+      described_class.stubs(:fetch_source_alias_list)
         .returns(JSON.dump(source_alias_lists[dist]))
       addon.before_prepare
     end
@@ -101,7 +101,7 @@ describe Travis::Build::Addons::Apt, :sexp do
 
   context 'when the source safelist cannot be fetched' do
     before do
-      described_class.stubs(:fetch_source_safelist).raises(StandardError)
+      described_class.stubs(:fetch_source_alias_list).raises(StandardError)
       addon.before_prepare
     end
 


### PR DESCRIPTION
This PR does the following:

1. Rename apt source safelist to apt source aliases; we are running in GCE environment nowadays, where there are no restrictions on the additional APT repositories. It is no longer a list of safe APT repositories, just aliases.
1. Add the ability to turn off alias list loading via the environment variable `TRAVIS_BUILD_APT_LOAD_SOURCE_ALIAS_LIST`. By setting this value to `false`, the alias list will be ignored. This is convenient for Enterprise installations.