### PR TITLE
Use rustup 'minimal' distribution by default

### DIFF
--- a/lib/travis/build/script/rust.rb
+++ b/lib/travis/build/script/rust.rb
@@ -3,7 +3,7 @@ module Travis
     class Script
       class Rust < Script
         RUST_RUSTUP = 'https://sh.rustup.rs'
-        RUSTUP_CMD = "curl -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=$TRAVIS_RUST_VERSION -y"
+        RUSTUP_CMD = "curl -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=$TRAVIS_RUST_VERSION --profile=minimal -y"
 
         DEFAULTS = {
           rust: 'stable',
@@ -29,7 +29,7 @@ module Travis
           sh.fold('rustup-install') do
             sh.echo 'Installing Rust', ansi: :yellow
             unless app_host.empty?
-              sh.cmd "curl -sSf https://#{app_host}/files/rustup-init.sh | sh -s -- --default-toolchain=$TRAVIS_RUST_VERSION -y", echo: true, assert: false
+              sh.cmd "curl -sSf https://#{app_host}/files/rustup-init.sh | sh -s -- --default-toolchain=$TRAVIS_RUST_VERSION --profile=minimal -y", echo: true, assert: false
               sh.if "$? -ne 0" do
                 sh.cmd RUSTUP_CMD, echo: true, assert: true
               end


### PR DESCRIPTION
The last version of rustup is exposing different _distributions_ containing each more or less component (see [documentation](https://blog.rust-lang.org/2019/10/15/Rustup-1.20.0.html#profiles)). From a build perspective, the `minimal` profile got the compiler `rustc` and `cargo` which are pretty much all you need. All components like `rustfmt`, `clippy` can still be installed through a `before_script`.

I was not able to make the tests run on my machine to verify I was not breaking anything. But the change being relatively minimal, I'm hoping the CI can tell me it's OK. I might need help if this is not the case.