### PR TITLE
Add debugging support for ARM and unpin tmate version

### DIFF
--- a/lib/travis/build/appliances/debug_tools.rb
+++ b/lib/travis/build/appliances/debug_tools.rb
@@ -70,7 +70,7 @@ module Travis
           # XXX the following does not apply to OSX
           def static_build_linux_url
             if config[:arch] == 'arm64'
-              "https://#{app_host}/files/tmate-static-linux-armv7l.tar.gz"
+              "https://#{app_host}/files/tmate-static-linux-arm64v8.tar.gz"
             else
               "https://#{app_host}/files/tmate-static-linux-amd64.tar.gz"
             end

--- a/lib/travis/build/appliances/debug_tools.rb
+++ b/lib/travis/build/appliances/debug_tools.rb
@@ -69,7 +69,11 @@ module Travis
 
           # XXX the following does not apply to OSX
           def static_build_linux_url
-            "https://#{app_host}/files/tmate-static-linux-amd64.tar.gz"
+            if config[:arch] == 'arm64'
+              "https://#{app_host}/files/tmate-static-linux-armv7l.tar.gz"
+            else
+              "https://#{app_host}/files/tmate-static-linux-amd64.tar.gz"
+            end
           end
       end
     end

--- a/lib/travis/build/appliances/debug_tools.rb
+++ b/lib/travis/build/appliances/debug_tools.rb
@@ -23,8 +23,8 @@ module Travis
 
             sh.if "-z $(command -v tmate)" do
               sh.if "$(uname) = 'Linux'" do
-                sh.cmd "wget -q -O tmate.tar.gz #{static_build_linux_url}", echo: false, retry: true
-                sh.cmd "tar --strip-components=1 -xf tmate.tar.gz", echo: false
+                sh.cmd "wget -q -O tmate.tar.xz #{static_build_linux_url}", echo: false, retry: true
+                sh.cmd "tar --strip-components=1 -xf tmate.tar.xz", echo: false
               end
               sh.else do
                 sh.echo "We are setting up the debug environment. This may take a while..."
@@ -70,9 +70,9 @@ module Travis
           # XXX the following does not apply to OSX
           def static_build_linux_url
             if config[:arch] == 'arm64'
-              "https://#{app_host}/files/tmate-static-linux-arm64v8.tar.gz"
+              "https://#{app_host}/files/tmate-static-linux-arm64v8.tar.xz"
             else
-              "https://#{app_host}/files/tmate-static-linux-amd64.tar.gz"
+              "https://#{app_host}/files/tmate-static-linux-amd64.tar.xz"
             end
           end
       end

--- a/lib/travis/build/rake_tasks.rb
+++ b/lib/travis/build/rake_tasks.rb
@@ -279,7 +279,7 @@ module Travis
       end
 
       def file_update_tmate
-        latest_release = '2.2.1'
+        latest_release = latest_release_for('tmate-io/tmate')
         logger.info "Latest tmate release is #{latest_release}"
 
         TMATE_ARCHES.each do |arch|

--- a/lib/travis/build/rake_tasks.rb
+++ b/lib/travis/build/rake_tasks.rb
@@ -26,6 +26,7 @@ module Travis
         "mvdan/sh/releases/download/#{SHFMT_VERSION}",
         "shfmt_#{SHFMT_VERSION}_%<uname>s_%<arch>s"
       )
+      TMATE_ARCHES = %w(amd64 armv7l)
 
       def fetch_githubusercontent_file(from, host: 'raw.githubusercontent.com',
                                        to: nil, mode: 0o755)
@@ -280,14 +281,17 @@ module Travis
       def file_update_tmate
         latest_release = '2.2.1'
         logger.info "Latest tmate release is #{latest_release}"
-        fetch_githubusercontent_file(
-          File.join(
-            'tmate-io/tmate/releases/download',
-            latest_release,
-            "tmate-#{latest_release}-static-linux-amd64.tar.gz"
-          ),
-          host: 'github.com', to: 'tmate-static-linux-amd64.tar.gz'
-        )
+
+        TMATE_ARCHES.each do |arch|
+          fetch_githubusercontent_file(
+            File.join(
+              'tmate-io/tmate/releases/download',
+              latest_release,
+              "tmate-#{latest_release}-static-linux-#{arch}.tar.gz"
+            ),
+            host: 'github.com', to: "tmate-static-linux-#{arch}.tar.gz"
+          )
+        end
       end
 
       def file_update_rustup

--- a/lib/travis/build/rake_tasks.rb
+++ b/lib/travis/build/rake_tasks.rb
@@ -26,7 +26,7 @@ module Travis
         "mvdan/sh/releases/download/#{SHFMT_VERSION}",
         "shfmt_#{SHFMT_VERSION}_%<uname>s_%<arch>s"
       )
-      TMATE_ARCHES = %w(amd64 armv7l)
+      TMATE_ARCHES = %w(amd64 arm64v8)
 
       def fetch_githubusercontent_file(from, host: 'raw.githubusercontent.com',
                                        to: nil, mode: 0o755)

--- a/lib/travis/build/rake_tasks.rb
+++ b/lib/travis/build/rake_tasks.rb
@@ -26,7 +26,6 @@ module Travis
         "mvdan/sh/releases/download/#{SHFMT_VERSION}",
         "shfmt_#{SHFMT_VERSION}_%<uname>s_%<arch>s"
       )
-      TMATE_ARCHES = %w(amd64 arm64v8)
 
       def fetch_githubusercontent_file(from, host: 'raw.githubusercontent.com',
                                        to: nil, mode: 0o755)
@@ -278,20 +277,18 @@ module Travis
         fetch_githubusercontent_file 'sormuras/bach/master/install-jdk.sh'
       end
 
-      def file_update_tmate
+      def file_update_tmate(arch)
         latest_release = latest_release_for('tmate-io/tmate')
         logger.info "Latest tmate release is #{latest_release}"
 
-        TMATE_ARCHES.each do |arch|
-          fetch_githubusercontent_file(
-            File.join(
-              'tmate-io/tmate/releases/download',
-              latest_release,
-              "tmate-#{latest_release}-static-linux-#{arch}.tar.gz"
-            ),
-            host: 'github.com', to: "tmate-static-linux-#{arch}.tar.gz"
-          )
-        end
+        fetch_githubusercontent_file(
+          File.join(
+            'tmate-io/tmate/releases/download',
+            latest_release,
+            "tmate-#{latest_release}-static-linux-#{arch}.tar.xz"
+          ),
+          host: 'github.com', to: "tmate-static-linux-#{arch}.tar.xz"
+        )
       end
 
       def file_update_rustup
@@ -377,9 +374,14 @@ module Travis
       desc 'update install-jdk.sh'
       file('public/files/install-jdk.sh') { file_update_install_jdk_sh }
 
-      desc 'update tmate'
-      file 'public/files/tmate-static-linux-amd64.tar.gz' do
-        file_update_tmate
+      desc 'update tmate for amd64'
+      file 'public/files/tmate-static-linux-amd64.tar.xz' do
+        file_update_tmate 'amd64'
+      end
+
+      desc 'update tmate for arm64v8'
+      file 'public/files/tmate-static-linux-arm64v8.tar.xz' do
+        file_update_tmate 'arm64v8'
       end
 
       desc 'update rustup'
@@ -438,7 +440,8 @@ module Travis
         'public/files/sbt',
         'public/files/sc-linux.tar.gz',
         'public/files/sc-osx.zip',
-        'public/files/tmate-static-linux-amd64.tar.gz',
+        'public/files/tmate-static-linux-amd64.tar.xz',
+        'public/files/tmate-static-linux-arm64v8.tar.xz',
         'public/version-aliases/ghc.json',
       ]
 

--- a/spec/build/rake_tasks_spec.rb
+++ b/spec/build/rake_tasks_spec.rb
@@ -35,7 +35,7 @@ describe Travis::Build::RakeTasks do
       end
 
       [
-        ['tmate-io/tmate', 'tmate-v1.2.5-static-linux-amd64.tar.gz'],
+        ['tmate-io/tmate', 'tmate-v1.2.5-static-linux-amd64.tar.xz'],
         ['tools/godep', 'godep_darwin_amd64'],
         ['tools/godep', 'godep_linux_amd64']
       ].each do |repo_slug, file_basename|
@@ -178,7 +178,7 @@ describe Travis::Build::RakeTasks do
     public/files/sbt
     public/files/sc-linux.tar.gz
     public/files/sc-osx.zip
-    public/files/tmate-static-linux-amd64.tar.gz
+    public/files/tmate-static-linux-amd64.tar.xz
     public/version-aliases/ghc.json
   ].each do |filename|
     it "can fetch #{filename}" do

--- a/spec/build/rake_tasks_spec.rb
+++ b/spec/build/rake_tasks_spec.rb
@@ -25,6 +25,7 @@ describe Travis::Build::RakeTasks do
     Faraday::Adapter::Test::Stubs.new do |stub|
       %w[
         creationix/nvm
+        tmate-io/tmate
         tools/godep
         travis-ci/gimme
       ].each do |repo_slug|
@@ -34,17 +35,13 @@ describe Travis::Build::RakeTasks do
       end
 
       [
+        ['tmate-io/tmate', 'tmate-v1.2.5-static-linux-amd64.tar.gz'],
         ['tools/godep', 'godep_darwin_amd64'],
         ['tools/godep', 'godep_linux_amd64']
       ].each do |repo_slug, file_basename|
         stub.get("/#{repo_slug}/releases/download/v1.2.5/#{file_basename}") do |*|
           [200, { 'Content-Type' => 'application/octet-stream' }, "\xb1"]
         end
-      end
-
-      # Pin tmate version to 2.2.1, the last release with static assets
-      stub.get("/tmate-io/tmate/releases/download/2.2.1/tmate-2.2.1-static-linux-amd64.tar.gz") do |*|
-        [200, { 'Content-Type' => 'application/octet-stream' }, "\xb1"]
       end
 
       %w[


### PR DESCRIPTION
## Purpose
This PR adds support for debug session ARM (more on this below), and unpins the `tmate` version, now that the latest release includes static binary files again.

## Caveat
The debug session for ARM-based builds does not quite work as is. The only way I've found so far is to inject a `set -x` statement strategically (this is not included in the PR). This job shows an example: https://staging.travis-ci.org/BanzaiMan/travis_staging_test/jobs/750562#L40