### PR TITLE
[community: R] update bioc-devel r-version to R-devel

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -601,8 +601,8 @@ module Travis
           when 'bioc-devel'
             config[:bioc_required] = true
             config[:bioc_use_devel] = true
-            config[:r] = 'release'
-            normalized_r_version('release')
+            config[:r] = 'devel'
+            normalized_r_version('devel')
           when 'bioc-release'
             config[:bioc_required] = true
             config[:bioc_use_devel] = false

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -11,7 +11,7 @@ describe Travis::Build::Script::R, :sexp do
 
   it 'normalizes bioc-devel correctly' do
     data[:config][:r] = 'bioc-devel'
-    should include_sexp [:export, ['TRAVIS_R_VERSION', '4.0.0']]
+    should include_sexp [:export, ['TRAVIS_R_VERSION', 'devel']]
     should include_sexp [:cmd, %r{install.packages\(\"BiocManager"\)},
                          assert: true, echo: true, timing: true, retry: true]
     should include_sexp [:cmd, %r{BiocManager::install\(version = \"devel\"},

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -11,7 +11,7 @@ describe Travis::Build::Script::R, :sexp do
 
   it 'normalizes bioc-devel correctly' do
     data[:config][:r] = 'bioc-devel'
-    should include_sexp [:export, ['TRAVIS_R_VERSION', '3.6.1']]
+    should include_sexp [:export, ['TRAVIS_R_VERSION', '4.0.0']]
     should include_sexp [:cmd, %r{install.packages\(\"BiocManager"\)},
                          assert: true, echo: true, timing: true, retry: true]
     should include_sexp [:cmd, %r{BiocManager::install\(version = \"devel\"},


### PR DESCRIPTION
With every Bioconductor release, the `lib/travis/build/script/r.rb` file has to
change so that the R versions are matching with those that are compatible
with Bioconductor release and devel versions. 

Here is the update to that file: 
Bioconductor version `3.11` uses R-devel (`4.0.0`). 

cc: @jimhester 

Reference: https://bioconductor.org/developers/how-to/useDevel/

Best,
Marcel