### PR TITLE
Set Julia release version to 1.0

### DIFF
--- a/lib/travis/build/script/julia.rb
+++ b/lib/travis/build/script/julia.rb
@@ -121,10 +121,12 @@ module Travis
               ext = 'mac64.dmg'
               nightlyext = ext
             end
-            case julia_version = Array(config[:julia]).first.to_s
-            when 'release'
+            julia_version = Array(config[:julia]).first.to_s
+            if julia_version == 'release'
               # CHANGEME on new minor releases (once or twice a year)
-              url = "julialang-s3.julialang.org/bin/#{osarch}/0.6/julia-0.6-latest-#{ext}"
+              julia_version = '1.0'
+            end
+            case julia_version
             when 'nightly'
               url = "julialangnightlies-s3.julialang.org/bin/#{osarch}/julia-latest-#{nightlyext}"
             when /^(\d+\.\d+)\.\d+$/


### PR DESCRIPTION
Currently `julia: release` uses Julia 0.6, which is long past end of life. This change sets `release` to point to 1.0, the current long term support version, and slightly simplifies the definition for `release`
rather than duplicating logic.

Do note that this will break builds that are currently assuming that `release` is 0.6, but then again, that is the entire design of `release`, which shouldn't be really be used anyway.

cc @staticfloat @StefanKarpinski