### PR TITLE
Allow user to specify core.autocrlf in .travis.yml

### DIFF
--- a/lib/travis/build/git/clone.rb
+++ b/lib/travis/build/git/clone.rb
@@ -66,6 +66,9 @@ module Travis
           end
 
           def clone_or_fetch
+            if autocrlf
+              sh.cmd "git config --global core.autocrlf #{autocrlf}"
+            end
             sh.if "! -d #{dir}/.git" do
               if sparse_checkout
                 sh.echo "Cloning with sparse checkout specified with #{sparse_checkout}", ansi: :yellow
@@ -129,6 +132,10 @@ module Travis
             else
               ""
             end
+          end
+
+          def autocrlf
+            config[:git][:autocrlf]
           end
 
           def branch


### PR DESCRIPTION
This addresses https://travis-ci.community/t/files-in-checkout-have-eol-changed-from-lf-to-crlf/349 and https://travis-ci.community/t/feature-request-update-git-configure-core-autocrlf/1102.

The default leaves the current behaviour exactly intact but allows users to specify `core.autocrlf`. Merging this would require an update to https://github.com/travis-ci/docs-travis-ci-com/blob/master/user/customizing-the-build.md which I'm happy to do if this PR is acceptable.