### PR TITLE
Check presence of `*file` when using shortcuts

### DIFF
--- a/lib/travis/build/script/objective_c.rb
+++ b/lib/travis/build/script/objective_c.rb
@@ -60,6 +60,13 @@ module Travis
               end
             end
           end
+          sh.else do
+            if data.cache?(:cocoapods)
+              sh.echo "cocoapods caching configured but a podfile is not found. Caching may not work.", ansi: :yellow
+            else
+              sh.raw ':'
+            end
+          end
         end
 
         def install

--- a/lib/travis/build/script/shared/bundler.rb
+++ b/lib/travis/build/script/shared/bundler.rb
@@ -52,6 +52,13 @@ module Travis
               end
             end
           end
+          sh.else do
+            if data.cache?(:bundler)
+              sh.echo "bundler caching is configured but a Gemfile is not found. Caching may not work.", ansi: :yellow
+            else
+              sh.raw ':'
+            end
+          end
         end
 
         def install


### PR DESCRIPTION
For `cache: bundler` and `cache: cocoapods` (and equivalent),
we do not set up caching if the required file is not found.
This needs to be communicated to the users.