### PR TITLE
Enable apt addon for Bionic

### DIFF
--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -13,6 +13,7 @@ module Travis
           precise
           trusty
           xenial
+          bionic
         ).freeze
 
         attr_reader :safelisted, :disallowed_while_sudo

--- a/lib/travis/build/config.rb
+++ b/lib/travis/build/config.rb
@@ -44,12 +44,18 @@ module Travis
             'http://archive.ubuntu.com/ubuntu/'
           )
         },
-        apt_package_safelist: Hash.new { |hash, dist| hash[dist] = \
-            ENV.fetch("TRAVIS_BUILD_APT_PACKAGE_SAFELIST_#{dist.upcase}", '')
+        apt_package_safelist: {
+          precise: ENV.fetch('TRAVIS_BUILD_APT_PACKAGE_SAFELIST_PRECISE', ''),
+          trusty: ENV.fetch('TRAVIS_BUILD_APT_PACKAGE_SAFELIST_TRUSTY', ''),
+          xenial: ENV.fetch('TRAVIS_BUILD_APT_PACKAGE_SAFELIST_XENIAL', ''),
+          bionic: ENV.fetch('TRAVIS_BUILD_APT_PACKAGE_SAFELIST_BIONIC', ''),
         },
         apt_proxy: ENV.fetch('TRAVIS_BUILD_APT_PROXY', ''),
-        apt_source_alias_list: Hash.new { |hash, dist| hash[dist] = \
-            ENV.fetch("TRAVIS_BUILD_APT_SOURCE_ALIAS_LIST_#{dist.upcase}", '')
+        apt_source_alias_list: {
+          precise: ENV.fetch('TRAVIS_BUILD_APT_SOURCE_ALIAS_LIST_PRECISE', ''),
+          trusty: ENV.fetch('TRAVIS_BUILD_APT_SOURCE_ALIAS_LIST_TRUSTY', ''),
+          xenial: ENV.fetch('TRAVIS_BUILD_APT_SOURCE_ALIAS_LIST_XENIAL', ''),
+          bionic: ENV.fetch('TRAVIS_BUILD_APT_SOURCE_ALIAS_LIST_BIONIC', ''),
         },
         apt_source_alias_list_key_url_template: ENV.fetch(
           'TRAVIS_BUILD_APT_SOURCE_ALIAS_LIST_KEY_URL_TEMPLATE',

--- a/lib/travis/build/config.rb
+++ b/lib/travis/build/config.rb
@@ -44,16 +44,12 @@ module Travis
             'http://archive.ubuntu.com/ubuntu/'
           )
         },
-        apt_package_safelist: {
-          precise: ENV.fetch('TRAVIS_BUILD_APT_PACKAGE_SAFELIST_PRECISE', ''),
-          trusty: ENV.fetch('TRAVIS_BUILD_APT_PACKAGE_SAFELIST_TRUSTY', ''),
-          xenial: ENV.fetch('TRAVIS_BUILD_APT_PACKAGE_SAFELIST_XENIAL', ''),
+        apt_package_safelist: Hash.new { |hash, dist| hash[dist] = \
+            ENV.fetch("TRAVIS_BUILD_APT_PACKAGE_SAFELIST_#{dist.upcase}", '')
         },
         apt_proxy: ENV.fetch('TRAVIS_BUILD_APT_PROXY', ''),
-        apt_source_alias_list: {
-          precise: ENV.fetch('TRAVIS_BUILD_APT_SOURCE_ALIAS_LIST_PRECISE', ''),
-          trusty: ENV.fetch('TRAVIS_BUILD_APT_SOURCE_ALIAS_LIST_TRUSTY', ''),
-          xenial: ENV.fetch('TRAVIS_BUILD_APT_SOURCE_ALIAS_LIST_XENIAL', ''),
+        apt_source_alias_list: Hash.new { |hash, dist| hash[dist] = \
+            ENV.fetch("TRAVIS_BUILD_APT_SOURCE_ALIAS_LIST_#{dist.upcase}", '')
         },
         apt_source_alias_list_key_url_template: ENV.fetch(
           'TRAVIS_BUILD_APT_SOURCE_ALIAS_LIST_KEY_URL_TEMPLATE',

--- a/spec/build/addons/apt_spec.rb
+++ b/spec/build/addons/apt_spec.rb
@@ -109,7 +109,7 @@ describe Travis::Build::Addons::Apt, :sexp do
 
     it 'defaults source safelist to empty hash' do
       expect(described_class.source_alias_lists)
-        .to eql({ precise: {}, trusty: {}, xenial: {}, unset: {} })
+        .to eql({ unset: {}, precise: {}, trusty: {}, xenial: {}, bionic: {} })
     end
   end
 


### PR DESCRIPTION
Fixes https://travis-ci.community/t/apt-addon-doesnt-run-in-bionic/4061.

I thought to make the hardcoded dist list unneeded by checking `$(lsb_release -is) == "Ubuntu"` but this can only be done if `travis_build` runs on the build machine. Is that true?