### PR TITLE
R: fix R installation on macOS for versions < 3.2

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -147,7 +147,13 @@ module Travis
                 sh.cmd "curl -fLo /tmp/R.pkg #{r_url}", retry: true
 
                 sh.echo 'Installing OS X binary package for R'
-                sh.cmd 'sudo installer -pkg "/tmp/R.pkg" -target /'
+                if r_version_less_than('3.2.0')
+                  # Old R installers would fail with:
+                  # "Certificate used to sign package is not trusted"
+                  sh.cmd 'sudo installer -pkg "/tmp/R.pkg" -target / -allowUntrusted'
+                else
+                  sh.cmd 'sudo installer -pkg "/tmp/R.pkg" -target /'
+                end
                 sh.rm '/tmp/R.pkg'
 
                 setup_fortran_osx if config[:fortran]

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -66,11 +66,13 @@ describe Travis::Build::Script::R, :sexp do
     should include_sexp [:cmd, %r{^curl.*bin/macosx/old/R-3\.2\.4-revised\.pkg},
                          assert: true, echo: true, retry: true, timing: true]
   end
-  it 'downloads and installs other R versions on OS X' do
+  it 'downloads and installs older R versions on OS X' do
     data[:config][:os] = 'osx'
     data[:config][:r] = '3.1.3'
     should include_sexp [:cmd, %r{^curl.*bin/macosx/old/R-3\.1\.3\.pkg},
                          assert: true, echo: true, retry: true, timing: true]
+    should include_sexp [:cmd, %r{^sudo installer -pkg "/tmp/R\.pkg" -target / -allowUntrusted},
+                         assert: true, echo: true, timing: true]
   end
   it 'downloads and installs R devel on OS X' do
     data[:config][:os] = 'osx'


### PR DESCRIPTION
When installing versions of R older than 3.2 on macOS, the installer fails on a certificate error:

```
$ curl -fLo /tmp/R.pkg http://cloud.r-project.org/bin/macosx/old/R-3.1.3.pkg
Installing OS X binary package for R
$ sudo installer -pkg "/tmp/R.pkg" -target /
installer: Package name is R 3.1.3 for Mac OS X 10.6 or higher (Snow Leopard build)
installer: Certificate used to sign package is not trusted. Use -allowUntrusted to override.
The command "sudo installer -pkg "/tmp/R.pkg" -target /" failed and exited with 1 during .
```

See https://travis-ci.org/ursa-labs/arrow-r-nightly/jobs/573914998 for example. 

This PR adds the -allowUntrusted argument for sufficiently old versions. I added a test assertion that the flag is added, but the test does not confirm that this executes successfully (just as the existing test passes even though builds fail).

cc @jeroen @jimhester 