### PR TITLE
Handle arch specification in Julia script

### DIFF
--- a/lib/travis/build/script/julia.rb
+++ b/lib/travis/build/script/julia.rb
@@ -40,6 +40,9 @@ module Travis
             sh.cmd 'CURL_USER_AGENT="Travis-CI $(curl --version | head -n 1)"'
             case config[:os]
             when 'linux'
+              if config[:julia] == 'nightly' && config[:arch] == 'arm64'
+                sh.failure 'Nightly Julia binaries are not available for AArch64'
+              end
               sh.cmd 'mkdir -p ~/julia'
               sh.cmd %Q{curl -A "$CURL_USER_AGENT" -s -L --retry 7 '#{julia_url}' } \
                        '| tar -C ~/julia -x -z --strip-components=1 -f -'
@@ -113,9 +116,16 @@ module Travis
           def julia_url
             case config[:os]
             when 'linux'
-              osarch = 'linux/x64'
-              ext = 'linux-x86_64.tar.gz'
-              nightlyext = 'linux64.tar.gz'
+              case config[:arch]
+              when 'arm64'
+                osarch = 'linux/aarch64'
+                ext = 'linux-aarch64.tar.gz'
+                nightlyext = nil  # There are no nightlies for ARM
+              else
+                osarch = 'linux/x64'
+                ext = 'linux-x86_64.tar.gz'
+                nightlyext = 'linux64.tar.gz'
+              end
             when 'osx'
               osarch = 'mac/x64'
               ext = 'mac64.dmg'


### PR DESCRIPTION
Currently the Julia script assumes that the architecture for Linux is x86-64. This adjusts the logic such that `config[:arch]` is handled appropriately for arm64, which Julia calls AArch64.

Note that not all versions of Julia have AArch64 binaries available, as it's not considered a tier 1 platform (so binaries are usually but not always available for releases). Thus requesting a particular Julia version with `arch: arm64` may fail, probably with some kind of weird, cryptic message from curl. The case of nightly binaries with ARM is handled explicitly here though, as we do not now nor have we ever had ARM nightly binaries.

cc @joshk