### PR TITLE
Retry more commands in apt addon

### DIFF
--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -163,7 +163,7 @@ module Travis
               safelisted.each do |source|
                 sourceline = source['sourceline'].output_safe
                 if sourceline.start_with?('ppa:')
-                  sh.cmd "sudo -E apt-add-repository -y #{sourceline.inspect}", echo: true, assert: true, timing: true
+                  sh.cmd "sudo -E apt-add-repository -y #{sourceline.inspect}", retry: true, echo: true, assert: true, timing: true
                 else
                   sh.cmd "curl -sSL \"#{safelisted_source_key_url(source)}\" | sudo -E apt-key add -", echo: true, assert: true, timing: true
                   # Avoid adding deb-src lines to work around https://bugs.launchpad.net/ubuntu/+source/software-properties/+bug/987264
@@ -210,7 +210,7 @@ module Travis
               sh.raw bash('travis_apt_get_options')
               command = 'sudo -E apt-get -yq --no-install-suggests --no-install-recommends ' \
                 "$(travis_apt_get_options) install #{safelisted.join(' ')}"
-              sh.cmd command, echo: true, timing: true
+              sh.cmd command, retry: true, echo: true, timing: true
 
               sh.raw "result=$?"
               sh.if '$result -ne 0' do

--- a/spec/build/addons/apt_packages_spec.rb
+++ b/spec/build/addons/apt_packages_spec.rb
@@ -26,26 +26,26 @@ describe Travis::Build::Addons::AptPackages, :sexp do
   context 'with multiple safelisted packages' do
     let(:config) { ['git', 'curl'] }
 
-    it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true] }
+    it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), retry: true, echo: true, timing: true] }
   end
 
   context 'with multiple packages, some safelisted' do
     let(:config) { ['git', 'curl', 'darkcoin'] }
 
-    it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true] }
+    it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), retry: true, echo: true, timing: true] }
   end
 
   context 'with multiple packages, some safelisted on unrestricted box' do
     let(:config) { ['git', 'curl', 'darkcoin'] }
     let(:paranoid) { false }
 
-    it { should include_sexp [:cmd, apt_get_install_command('git', 'curl', 'darkcoin'), echo: true, timing: true] }
+    it { should include_sexp [:cmd, apt_get_install_command('git', 'curl', 'darkcoin'), retry: true, echo: true, timing: true] }
   end
 
   context 'with singular safelisted package' do
     let(:config) { 'git' }
 
-    it { should include_sexp [:cmd, apt_get_install_command('git'), echo: true, timing: true] }
+    it { should include_sexp [:cmd, apt_get_install_command('git'), retry: true, echo: true, timing: true] }
   end
 
   context 'with no safelisted packages' do

--- a/spec/build/addons/apt_spec.rb
+++ b/spec/build/addons/apt_spec.rb
@@ -128,32 +128,32 @@ describe Travis::Build::Addons::Apt, :sexp do
 
       it { store_example(name: 'safelisted') }
 
-      it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true] }
+      it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), retry: true, echo: true, timing: true] }
     end
 
     context 'with multiple packages, some safelisted' do
       let(:apt_config) { { packages: ['git', 'curl', 'darkcoin'] } }
 
-      it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true] }
+      it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), retry: true, echo: true, timing: true] }
 
       context 'when sudo is enabled' do
         let(:paranoid) { false }
 
-        it { should include_sexp [:cmd, apt_get_install_command('git', 'curl', 'darkcoin'), echo: true, timing: true] }
+        it { should include_sexp [:cmd, apt_get_install_command('git', 'curl', 'darkcoin'), retry: true, echo: true, timing: true] }
       end
 
       context 'when safelist skippping is enabled' do
         let(:paranoid) { true }
         let(:safelist_skip) { true }
 
-        it { should include_sexp [:cmd, apt_get_install_command('git', 'curl', 'darkcoin'), echo: true, timing: true] }
+        it { should include_sexp [:cmd, apt_get_install_command('git', 'curl', 'darkcoin'), retry: true, echo: true, timing: true] }
       end
     end
 
     context 'with singular safelisted package' do
       let(:apt_config) { { packages: 'git' } }
 
-      it { should include_sexp [:cmd, apt_get_install_command('git'), echo: true, timing: true] }
+      it { should include_sexp [:cmd, apt_get_install_command('git'), retry: true, echo: true, timing: true] }
     end
 
     context 'with no safelisted packages' do
@@ -165,7 +165,7 @@ describe Travis::Build::Addons::Apt, :sexp do
     context 'with nested arrays of packages' do
       let(:apt_config) { { packages: [%w(git curl)] } }
 
-      it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), echo: true, timing: true] }
+      it { should include_sexp [:cmd, apt_get_install_command('git', 'curl'), retry: true, echo: true, timing: true] }
     end
   end
 
@@ -216,14 +216,14 @@ describe Travis::Build::Addons::Apt, :sexp do
     context 'with multiple safelisted sources' do
       let(:apt_config) { { sources: ['deadsnakes-xenial'] } }
 
-      it { should include_sexp [:cmd, apt_add_repository_command(deadsnakes['sourceline']), echo: true, assert: true, timing: true] }
+      it { should include_sexp [:cmd, apt_add_repository_command(deadsnakes['sourceline']), retry: true, echo: true, assert: true, timing: true] }
     end
 
     context 'with multiple sources, some safelisted' do
       let(:apt_config) { { sources: ['packagecloud-xenial', 'deadsnakes-xenial', 'evilbadthings', 'ppa:evilbadppa', { sourceline: 'foobar' }] } }
 
       it { should include_sexp [:cmd, apt_sources_append_command(packagecloud['sourceline']), echo: true, assert: true, timing: true] }
-      it { should include_sexp [:cmd, apt_add_repository_command(deadsnakes['sourceline']), echo: true, assert: true, timing: true] }
+      it { should include_sexp [:cmd, apt_add_repository_command(deadsnakes['sourceline']), retry: true, echo: true, assert: true, timing: true] }
       it { should_not include_sexp [:cmd, apt_sources_append_command(evilbadthings['sourceline']), echo: true, assert: true, timing: true] }
       it { should_not include_sexp [:cmd, apt_add_repository_command('ppa:evilbadppa'), echo: true, assert: true, timing: true] }
       it { should_not include_sexp [:cmd, apt_sources_append_command('foobar'), echo: true, assert: true, timing: true] }
@@ -246,7 +246,7 @@ describe Travis::Build::Addons::Apt, :sexp do
       let(:apt_config) { { sources: ['packagecloud-xenial', 'deadsnakes-xenial', 'evilbadthings', 'ppa:archivematica/externals', { sourceline: 'foobar' }] } }
 
       it { should include_sexp [:cmd, apt_sources_append_command(packagecloud['sourceline']), echo: true, assert: true, timing: true] }
-      it { should include_sexp [:cmd, apt_add_repository_command(deadsnakes['sourceline']), echo: true, assert: true, timing: true] }
+      it { should include_sexp [:cmd, apt_add_repository_command(deadsnakes['sourceline']), retry: true, echo: true, assert: true, timing: true] }
       it { should include_sexp [:cmd, apt_sources_append_command('foobar'), echo: true, assert: true, timing: true] }
       it { should_not include_sexp [:cmd, apt_sources_append_command(evilbadthings['sourceline']), echo: true, assert: true, timing: true] }
       it { should_not include_sexp [:cmd, apt_add_repository_command('ppa:evilbadppa'), echo: true, assert: true, timing: true] }
@@ -258,7 +258,7 @@ describe Travis::Build::Addons::Apt, :sexp do
       let(:safelist_skip) { true }
 
       it { should include_sexp [:cmd, apt_sources_append_command(packagecloud['sourceline']), echo: true, assert: true, timing: true] }
-      it { should include_sexp [:cmd, apt_add_repository_command(deadsnakes['sourceline']), echo: true, assert: true, timing: true] }
+      it { should include_sexp [:cmd, apt_add_repository_command(deadsnakes['sourceline']), retry: true, echo: true, assert: true, timing: true] }
       it { should include_sexp [:cmd, apt_sources_append_command('foobar'), echo: true, assert: true, timing: true] }
       it { should_not include_sexp [:cmd, apt_sources_append_command(evilbadthings['sourceline']), echo: true, assert: true, timing: true] }
       it { should_not include_sexp [:cmd, apt_add_repository_command('ppa:evilbadppa'), echo: true, assert: true, timing: true] }


### PR DESCRIPTION
At TravisCI of ruby/ruby repository, we often see random failures on `apt` plugin, but we do not want to see CI failure on that part. 

I'd like to suggest introducing retries for the following failures:

#### sudo -E apt-add-repository -y ... 
* May 26: https://travis-ci.org/ruby/ruby/jobs/537363191
* May 31: https://travis-ci.org/ruby/ruby/jobs/539694628

#### sudo -E apt-get -yq --no-install-suggests --no-install-recommends $(travis_apt_get_options) install ...
* May 26: https://travis-ci.org/ruby/ruby/jobs/537354169
* May 26: https://travis-ci.org/ruby/ruby/jobs/537354958
* May 31: https://travis-ci.org/ruby/ruby/jobs/539259851