### PR TITLE
Don't install mariadb-server

### DIFF
--- a/lib/travis/build/addons/mariadb.rb
+++ b/lib/travis/build/addons/mariadb.rb
@@ -23,7 +23,7 @@ module Travis
             end
             sh.cmd 'add-apt-repository "deb http://%p/mariadb/repo/%p/ubuntu $TRAVIS_DIST main"' % [MARIADB_MIRROR, mariadb_version], sudo: true
             sh.cmd 'travis_apt_get_update', retry: true, echo: true
-            sh.cmd "PACKAGES='mariadb-server mariadb-server-#{mariadb_version}'", echo: true
+            sh.cmd "PACKAGES='mariadb-server-#{mariadb_version}'", echo: true
             sh.cmd "if [[ $(lsb_release -cs) = 'precise' ]]; then PACKAGES=\"${PACKAGES} libmariadbclient-dev\"; fi", echo: true
             sh.if '"$TRAVIS_DIST" != precise && "$TRAVIS_DIST" != trusty' do
               sh.cmd 'rm -rf /var/lib/mysql', sudo: true, echo: false, timing: false

--- a/spec/build/addons/mariadb_spec.rb
+++ b/spec/build/addons/mariadb_spec.rb
@@ -23,7 +23,7 @@ describe Travis::Build::Addons::Mariadb, :sexp do
   it { should include_sexp [:cmd, "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 #{Travis::Build::Addons::Mariadb::MARIADB_GPG_KEY_OLD}", sudo: true] }
   it { should include_sexp [:cmd, 'add-apt-repository "deb http://%p/mariadb/repo/%p/ubuntu $TRAVIS_DIST main"' % [Travis::Build::Addons::Mariadb::MARIADB_MIRROR, config], sudo: true] }
   it { should include_sexp [:cmd, 'travis_apt_get_update', retry: true, echo: true] }
-  it { should include_sexp [:cmd, "PACKAGES='mariadb-server mariadb-server-10.0'", echo: true] }
+  it { should include_sexp [:cmd, "PACKAGES='mariadb-server-10.0'", echo: true] }
   it { should include_sexp [:cmd, "rm -rf /var/lib/mysql", sudo: true] }
   it { should include_sexp [:cmd, "apt-get install -y -o Dpkg::Options::='--force-confnew' $PACKAGES", sudo: true, echo: true, timing: true] }
   it { should include_sexp [:cmd, "service mysql start", sudo: true, echo: true, timing: true] }


### PR DESCRIPTION
It's a metapackage dependent on the "best" available version (10.3 as of this writing).
So installing it makes it impossible to install anything but 10.3.

https://travis-ci.community/t/mariadb-10-1-add-on-installation-broken/4398/4