### PR TITLE
use printf rather than echo -e to report command result

### DIFF
--- a/lib/travis/build/bash/travis_assert.bash
+++ b/lib/travis/build/bash/travis_assert.bash
@@ -1,7 +1,8 @@
 travis_assert() {
   local result="${1:-${?}}"
   if [[ "${result}" -ne 0 ]]; then
-    echo -e "${ANSI_RED}The command \"${TRAVIS_CMD}\" failed and exited with ${result} during ${TRAVIS_STAGE}.${ANSI_RESET}\\n\\nYour build has been stopped."
+    printf "${ANSI_RED}The command \"%s\" failed and exited with ${result} during %s.${ANSI_RESET}\\n" "${TRAVIS_CMD}" "${TRAVIS_STAGE}"
+    printf "\\nYour build has been stopped.\\n"
     travis_terminate 2
   fi
 }

--- a/lib/travis/build/bash/travis_result.bash
+++ b/lib/travis/build/bash/travis_result.bash
@@ -3,8 +3,8 @@ travis_result() {
   export TRAVIS_TEST_RESULT=$((${TRAVIS_TEST_RESULT:-0} | $((result != 0))))
 
   if [[ "${result}" -eq 0 ]]; then
-    echo -e "${ANSI_GREEN}The command \"${TRAVIS_CMD}\" exited with ${result}.${ANSI_RESET}\\n"
+    printf "${ANSI_GREEN}The command \"%s\" exited with ${result}.${ANSI_RESET}\\n" "${TRAVIS_CMD}"
   else
-    echo -e "${ANSI_RED}The command \"${TRAVIS_CMD}\" exited with ${result}.${ANSI_RESET}\\n"
+    printf "${ANSI_RED}The command \"%s\" exited with ${result}.${ANSI_RESET}\\n" "${TRAVIS_CMD}"
   fi
 }

--- a/lib/travis/build/bash/travis_wait.bash
+++ b/lib/travis/build/bash/travis_wait.bash
@@ -24,9 +24,9 @@ travis_wait() {
   }
 
   if [[ "${result}" -eq 0 ]]; then
-    echo -e "\\n${ANSI_GREEN}The command ${cmd[*]} exited with ${result}.${ANSI_RESET}"
+    printf "\\n${ANSI_GREEN}The command %s exited with ${result}.${ANSI_RESET}\\n" "${cmd[*]}"
   else
-    echo -e "\\n${ANSI_RED}The command ${cmd[*]} exited with ${result}.${ANSI_RESET}"
+    printf "\\n${ANSI_RED}The command %s exited with ${result}.${ANSI_RESET}\\n" "${cmd[*]}"
   fi
 
   echo -e "\\n${ANSI_GREEN}Log:${ANSI_RESET}\\n"


### PR DESCRIPTION
This PR makes the command string printed in "The command ${cmd} exited with ${result}" come out verbatim, without interpreting backslash escapes in the command string.

Example showing the issue, with this in .travis.yml:
```yaml
script:
  - printf >>config.py '%s = False\n' BENCHMARK DEMO
```

The command appears in build log twice, first verbatim, but then with a newline in place of `\n`:
```
$ printf >>config.py '%s = False\n' BENCHMARK DEMO
The command "printf >>config.py '%s = False
' BENCHMARK DEMO" exited with 0.
```
