### PR TITLE
Update all named Rust channels

### DIFF
--- a/lib/travis/build/script/rust.rb
+++ b/lib/travis/build/script/rust.rb
@@ -37,7 +37,7 @@ module Travis
               sh.cmd RUSTUP_CMD, echo: true, assert: true
             end
             sh.export 'PATH', "${TRAVIS_HOME}/.cargo/bin:$PATH"
-            if version.include? 'nightly'
+            if version =~ /nightly|stable|beta/
               sh.cmd 'rustup update', echo: true
             end
           end

--- a/spec/build/script/rust_spec.rb
+++ b/spec/build/script/rust_spec.rb
@@ -28,6 +28,10 @@ describe Travis::Build::Script::Rust, :sexp do
     should include_sexp [:cmd, 'cargo --version', assert: true, echo: true]
   end
 
+  it 'runs rustup update' do
+    should include_sexp [:cmd, 'rustup update', echo: true, timing: true, assert: true]
+  end
+
   it 'runs cargo test' do
     should include_sexp [:cmd, 'cargo test --verbose', echo: true, timing: true]
   end


### PR DESCRIPTION
Previously, we did this only for `nightly` (https://github.com/travis-ci/travis-build/pull/1758), but this is useful for
other channels as well.

See also: https://travis-ci.community/t/stable-rust-channel-outdated/4213