### PR TITLE
Fix failure when setting Rust version(s)

### DIFF
--- a/lib/travis/build/script/rust.rb
+++ b/lib/travis/build/script/rust.rb
@@ -12,7 +12,7 @@ module Travis
         def export
           super
 
-          sh.export 'TRAVIS_RUST_VERSION', config[:rust].to_s.shellescape, echo: false
+          sh.export 'TRAVIS_RUST_VERSION', version.shellescape, echo: false
         end
 
         def setup_cache

--- a/spec/build/script/rust_spec.rb
+++ b/spec/build/script/rust_spec.rb
@@ -40,6 +40,15 @@ describe Travis::Build::Script::Rust, :sexp do
     should include_sexp [:cmd, 'cargo test --verbose', echo: true, timing: true]
   end
 
+  context "when Rust version is an array" do
+    let(:version) { 'nightly' }
+    let(:data) { payload_for(:push, :rust, config: { rust: [version] }) }
+
+    it 'sets TRAVIS_RUST_VERSION environment variables the first version specified' do
+      should include_sexp [:export, ['TRAVIS_RUST_VERSION', version]]
+    end
+  end
+
   context "when cache is configured" do
     let(:options) { { fetch_timeout: 20, push_timeout: 30, type: 's3', s3: { bucket: 's3_bucket', secret_access_key: 's3_secret_access_key', access_key_id: 's3_access_key_id' } } }
     let(:data)   { payload_for(:push, :rust, config: { cache: 'cargo' }, cache_options: options) }


### PR DESCRIPTION
same as #1718

```yaml
- language: rust
  rust:
    - stable
```

```sh
0.39s$ curl -sSf https://build.travis-ci.org/files/rustup-init.sh | sh -s -- --default-toolchain=$TRAVIS_RUST_VERSION -y
info: downloading installer
Warning: Not forcing TLS v1.2, this is potentially less secure
error: Pre-checks for host and toolchain failed: invalid toolchain name: '["stable"]'
I
```