### PR TITLE
Fix URL for downloading R-devel on macOS

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -122,9 +122,9 @@ module Travis
                 # output.
                 sh.cmd 'brew update >/dev/null', retry: true
 
-                # R-devel builds available at research.att.com
+                # R-devel builds available at mac.r-project.org
                 if r_version == 'devel'
-                  r_url = "https://r.research.att.com/el-capitan/R-devel/R-devel-el-capitan-signed.pkg"
+                  r_url = "https://mac.r-project.org/el-capitan/R-devel/R-devel-el-capitan.pkg"
 
                 # The latest release is the only one available in /bin/macosx
                 elsif r_version == r_latest

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -75,7 +75,7 @@ describe Travis::Build::Script::R, :sexp do
   it 'downloads and installs R devel on OS X' do
     data[:config][:os] = 'osx'
     data[:config][:r] = 'devel'
-    should include_sexp [:cmd, %r{^curl.*r\.research\.att\.com/el-capitan/R-devel/R-devel-el-capitan-signed\.pkg},
+    should include_sexp [:cmd, %r{^curl.*mac-r\.project\.org/el-capitan/R-devel/R-devel-el-capitan\.pkg},
                          assert: true, echo: true, retry: true, timing: true]
   end
   it 'downloads and installs gfortran libraries on OS X' do

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -75,7 +75,7 @@ describe Travis::Build::Script::R, :sexp do
   it 'downloads and installs R devel on OS X' do
     data[:config][:os] = 'osx'
     data[:config][:r] = 'devel'
-    should include_sexp [:cmd, %r{^curl.*mac-r\.project\.org/el-capitan/R-devel/R-devel-el-capitan\.pkg},
+    should include_sexp [:cmd, %r{^curl.*mac\.r-project\.org/el-capitan/R-devel/R-devel-el-capitan\.pkg},
                          assert: true, echo: true, retry: true, timing: true]
   end
   it 'downloads and installs gfortran libraries on OS X' do


### PR DESCRIPTION
The current URL 404s: https://travis-ci.org/nealrichardson/arrow-r-ci/jobs/554464322#L58

https://r.research.att.com/el-capitan/R-devel/ redirects to https://mac.r-project.org/el-capitan/R-devel/ and shows that the correct file name is R-devel-el-capitan.pkg

cc @jimhester @jeroen