### PR TITLE
Remove GitHub status check logic when clone fails

### DIFF
--- a/lib/travis/build/git/clone.rb
+++ b/lib/travis/build/git/clone.rb
@@ -74,12 +74,10 @@ module Travis
                 sh.cmd "echo #{sparse_checkout} >> #{dir}/.git/info/sparse-checkout", assert: true, retry: true
                 sh.cmd "git -C #{dir} remote add origin #{data.source_url}", assert: true, retry: true
                 sh.cmd "git -C #{dir} pull origin #{branch} #{pull_args}", assert: false, retry: true
-                warn_github_status
                 sh.cmd "cat #{dir}/#{sparse_checkout} >> #{dir}/.git/info/sparse-checkout", assert: true, retry: true
                 sh.cmd "git -C #{dir} reset --hard", assert: true, timing: false
               else
                 git_clone
-                warn_github_status
               end
             end
             sh.else do
@@ -159,22 +157,6 @@ module Travis
 
           def config
             data.config
-          end
-
-          def warn_github_status
-            return unless github?
-
-            sh.if "$? -ne 0" do
-              sh.echo "Failed to clone from GitHub.", ansi: :red
-              sh.echo "Checking GitHub status (https://status.github.com/api/last-message.json):"
-              sh.raw "curl -sL https://status.github.com/api/last-message.json | jq -r .[]"
-              sh.raw "travis_terminate 1"
-            end
-          end
-
-          def github?
-            host = data.source_host.to_s.downcase
-            host == 'github.com' || host.end_with?('.github.com')
           end
       end
     end

--- a/spec/build/script/node_js_spec.rb
+++ b/spec/build/script/node_js_spec.rb
@@ -33,7 +33,7 @@ describe Travis::Build::Script::NodeJs, :sexp do
       end
 
       context 'when nvm install fails' do
-        let(:sexp_if)      { sexp_filter(subject, [:if, '$? -ne 0'])[1] }
+        let(:sexp_if)      { sexp_filter(subject, [:if, '$? -ne 0'])[0] }
 
         it 'tries to use locally available version' do
           expect(sexp_if).to include_sexp [:cmd, 'nvm use 0.9', echo: true]

--- a/spec/build/script/php_spec.rb
+++ b/spec/build/script/php_spec.rb
@@ -146,7 +146,7 @@ describe Travis::Build::Script::Php, :sexp do
   describe 'when desired PHP version is not found' do
     let(:version) { '7.0.0beta2' }
     let(:data) { payload_for(:push, :php, config: { php: version }) }
-    let(:sexp) { sexp_find(sexp_filter(subject, [:if, "$? -ne 0"])[1], [:then]) }
+    let(:sexp) { sexp_find(sexp_filter(subject, [:if, "$? -ne 0"])[0], [:then]) }
 
     it 'installs PHP version on demand' do
       expect(sexp).to include_sexp [:raw, "archive_url=https://s3.amazonaws.com/travis-php-archives/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/php-#{version}.tar.bz2", assert: true]


### PR DESCRIPTION
The API endpoint no longer exists

The specs need fixing because there are one fewer
nodes that checks `$0 -ne 0`.