### PR TITLE
Install rethinkdb despite expired GPG key

### DIFF
--- a/lib/travis/build/addons/rethinkdb.rb
+++ b/lib/travis/build/addons/rethinkdb.rb
@@ -19,7 +19,7 @@ module Travis
               sh.cmd 'echo -e "\ndeb http://download.rethinkdb.com/apt $(lsb_release -cs) main" | sudo tee -a /etc/apt/sources.list > /dev/null'
               sh.cmd 'travis_apt_get_update', assert: false
               sh.cmd "package_version=`apt-cache show rethinkdb | grep -F \"Version: #{rethinkdb_version}\" | sort -r | head -n 1 | awk '{printf $2}'`"
-              sh.cmd "apt-get install -y -o Dpkg::Options::='--force-confnew' rethinkdb=$package_version", sudo: true, echo: true, timing: true
+              sh.cmd "apt-get install -y -o Dpkg::Options::='--force-confnew' --allow-unauthenticated rethinkdb=$package_version", sudo: true, echo: true, timing: true
               sh.echo "Installing RethinkDB default instance configuration"
               sh.cmd "cp /etc/rethinkdb/default.conf.sample /etc/rethinkdb/instances.d/default.conf", sudo: true
               sh.echo "Starting RethinkDB v#{rethinkdb_version}", ansi: :yellow
@@ -39,4 +39,3 @@ module Travis
     end
   end
 end
-

--- a/spec/build/addons/rethinkdb_spec.rb
+++ b/spec/build/addons/rethinkdb_spec.rb
@@ -27,7 +27,7 @@ describe Travis::Build::Addons::Rethinkdb, :sexp do
   it { should include_sexp [:cmd, "wget -qO- https://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -v -''", echo: true] }
   it { should include_sexp [:cmd, 'echo -e "\ndeb http://download.rethinkdb.com/apt $(lsb_release -cs) main" | sudo tee -a /etc/apt/sources.list > /dev/null'] }
   it { should include_sexp [:cmd, 'travis_apt_get_update'] }
-  it { should include_sexp [:cmd, "apt-get install -y -o Dpkg::Options::='--force-confnew' rethinkdb=$package_version", sudo: true, echo: true, timing: true] }
+  it { should include_sexp [:cmd, "apt-get install -y -o Dpkg::Options::='--force-confnew' --allow-unauthenticated rethinkdb=$package_version", sudo: true, echo: true, timing: true] }
   it { should include_sexp [:cmd, "cp /etc/rethinkdb/default.conf.sample /etc/rethinkdb/instances.d/default.conf", sudo: true] }
   it { should include_sexp [:cmd, "service rethinkdb start", sudo: true, echo: true, timing: true] }
   it { should include_sexp [:cmd, "rethinkdb --version", echo: true] }


### PR DESCRIPTION
Due to https://github.com/rethinkdb/rethinkdb/issues/6750, installation
is failing.