### PR TITLE
Send `nvm install` STDERR to /dev/null for node_js < 1.0

### DIFF
--- a/lib/travis/build/script/node_js/manager/nvm.rb
+++ b/lib/travis/build/script/node_js/manager/nvm.rb
@@ -51,7 +51,7 @@ module Travis
 
           def install_version(ver)
             sh.fold "nvm.install" do
-              sh.cmd "nvm install #{ver}", assert: false, timing: true
+              sh.cmd "nvm install #{ver}#{devnull}", assert: false, timing: true
               sh.if '$? -ne 0' do
                 sh.echo "Failed to install #{ver}. Remote repository may not be reachable.", ansi: :red
                 sh.echo "Using locally available version #{ver}, if applicable."
@@ -62,6 +62,14 @@ module Travis
                 end
               end
               sh.export 'TRAVIS_NODE_VERSION', ver, echo: false
+            end
+          end
+
+          def devnull
+            if node_js.version.start_with? '0'
+              ' 2>/dev/null'
+            else
+              ''
             end
           end
 


### PR DESCRIPTION
To save on log output from `nvm install 0.x`, which could take a lot of log allowance.

This reduces the log output from 28000+ lines to [263 lines](https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/750282)