### PR TITLE
Inject job's arch value into cache name

### DIFF
--- a/lib/travis/build/script/shared/workspace.rb
+++ b/lib/travis/build/script/shared/workspace.rb
@@ -15,7 +15,7 @@ module Travis
           @paths = Array(paths)
           @type = type
           @directory_cache = cache_class.new(@sh, @data, name, Time.now, 'workspace')
-          @directory_cache.define_singleton_method :prefixed do |branch, extras|
+          @directory_cache.define_singleton_method :prefixed do |branch, extras, arch|
             parts = case aws_signature_version
             when '2'
               [ 'workspaces', data.build[:id], name ]

--- a/spec/build/script/directory_cache_spec.rb
+++ b/spec/build/script/directory_cache_spec.rb
@@ -91,6 +91,12 @@ describe Travis::Build::Script::DirectoryCache, :sexp do
 
         it { expect(file_name).to eq "cache-#{CACHE_SLUG_EXTRAS}--rvm-default--gemfile-Gemfile.tgz" }
       end
+
+      context 'when looking for cache with extra information and arch name' do
+        let(:file_name) { URI(cache.fetch_url('foo', true, true)).path.split('/').last }
+
+        it { expect(file_name).to eq "cache-#{data[:config][:arch]}-#{CACHE_SLUG_EXTRAS}--rvm-default--gemfile-Gemfile.tgz" }
+      end
     end
   end
 
@@ -99,12 +105,12 @@ describe Travis::Build::Script::DirectoryCache, :sexp do
       let(:config) { { cache: 'bundler' } }
       let(:file_name) { URI(cache.push_url).path.split('/').last }
 
-      it { expect(file_name).to eq "cache-#{CACHE_SLUG_EXTRAS}--rvm-default--gemfile-Gemfile.tgz" }
+      it { expect(file_name).to eq "cache-#{data[:config][:arch]}-#{CACHE_SLUG_EXTRAS}--rvm-default--gemfile-Gemfile.tgz" }
 
       context 'and "os: osx"' do
         let(:config) { { cache: 'bundler', os: 'osx' } }
 
-        it { expect(file_name).to eq "cache-#{CACHE_SLUG_EXTRAS.gsub('linux','osx')}--rvm-default--gemfile-Gemfile.tgz" }
+        it { expect(file_name).to eq "cache-#{data[:config][:arch]}-#{CACHE_SLUG_EXTRAS.gsub('linux','osx')}--rvm-default--gemfile-Gemfile.tgz" }
       end
     end
   end

--- a/spec/support/payloads.rb
+++ b/spec/support/payloads.rb
@@ -8,6 +8,7 @@ PAYLOADS = {
     'host' => 'travis-ci.com',
     'config' => {
       'os' => 'linux',
+      'arch' => 'amd64',
       'env' => ['FOO=foo', 'SECURE BAR=bar']
     },
     'repository' => {


### PR DESCRIPTION
## Problem
Caches do not consider `arch` values when looking for and uploading the cache, so if multiple jobs share the same name but different `arch` values, the builds would fail if the cache is expected to contain binary files for certain CPU.

## A workaround

For this PR, we inject into the list of preferred cache URLs that contains the `arch` value in it. Admittedly this is not a clean way to achieve the result; it is far more logical to modify `Script#cache_slug` to include the `arch` value. Unfortunately, this is problematic because it breaks the `fetch_url` logic and accommodating such a change seems quite complicated. This is necessary because existing caches would not be found otherwise.

Over time, though, (about 45 days) after this code goes into production, all the caches in use would have arch values in them, and we can simply remove this ugly workaround.

## Tests:

1. https://staging.travis-ci.org/BanzaiMan/travis_staging_test/jobs/751325#L128 fails to find a suitable cache (`amd64` one first on line 134, then one without arch on line 135), but uploads the cache with the arch value on line 148
1. https://staging.travis-ci.org/BanzaiMan/travis_staging_test/jobs/751328#L132 subsequently fetches the cache with the correct name.