### PR TITLE
haxe: use win64 for "development"

### DIFF
--- a/lib/travis/build/script/haxe.rb
+++ b/lib/travis/build/script/haxe.rb
@@ -211,7 +211,7 @@ module Travis
               when 'osx'
                 "mac/haxe_latest.tar.gz"
               when 'windows'
-                "windows/haxe_latest.zip"
+                "windows64/haxe_latest.zip"
               end
               "https://build.haxe.org/builds/haxe/#{file}"
             else


### PR DESCRIPTION
Fix `haxe: development` for Windows build. Should be safe to directly deploy to production.