### PR TITLE
Fail non-Linux Hack jobs

### DIFF
--- a/lib/travis/build/script/hack.rb
+++ b/lib/travis/build/script/hack.rb
@@ -26,6 +26,11 @@ module Travis
         attr_accessor :hhvm_version, :hhvm_package_name, :lts_p
 
         def configure
+          unless config[:os] == 'linux'
+            sh.failure "Currently, Hack is supported only on Linux"
+            return
+          end
+
           if md = HHVM_VERSION_REGEXP.match(version)
             @hhvm_version = md[:num]
             @hhvm_package_name = md[:name] ? md[0] : 'hhvm'
@@ -33,6 +38,7 @@ module Travis
           else
             sh.echo "Unsupported hhvm version given #{version}"
             sh.failure ""
+            return
           end
 
           configure_hhvm

--- a/spec/build/script/hack_spec.rb
+++ b/spec/build/script/hack_spec.rb
@@ -24,6 +24,17 @@ describe Travis::Build::Script::Hack, :sexp do
     end
   end
 
+  context 'on mac' do
+    before { data[:config][:os] = 'osx' }
+
+    it "fails" do
+      store_example name: 'mac'
+      should include_sexp [:echo, /Currently, Hack is supported only on Linux/]
+      should include_sexp [:raw, 'false']
+      should_not include_sexp [:cmd, "sudo apt-get install hhvm -y 2>&1 >/dev/null", assert: true, timing: true, echo: true]
+    end
+  end
+
   HHVM_NUMERIC_VERSIONS = [
     nil,
     'hhvm',


### PR DESCRIPTION
Until we implement [Homebrew-based installation](https://docs.hhvm.com/hhvm/installation/mac), we should reject `language: hack` + `os: mac`.