### PR TITLE
Add support for GemStone on Ubuntu 16.04 and 18.04

### DIFF
--- a/lib/travis/build/script/smalltalk.rb
+++ b/lib/travis/build/script/smalltalk.rb
@@ -216,10 +216,14 @@ module Travis
               sh.cmd 'sudo ln -f -s /lib/i386-linux-gnu/libpam.so.0 /lib/libpam.so.0'
               sh.cmd 'sudo ln -f -s /usr/lib/i386-lin-gnu/libstdc++.so.6 /usr/lib/i386-linux-gnu/libstdc++.so'
             end
-            sh.if '$(uname -m) != ppc64le && $(lsb_release -cs) = trusty' do
+            sh.elif '$(lsb_release -cs) = trusty' do
               sh.cmd 'sudo dpkg --add-architecture i386'
               gemstone_install_linux_dependencies
               sh.cmd 'sudo ln -f -s /usr/lib/i386-lin-gnu/libstdc++.so.6 /usr/lib/i386-linux-gnu/libstdc++.so'
+            end
+            sh.elif '$(lsb_release -cs) = xenial || $(lsb_release -cs) = bionic' do
+              sh.cmd 'sudo dpkg --add-architecture i386'
+              gemstone_install_linux_dependencies
             end
           end
 

--- a/lib/travis/build/script/smalltalk.rb
+++ b/lib/travis/build/script/smalltalk.rb
@@ -225,6 +225,10 @@ module Travis
               sh.cmd 'sudo dpkg --add-architecture i386'
               gemstone_install_linux_dependencies
             end
+            sh.else do
+              sh.echo 'Unsupported Linux distribution: $(lsb_release -cs)', ansi: :red
+              sh.raw 'travis_assert 1' # Let the build fail
+            end
           end
 
           def gemstone_install_linux_dependencies


### PR DESCRIPTION
and drop check for POWER architecture (it's not supported anyway).

Closes https://github.com/hpi-swa/smalltalkCI/issues/445#issuecomment-564743137