### PR TITLE
Fix missing /etc/nix directory

### DIFF
--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -35,6 +35,7 @@ module Travis
             sh.cmd "sudo mkdir -p -m 0755 /nix/"
             sh.cmd "sudo chown $USER /nix/"
             # Set nix config dir and make config Hydra compatible
+            sh.cmd "sudo mkdir -p -m 0755 /etc/nix"
             sh.cmd "echo 'build-max-jobs = 4' | sudo tee /etc/nix/nix.conf > /dev/null"
           end
         end


### PR DESCRIPTION
I noticed 

> tee: /etc/nix/nix.conf: No such file or directory

in my build logs.  tee can create files, but it does not create missing directories. `/etc/nix` does not seem to be existing.  Therefore the error message. Creating the /etc/nix directory before trying to create a file in there fixes this.

I did not test this change in any way.