### PR TITLE
Bump latest R version to 3.6.2

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -589,7 +589,7 @@ module Travis
 
         def normalized_r_version(v=Array(config[:r]).first.to_s)
           case v
-          when 'release' then '3.6.1'
+          when 'release' then '3.6.2'
           when 'oldrel' then '3.5.3'
           when '3.0' then '3.0.3'
           when '3.1' then '3.1.3'
@@ -597,7 +597,7 @@ module Travis
           when '3.3' then '3.3.3'
           when '3.4' then '3.4.4'
           when '3.5' then '3.5.3'
-          when '3.6' then '3.6.1'
+          when '3.6' then '3.6.2'
           when 'bioc-devel'
             config[:bioc_required] = true
             config[:bioc_use_devel] = true

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -22,7 +22,7 @@ describe Travis::Build::Script::R, :sexp do
     data[:config][:r] = 'bioc-release'
     should include_sexp [:cmd, %r{install.packages\(\"BiocManager"\)},
                          assert: true, echo: true, timing: true, retry: true]
-    should include_sexp [:export, ['TRAVIS_R_VERSION', '3.6.1']]
+    should include_sexp [:export, ['TRAVIS_R_VERSION', '3.6.2']]
   end
 
   it 'r_packages works with a single package set' do
@@ -50,7 +50,7 @@ describe Travis::Build::Script::R, :sexp do
   end
 
   it 'downloads and installs latest R' do
-    should include_sexp [:cmd, %r{^curl.*https://travis-ci\.rstudio\.org/R-3\.6\.1-\$\(lsb_release -cs\)\.xz},
+    should include_sexp [:cmd, %r{^curl.*https://travis-ci\.rstudio\.org/R-3\.6\.2-\$\(lsb_release -cs\)\.xz},
                          assert: true, echo: true, retry: true, timing: true]
   end
 
@@ -249,7 +249,7 @@ describe Travis::Build::Script::R, :sexp do
     }
     it {
       data[:config][:r] = 'release'
-      should eq("cache-#{CACHE_SLUG_EXTRAS}--R-3.6.1")
+      should eq("cache-#{CACHE_SLUG_EXTRAS}--R-3.6.2")
     }
     it {
       data[:config][:r] = 'oldrel'


### PR DESCRIPTION
R 3.6.2 was released on December 12: https://stat.ethz.ch/pipermail/r-announce/2019/000647.html

cc @jeroen @jimhester 