### PR TITLE
travis_terminate: preserve previous return by default

### DIFF
--- a/lib/travis/build/bash/travis_terminate.bash
+++ b/lib/travis/build/bash/travis_terminate.bash
@@ -1,9 +1,13 @@
 travis_terminate() {
+  local old_ret="$?"
   if [[ ! "${TRAVIS_OS_NAME}" ]]; then
     return
   fi
 
   _travis_terminate_agent
+  if [[ ! $1 ]]; then
+    set -- "$old_ret"
+  fi
   "_travis_terminate_${TRAVIS_OS_NAME}" "${@}"
 }
 


### PR DESCRIPTION
the usual `|| travis_terminate` idiom loses some information by not providing the old return value. Let's fix that.