### PR TITLE
Update Nix to 2.3.1

### DIFF
--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -9,7 +9,7 @@ module Travis
     class Script
       class Nix < Script
         DEFAULTS = {
-          nix: '2.0.4'
+          nix: '2.3.1'
         }
 
         def export


### PR DESCRIPTION
Published 2019-10-10, see https://nixos.org/releases/nix/