### PR TITLE
Show apt debug information if MariaDB package install fails

### DIFF
--- a/lib/travis/build/addons/mariadb.rb
+++ b/lib/travis/build/addons/mariadb.rb
@@ -28,7 +28,7 @@ module Travis
             sh.if '"$TRAVIS_DIST" != precise && "$TRAVIS_DIST" != trusty' do
               sh.cmd 'rm -rf /var/lib/mysql', sudo: true, echo: false, timing: false
             end
-            sh.cmd "apt-get install -y -o Dpkg::Options::='--force-confnew' $PACKAGES", sudo: true, echo: true, timing: true
+            sh.cmd "apt-get install -y -o Debug::pkgProblemResolver=yes -o Dpkg::Options::='--force-confnew' $PACKAGES", sudo: true, echo: true, timing: true
             sh.echo "Starting MariaDB v#{mariadb_version}", ansi: :yellow
             sh.if '"$TRAVIS_INIT" == upstart' do
               sh.cmd "service mysql start", sudo: true, assert: false, echo: true, timing: true

--- a/spec/build/addons/mariadb_spec.rb
+++ b/spec/build/addons/mariadb_spec.rb
@@ -25,7 +25,7 @@ describe Travis::Build::Addons::Mariadb, :sexp do
   it { should include_sexp [:cmd, 'travis_apt_get_update', retry: true, echo: true] }
   it { should include_sexp [:cmd, "PACKAGES='mariadb-server-10.0'", echo: true] }
   it { should include_sexp [:cmd, "rm -rf /var/lib/mysql", sudo: true] }
-  it { should include_sexp [:cmd, "apt-get install -y -o Dpkg::Options::='--force-confnew' $PACKAGES", sudo: true, echo: true, timing: true] }
+  it { should include_sexp [:cmd, "apt-get install -y -o Debug::pkgProblemResolver=yes -o Dpkg::Options::='--force-confnew' $PACKAGES", sudo: true, echo: true, timing: true] }
   it { should include_sexp [:cmd, "service mysql start", sudo: true, echo: true, timing: true] }
   it { should include_sexp [:cmd, "mysql --version", echo: true] }
 end


### PR DESCRIPTION
The default apt-get error message is useless. This adds debug output from conflicts resolver that allows to see what exactly is wrong, See https://serverfault.com/questions/986463/get-more-information-from-apt-get-if-it-reports-an-impossible-situation