### PR TITLE
Adapt artifacts to Windows

### DIFF
--- a/lib/travis/build/bash/travis_artifacts_install.bash
+++ b/lib/travis/build/bash/travis_artifacts_install.bash
@@ -2,7 +2,7 @@ travis_artifacts_install() {
   local source="https://s3.amazonaws.com/travis-ci-gmbh/artifacts/stable/build/${TRAVIS_OS_NAME}/${TRAVIS_ARCH}/artifacts"
   local target="${TRAVIS_HOME}/bin/artifacts"
 
-  if [[ ${TRAVIS_OS_NAME} = "windows" ]]; then
+  if [[ ${TRAVIS_OS_NAME} == "windows" ]]; then
     source="${source}.exe"
   fi
 

--- a/lib/travis/build/bash/travis_artifacts_install.bash
+++ b/lib/travis/build/bash/travis_artifacts_install.bash
@@ -2,6 +2,10 @@ travis_artifacts_install() {
   local source="https://s3.amazonaws.com/travis-ci-gmbh/artifacts/stable/build/${TRAVIS_OS_NAME}/${TRAVIS_ARCH}/artifacts"
   local target="${TRAVIS_HOME}/bin/artifacts"
 
+  if [[ ${TRAVIS_OS_NAME} = "windows" ]]; then
+    source="${source}.exe"
+  fi
+
   mkdir -p "$(dirname "${target}")"
   travis_download "${source}" "${target}"
   chmod +x "${target}"


### PR DESCRIPTION
Enable artifacts addon for Windows. See https://travis-ci.community/t/artifact-uploader-binary-not-found/4978

Before: https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/753351#L95
After: https://staging.travis-ci.org/BanzaiMan/travis_staging_test/builds/753353#L91-L92 (The command `artifacts` runs, but fails because it's not configured correctly.)