### PR TITLE
Skip setting mirror unless maven is configured

### DIFF
--- a/lib/travis/build/bash/travis_maven_central_mirror.bash
+++ b/lib/travis/build/bash/travis_maven_central_mirror.bash
@@ -1,5 +1,7 @@
 travis_maven_central_mirror() {
   local google_mirror=$1
+  if [[ ! -f $HOME/.m2/settings.xml ]]; then return; fi
+
   ruby -rrexml/document -e "doc=REXML::Document.new(File.read('$HOME/.m2/settings.xml')); doc.elements['/settings'] << REXML::Document.new('<mirrors>
     <mirror>
       <id>google-maven-central</id>


### PR DESCRIPTION
Notably, our Mac images may not have it. https://travis-ci.community/t/previously-working-build-failing-with-services-are-not-supported-on-osx/3960