### PR TITLE
Fix failure when setting Elm version(s)

### DIFF
--- a/lib/travis/build/script/elm.rb
+++ b/lib/travis/build/script/elm.rb
@@ -97,7 +97,7 @@ module Travis
         private
 
           def elm_version
-            config[:elm].to_s
+            Array(config[:elm]).first.to_s
           end
 
           def elm_version_number(index)

--- a/spec/build/script/elm_spec.rb
+++ b/spec/build/script/elm_spec.rb
@@ -36,6 +36,15 @@ describe Travis::Build::Script::Elm, :sexp do
     end
   end
 
+  context "given 'elm: [elm0.18.0]'" do
+    it "sets TRAVIS_ELM_* environment variables to elm0.18.0" do
+      data[:config][:elm] = ['elm0.18.0']
+      should include_sexp [:export, ['TRAVIS_ELM_VERSION', 'elm0.18.0']]
+      should include_sexp [:export, ['TRAVIS_ELM_TEST_VERSION', 'elm0.18.0']]
+      should include_sexp [:export, ['TRAVIS_ELM_FORMAT_VERSION', 'elm0.18.0']]
+    end
+  end
+
   context "given 'elm_test: elm0.18.0'" do
     it "sets TRAVIS_ELM_* environment variables correctly" do
       data[:config][:elm_test] = 'elm0.18.0'


### PR DESCRIPTION
```yaml
- language: elm
  elm:
    - 0.19.0
```

```sh
$ npm install -g elm@["0.19.0"]
npm ERR! code EINVALIDTAGNAME
npm ERR! Invalid tag name "[0.19.0]": Tags may not have any characters that encodeURIComponent encodes.
npm ERR! A complete log of this run can be found in:
npm ERR!     /home/travis/.npm/_logs/2019-06-12T06_14_44_617Z-debug.log
The command "npm install -g elm@["0.19.0"]" failed and exited with 1 during .
```