### PR TITLE
Don't print sudo warnings

### DIFF
--- a/lib/travis/build/appliances/fix_etc_hosts.rb
+++ b/lib/travis/build/appliances/fix_etc_hosts.rb
@@ -5,7 +5,7 @@ module Travis
     module Appliances
       class FixEtcHosts < Base
         def apply
-          sh.raw %(sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 '`hostname`'/' -i'.bak' /etc/hosts)
+          sh.raw %(sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 '`hostname`'/' -i'.bak' /etc/hosts 2> /dev/null)
         end
 
         def apply?

--- a/lib/travis/build/appliances/put_localhost_first.rb
+++ b/lib/travis/build/appliances/put_localhost_first.rb
@@ -10,9 +10,9 @@ module Travis
           # remove lines with 127.0.0.1
           sh.raw %q(sed '/^127\.0\.0\.1/d' /etc/hosts > /tmp/hosts_sans_127_0_0_1)
           # reconstruct /etc/hosts
-          sh.raw %q(cat /tmp/hosts_sans_127_0_0_1 | sudo tee /etc/hosts > /dev/null)
-          sh.raw %q(echo -n "127.0.0.1 localhost " | sudo tee -a /etc/hosts > /dev/null)
-          sh.raw %q({ cat /tmp/hosts_127_0_0_1; echo; } | sudo tee -a /etc/hosts > /dev/null)
+          sh.raw %q(cat /tmp/hosts_sans_127_0_0_1 | sudo tee /etc/hosts &> /dev/null)
+          sh.raw %q(echo -n "127.0.0.1 localhost " | sudo tee -a /etc/hosts &> /dev/null)
+          sh.raw %q({ cat /tmp/hosts_127_0_0_1; echo; } | sudo tee -a /etc/hosts &> /dev/null)
         end
       end
     end

--- a/spec/build/script/shared/appliances/fix_etc_hosts.rb
+++ b/spec/build/script/shared/appliances/fix_etc_hosts.rb
@@ -1,5 +1,5 @@
 shared_examples_for 'fix etc/hosts' do
-  let(:fix_etc_hosts) { "sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 '`hostname`'/' -i'.bak' /etc/hosts" }
+  let(:fix_etc_hosts) { "sudo sed -e 's/^\\(127\\.0\\.0\\.1.*\\)$/\\1 '`hostname`'/' -i'.bak' /etc/hosts 2> /dev/null" }
 
   it 'adds an entry to /etc/hosts for localhost' do
     should include_sexp [:raw, fix_etc_hosts]


### PR DESCRIPTION
This hides the sudo warnings on bionic build.

Example bad build:
https://staging.travis-ci.org/DamianSzymanski/qa/builds/748259

Example fixed:
https://staging.travis-ci.org/DamianSzymanski/qa/builds/748263