### PR TITLE
Add Hack support

### DIFF
--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -35,6 +35,7 @@ require 'travis/build/script/objective_c'
 require 'travis/build/script/perl'
 require 'travis/build/script/perl6'
 require 'travis/build/script/php'
+require 'travis/build/script/hack'
 require 'travis/build/script/pure_java'
 require 'travis/build/script/python'
 require 'travis/build/script/r'
@@ -451,7 +452,7 @@ module Travis
         end
 
         def check_deprecation
-          return unless self.class.const_defined?("DEPRECATIONS")
+          return unless self.class.const_defined?("DEPRECATIONS", false)
           self.class.const_get("DEPRECATIONS").each do |cfg|
             if data.language_default_p && DateTime.now < Date.parse(cfg[:cutoff_date])
               sh.echo "Using the default #{cfg[:name] || self.class.name} version #{cfg[:current_default]}. " \

--- a/lib/travis/build/script/hack.rb
+++ b/lib/travis/build/script/hack.rb
@@ -15,11 +15,6 @@ module Travis
           super
         end
 
-        def announce
-          super
-          sh.cmd 'hhvm --version'
-        end
-
         def install
           sh.cmd 'composer install', echo: true, timing: true
         end

--- a/lib/travis/build/script/hack.rb
+++ b/lib/travis/build/script/hack.rb
@@ -10,7 +10,7 @@ module Travis
 
         def configure
           unless hhvm?
-            sh.terminate 2, "Hack requires HHVM, but HHVM is not configured with \`hhvm:\`. Terminating.", ansi: :red
+            sh.terminate 1, "Hack requires HHVM, but HHVM is not configured with \`hhvm:\`. Terminating.", ansi: :red
           end
           super
         end

--- a/lib/travis/build/script/hack.rb
+++ b/lib/travis/build/script/hack.rb
@@ -1,0 +1,42 @@
+module Travis
+  module Build
+    class Script
+      class Hack < Php
+        DEFAULTS = {
+          php: '7.3',
+          composer: '--no-interaction --prefer-source',
+          hhvm: 'hhvm-4.25'
+        }
+
+        def configure
+          unless hhvm?
+            sh.terminate 2, "Hack requires HHVM, but HHVM is not configured with \`hhvm:\`. Terminating.", ansi: :red
+          end
+        end
+
+        def announce
+          super
+          sh.cmd 'hhvm --version'
+        end
+
+        def install
+          sh.cmd 'composer install', echo: true, timing: true
+        end
+
+        def script
+          sh.cmd 'hh_client', echo: true, timing: true
+          sh.if "test -x vendor/bin/hacktest" do
+            sh.cmd 'vendor/bin/hacktest tests/', echo: true, timing: true
+          end
+          sh.if '!(hhvm --version | grep -q -- -dev) && test -x vendor/bin/hhast-lint' do
+            sh.cmd 'vendor/bin/hhast-lint'
+          end
+        end
+
+        def cache_slug
+          super << '--hhvm-' << hhvm_version
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/build/script/hack.rb
+++ b/lib/travis/build/script/hack.rb
@@ -12,6 +12,7 @@ module Travis
           unless hhvm?
             sh.terminate 2, "Hack requires HHVM, but HHVM is not configured with \`hhvm:\`. Terminating.", ansi: :red
           end
+          super
         end
 
         def announce

--- a/lib/travis/build/script/hack.rb
+++ b/lib/travis/build/script/hack.rb
@@ -15,13 +15,6 @@ module Travis
           super
         end
 
-        def setup
-          setup_hhvm
-          setup_php_on_demand php_version
-          sh.cmd "phpenv rehash", assert: false, echo: false, timing: false
-          composer_self_update
-        end
-
         def install
           sh.cmd 'composer install', echo: true, timing: true
         end

--- a/lib/travis/build/script/hack.rb
+++ b/lib/travis/build/script/hack.rb
@@ -25,10 +25,10 @@ module Travis
 
         def script
           sh.cmd 'hh_client', echo: true, timing: true
-          sh.if "test -x vendor/bin/hacktest" do
+          sh.if "-x vendor/bin/hacktest" do
             sh.cmd 'vendor/bin/hacktest tests/', echo: true, timing: true
           end
-          sh.if '!(hhvm --version | grep -q -- -dev) && test -x vendor/bin/hhast-lint' do
+          sh.if '!(hhvm --version | grep -q -- -dev) && -x vendor/bin/hhast-lint' do
             sh.cmd 'vendor/bin/hhast-lint'
           end
         end

--- a/lib/travis/build/script/hack.rb
+++ b/lib/travis/build/script/hack.rb
@@ -36,6 +36,10 @@ module Travis
         def cache_slug
           super << '--hhvm-' << hhvm_version
         end
+
+        def version
+          Array(config[:hhvm]).first.to_s
+        end
       end
     end
   end

--- a/lib/travis/build/script/hack.rb
+++ b/lib/travis/build/script/hack.rb
@@ -8,13 +8,6 @@ module Travis
           hhvm: 'hhvm-4.25'
         }
 
-        def configure
-          unless hhvm?
-            sh.terminate 1, "Hack requires HHVM, but HHVM is not configured with \`hhvm:\`. Terminating.", ansi: :red
-          end
-          super
-        end
-
         def install
           sh.cmd 'composer install', echo: true, timing: true
         end

--- a/lib/travis/build/script/hack.rb
+++ b/lib/travis/build/script/hack.rb
@@ -15,6 +15,13 @@ module Travis
           super
         end
 
+        def setup
+          setup_hhvm
+          setup_php_on_demand php_version
+          sh.cmd "phpenv rehash", assert: false, echo: false, timing: false
+          composer_self_update
+        end
+
         def install
           sh.cmd 'composer install', echo: true, timing: true
         end
@@ -34,7 +41,11 @@ module Travis
         end
 
         def version
-          Array(config[:hhvm]).first.to_s
+          Array(config[:hhvm]).first
+        end
+
+        def php_version
+          Array(config[:php]).first
         end
       end
     end

--- a/lib/travis/build/script/hack.rb
+++ b/lib/travis/build/script/hack.rb
@@ -30,15 +30,11 @@ module Travis
         end
 
         def cache_slug
-          super << '--hhvm-' << hhvm_version
+          super << '--hhvm-' << hhvm_version.to_s
         end
 
-        def version
+        def hhvm_version_raw
           Array(config[:hhvm]).first
-        end
-
-        def php_version
-          Array(config[:php]).first
         end
       end
     end

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -29,14 +29,7 @@ module Travis
         def setup
           super
 
-          if php_5_3_or_older?
-            sh.if "$(lsb_release -sc 2>/dev/null) != precise" do
-              sh.echo "PHP #{version} is supported only on Precise.", ansi: :red
-              sh.echo "See https://docs.travis-ci.com/user/reference/trusty#PHP-images on how to test PHP 5.3 on Precise.", ansi: :red
-              sh.echo "Terminating.", ansi: :red
-              sh.failure
-            end
-          end
+          reject_old_php
 
           if hhvm?
             setup_hhvm
@@ -252,6 +245,17 @@ hhvm.libxml.ext_entity_whitelist=file,http,https
             end
           end
           sh.cmd "phpenv global #{ver}", assert: true
+        end
+
+        def reject_old_php
+          if php_5_3_or_older?
+            sh.if "$(lsb_release -sc 2>/dev/null) != precise" do
+              sh.echo "PHP #{version} is supported only on Precise.", ansi: :red
+              sh.echo "See https://docs.travis-ci.com/user/reference/trusty#PHP-images on how to test PHP 5.3 on Precise.", ansi: :red
+              sh.echo "Terminating.", ansi: :red
+              sh.failure
+            end
+          end
         end
       end
     end

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -31,9 +31,15 @@ module Travis
 
           reject_old_php
 
-          if hhvm?
+          case self
+          when Travis::Build::Script::Php
+            if hhvm?
+              setup_hhvm
+            else
+              setup_php_on_demand version
+            end
+          when Travis::Build::Script::Hack
             setup_hhvm
-          else
             setup_php_on_demand version
           end
           sh.cmd "phpenv rehash", assert: false, echo: false, timing: false

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -42,8 +42,8 @@ module Travis
 
           case self
           when Travis::Build::Script::Hack
-            setup_hhvm
             setup_php_on_demand version
+            setup_hhvm
           when Travis::Build::Script::Php
             if hhvm?
               setup_hhvm

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -120,6 +120,8 @@ module Travis
           return unless hhvm?
           if match_data = /-(\d+(?:\.\d+)*)$/.match(version)
             match_data[1]
+          else
+            ''
           end
         end
 
@@ -152,7 +154,7 @@ module Travis
               sh.raw 'sudo find /etc/apt -type f -exec sed -e "/hhvm\\.com/d" -i.bak {} \;'
 
               if hhvm_version
-                sh.raw "echo \"deb [ arch=amd64 ] http://dl.hhvm.com/ubuntu $(lsb_release -sc)-lts-#{hhvm_version} main\" | sudo tee -a /etc/apt/sources.list >&/dev/null"
+                sh.raw "echo \"deb [ arch=amd64 ] http://dl.hhvm.com/ubuntu $(lsb_release -sc)-#{hhvm_version} main\" | sudo tee -a /etc/apt/sources.list >&/dev/null"
                 sh.raw 'sudo apt-get purge hhvm >&/dev/null'
               else
                 # use latest

--- a/lib/travis/build/script/php.rb
+++ b/lib/travis/build/script/php.rb
@@ -176,7 +176,7 @@ hhvm.libxml.ext_entity_whitelist=file,http,https
             setup_alias(version, '7.0')
             version = '7.0'
           end
-          sh.raw archive_url_for('travis-php-archives', version)
+          sh.raw archive_url_for('travis-php-archives', version, 'php')
           sh.echo "Downloading archive: ${archive_url}", ansi: :yellow
           sh.cmd "curl -s -o archive.tar.bz2 $archive_url && tar xjf archive.tar.bz2 --directory /", echo: true, assert: false
           sh.cmd "rm -f archive.tar.bz2", echo: false

--- a/spec/build/script/hack_spec.rb
+++ b/spec/build/script/hack_spec.rb
@@ -1,0 +1,121 @@
+require 'spec_helper'
+
+describe Travis::Build::Script::Hack, :sexp do
+  let(:data)     { payload_for(:push, :hack) }
+  let(:script)   { described_class.new(data) }
+  subject(:sexp) { script.sexp }
+  it             { store_example }
+
+  it_behaves_like 'a bash script'
+
+  it_behaves_like 'compiled script' do
+    let(:code) { ['TRAVIS_LANGUAGE=hack'] }
+  end
+
+  it_behaves_like 'a build script sexp'
+
+  it 'sets TRAVIS_PHP_VERSION' do
+    should include_sexp [:export, ['TRAVIS_PHP_VERSION', '7.3']]
+  end
+
+  it 'sets up the php version' do
+    should include_sexp [:cmd, 'phpenv global 7.3 2>/dev/null', echo: true, timing: true]
+    should include_sexp [:cmd, 'phpenv rehash']
+  end
+
+  it 'announces php --version' do
+    should include_sexp [:cmd, 'php --version', echo: true]
+  end
+
+  it 'announces composer --version' do
+    should include_sexp [:cmd, 'composer --version', echo: true]
+  end
+
+  describe 'installs php nightly' do
+    before { data[:config][:php] = 'nightly' }
+    it { should include_sexp [:cmd, 'curl -s -o archive.tar.bz2 $archive_url && tar xjf archive.tar.bz2 --directory /', echo: true, timing: true] }
+  end
+
+  context 'with php nightly' do
+    describe 'writes ~/.pearrc if necessary' do
+      before { data[:config][:php] = 'nightly' }
+      it { should include_sexp [:echo, 'Writing ${TRAVIS_HOME}/.pearrc', ansi: :yellow] }
+    end
+  end
+
+  context 'with unrecognized php version' do
+    describe 'writes ~/.pearrc if necessary' do
+      before { data[:config][:php] = 'foobar' }
+      it { should include_sexp [:echo, 'Writing ${TRAVIS_HOME}/.pearrc', ansi: :yellow] }
+    end
+  end
+
+  context 'with php 5.4' do
+    describe 'writes ~/.pearrc if necessary' do
+      before { data[:config][:php] = '5.4' }
+      it { should include_sexp [:echo, 'Writing ${TRAVIS_HOME}/.pearrc', ansi: :yellow] }
+    end
+  end
+
+  context 'with php 5.3' do
+    before { data[:config][:php] = '5.3' }
+    after { store_example(name: '5.3') }
+    describe 'does not write ~/.pearrc' do
+      it { should_not include_sexp [:echo, 'Writing ${TRAVIS_HOME}/.pearrc', ansi: :yellow] }
+    end
+
+    describe 'when running on non-Precise image' do
+      let(:sexp) { sexp_find(sexp_filter(subject, [:if, "$(lsb_release -sc 2>/dev/null) != precise"])[0], [:then]) }
+
+      it "terminates early" do
+        # These are the last commands of sh.failure
+        expect(sexp).to include_sexp [:raw, "set -e", assert: true]
+        expect(sexp).to include_sexp [:raw, "false", assert: true]
+      end
+    end
+  end
+
+  describe 'installs php 7' do
+    before { data[:config][:php] = '7' }
+    it { should include_sexp [:cmd, 'ln -s ~/.phpenv/versions/7.0 ~/.phpenv/versions/7', assert: true, timing: true] }
+  end
+
+  context 'when php version is given as array' do
+    before { data[:config][:php] = %w(7) }
+    it { should include_sexp [:cmd, 'ln -s ~/.phpenv/versions/7.0 ~/.phpenv/versions/7', assert: true, timing: true] }
+  end
+
+  describe 'fixes php.ini for hhvm' do
+    let(:path)     { '/etc/hhvm/php.ini' }
+    let(:addition) { %(date.timezone = "UTC"\nhhvm.libxml.ext_entity_whitelist=file,http,https\n) }
+    before { data[:config][:php] = 'hhvm' }
+    it { should include_sexp [:raw, "sudo mkdir -p $(dirname #{path}); echo '#{addition}' | sudo tee -a #{path} > /dev/null"] }
+    it { should include_sexp [:raw, "sudo chown $(whoami) #{path}"] }
+    it { should include_sexp [:raw, "grep session.save_path #{path} | cut -d= -f2 | sudo xargs mkdir -m 01733 -p"] }
+  end
+
+   describe 'installs hhvm-nightly' do
+    before { data[:config][:hhvm] = 'hhvm-nightly' }
+    it { should include_sexp [:cmd, 'travis_apt_get_update'] }
+    it { should include_sexp [:cmd, 'sudo apt-get install hhvm-nightly -y 2>&1 >/dev/null'] }
+    it { store_example(name: 'hhvm-nightly') }
+  end
+
+   describe 'installs specific hhvm version' do
+    before { data[:config][:hhvm] = 'hhvm-3.12' }
+    it { should include_sexp [:cmd, 'travis_apt_get_update'] }
+    it { should include_sexp [:cmd, 'sudo apt-get install -y hhvm', timing: true, assert: true, echo: true] }
+    it { should include_sexp [:raw, "echo \"deb [ arch=amd64 ] http://dl.hhvm.com/ubuntu $(lsb_release -sc)-3.12 main\" | sudo tee -a /etc/apt/sources.list >&/dev/null"] }
+  end
+
+  describe 'when desired PHP version is not found' do
+    let(:version) { '7.0.0beta2' }
+    let(:data) { payload_for(:push, :php, config: { php: version }) }
+    let(:sexp) { sexp_find(sexp_filter(subject, [:if, "$? -ne 0"])[0], [:then]) }
+
+    it 'installs PHP version on demand' do
+      expect(sexp).to include_sexp [:raw, "archive_url=https://s3.amazonaws.com/travis-php-archives/binaries/${travis_host_os}/${travis_rel_version}/$(uname -m)/php-#{version}.tar.bz2", assert: true]
+      expect(sexp).to include_sexp [:cmd, "curl -s -o archive.tar.bz2 $archive_url && tar xjf archive.tar.bz2 --directory /", echo: true, timing: true]
+    end
+  end
+end

--- a/spec/build/script/php_spec.rb
+++ b/spec/build/script/php_spec.rb
@@ -139,9 +139,9 @@ describe Travis::Build::Script::Php, :sexp do
     before { data[:config][:php] = 'hhvm-3.12' }
     it { should include_sexp [:cmd, 'travis_apt_get_update'] }
     it { should include_sexp [:cmd, 'sudo apt-get install -y hhvm', timing: true, assert: true, echo: true] }
-    it { should include_sexp [:raw, "echo \"deb [ arch=amd64 ] http://dl.hhvm.com/ubuntu $(lsb_release -sc)-lts-3.12 main\" | sudo tee -a /etc/apt/sources.list >&/dev/null"] }
+    it { should include_sexp [:raw, "echo \"deb [ arch=amd64 ] http://dl.hhvm.com/ubuntu $(lsb_release -sc)-3.12 main\" | sudo tee -a /etc/apt/sources.list >&/dev/null"] }
   end
-  
+
   describe 'when desired PHP version is not found' do
     let(:version) { '7.0.0beta2' }
     let(:data) { payload_for(:push, :php, config: { php: version }) }


### PR DESCRIPTION
Another attempt at adding Hack support. For previous efforts, see #1318, #1672.

The default build logic is based on https://docs.hhvm.com/hack/getting-started/starting-a-real-project#configuring-travisci:

```sh
#!/bin/sh
set -ex
apt update -y
DEBIAN_FRONTEND=noninteractive apt install -y php-cli zip unzip
hhvm --version
php --version

(
  cd $(mktemp -d)
  curl https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
)
composer install

hh_client
vendor/bin/hacktest tests/
if !(hhvm --version | grep -q -- -dev); then
  vendor/bin/hhast-lint
fi
```