### PR TITLE
Pin tmate to 2.2.1

### DIFF
--- a/lib/travis/build/rake_tasks.rb
+++ b/lib/travis/build/rake_tasks.rb
@@ -278,7 +278,7 @@ module Travis
       end
 
       def file_update_tmate
-        latest_release = latest_release_for('tmate-io/tmate')
+        latest_release = '2.2.1'
         logger.info "Latest tmate release is #{latest_release}"
         fetch_githubusercontent_file(
           File.join(


### PR DESCRIPTION
The latest release 2.3.0 doesn't have binary archives.

https://github.com/tmate-io/tmate/issues/159