### PR TITLE
Fix "Error: Bioconductor version not changed" on changing existing ve…

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -428,7 +428,7 @@ module Travis
                   'if (!requireNamespace("BiocManager", quietly=TRUE))'\
                   '  install.packages("BiocManager");'\
                   "if (#{as_r_boolean(config[:bioc_use_devel])})"\
-                  ' BiocManager::install(version = "devel");'\
+                  ' BiocManager::install(version = "devel", ask = FALSE);'\
                   'cat(append = TRUE, file = "~/.Rprofile.site", "options(repos = BiocManager::repositories());")'
                 end
                 sh.cmd "Rscript -e '#{bioc_install_script}'", retry: true


### PR DESCRIPTION
…rsion

Fixes https://travis-ci.community/t/error-bioconductor-version-not-changed/3491

The same change will need to be done for https://github.com/travis-ci/travis-build/pull/1710 since current images have 3.8 preinstalled apparently.

Tested locally.