### PR TITLE
Use bash version of casher in all builds

### DIFF
--- a/lib/travis/build/rake_tasks.rb
+++ b/lib/travis/build/rake_tasks.rb
@@ -230,7 +230,7 @@ module Travis
       end
 
       def file_update_casher
-        fetch_githubusercontent_file 'travis-ci/casher/production/bin/casher'
+        fetch_githubusercontent_file 'travis-ci/casher/bash/bin/casher'
       end
 
       def file_update_gimme

--- a/lib/travis/build/script/shared/directory_cache/base.rb
+++ b/lib/travis/build/script/shared/directory_cache/base.rb
@@ -280,7 +280,7 @@ module Travis
               if branch = data.cache[:branch]
                 branch
               else
-                edge? ? 'master' : 'production'
+                edge? ? 'master' : 'bash'
               end
             end
 
@@ -299,7 +299,7 @@ module Travis
             def update_static_file(name, location, remote_location, assert = false)
               flags = "-sf #{debug_flags}"
               cmd_opts = {retry: true, assert: false, echo: 'Installing caching utilities'}
-              if casher_branch == 'production'
+              if casher_branch == 'bash'
                 static_file_location = "https://#{app_host}/files/#{name}".output_safe
                 sh.cmd curl_cmd(flags, location, static_file_location), cmd_opts
                 sh.if "$? -ne 0" do

--- a/spec/build/rake_tasks_spec.rb
+++ b/spec/build/rake_tasks_spec.rb
@@ -51,7 +51,7 @@ describe Travis::Build::RakeTasks do
         /paulp/sbt-extras/master/sbt
         /sc-linux.tar.gz
         /sc-osx.zip
-        /travis-ci/casher/production/bin/casher
+        /travis-ci/casher/bash/bin/casher
         /travis-ci/gimme/v1.2.5/gimme
       ].each do |filepath|
         stub.get(filepath) do |*|

--- a/spec/build/script/directory_cache/gcs_spec.rb
+++ b/spec/build/script/directory_cache/gcs_spec.rb
@@ -63,8 +63,8 @@ describe Travis::Build::Script::DirectoryCache::Gcs, :sexp do
     let(:url) { "https://raw.githubusercontent.com/travis-ci/casher/#{branch}/bin/casher" }
     let(:cmd) { [:cmd,  "curl -sf  -o $CASHER_DIR/bin/casher #{url}", retry: true, echo: 'Installing caching utilities'] }
 
-    describe 'uses casher production in default mode' do
-      let(:branch) { 'production' }
+    describe 'uses casher bash in default mode' do
+      let(:branch) { 'bash' }
       let(:cmd) { [:cmd,  "curl -sf  -o $CASHER_DIR/bin/casher #{url}",retry: true, echo: "Installing caching utilities from the Travis CI server (https://#{Travis::Build.config.app_host.output_safe}/files/casher) failed, failing over to using GitHub (#{url})"] }
       it { should include_sexp [:export, ['CASHER_DIR', '${TRAVIS_HOME}/.casher'], echo: true] }
       it { should include_sexp [:mkdir, '$CASHER_DIR/bin', recursive: true] }

--- a/spec/build/script/directory_cache/s3_spec.rb
+++ b/spec/build/script/directory_cache/s3_spec.rb
@@ -58,8 +58,8 @@ describe Travis::Build::Script::DirectoryCache::S3, :sexp do
     let(:url) { "https://raw.githubusercontent.com/travis-ci/casher/#{branch}/bin/casher" }
     let(:cmd) { [:cmd,  "curl -sf  -o $CASHER_DIR/bin/casher #{url}", retry: true, echo: 'Installing caching utilities'] }
 
-    describe 'uses casher production in default mode' do
-      let(:branch) { 'production' }
+    describe 'uses casher bash in default mode' do
+      let(:branch) { 'bash' }
       let(:cmd) { [:cmd,  "curl -sf  -o $CASHER_DIR/bin/casher #{url}",retry: true, echo: "Installing caching utilities from the Travis CI server (https://#{Travis::Build.config.app_host.output_safe}/files/casher) failed, failing over to using GitHub (#{url})"] }
       it { should include_sexp [:export, ['CASHER_DIR', '${TRAVIS_HOME}/.casher'], echo: true] }
       it { should include_sexp [:mkdir, '$CASHER_DIR/bin', recursive: true] }


### PR DESCRIPTION
Alternatively, we can force push `casher`'s `production` branch to point to the `bash` version, but that would require both .org and .com to use it at the same time. To limit the scope of testing, we tell `travis-build` to fetch the bash version instead.