### PR TITLE
Reduce connect timeout

### DIFF
--- a/lib/travis/build/bash/travis_download.bash
+++ b/lib/travis/build/bash/travis_download.bash
@@ -3,12 +3,12 @@ travis_download() {
   local dst="${2}"
 
   if curl --version &>/dev/null; then
-    curl -fsSL --connect-timeout 5 "${src}" -o "${dst}" 2>/dev/null
+    curl -fsSL --connect-timeout 1 "${src}" -o "${dst}" 2>/dev/null
     return "${?}"
   fi
 
   if wget --version &>/dev/null; then
-    wget --connect-timeout 5 -q "${src}" -O "${dst}" 2>/dev/null
+    wget --connect-timeout 1 -q "${src}" -O "${dst}" 2>/dev/null
     return "${?}"
   fi
 


### PR DESCRIPTION
Curl will retry 3 times by default, thus with a timeout of 5 seconds and a non working network we will see a pause of 20 seconds. If the network is not working, 3 retries with 1 second timeout is enough.