### PR TITLE
nix: update to 2.3.6

### DIFF
--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -49,13 +49,7 @@ module Travis
             sh.cmd "wget --retry-connrefused --waitretry=1 -O /tmp/nix-install https://nixos.org/releases/nix/#{version}/install"
             sh.cmd "yes | sh /tmp/nix-install"
 
-            if config[:os] == 'linux'
-              # single-user install (linux)
-              sh.cmd 'source ${TRAVIS_HOME}/.nix-profile/etc/profile.d/nix.sh'
-            else
-              # multi-user install (macos)
-              sh.cmd 'source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
-            end
+            sh.cmd 'source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
           end
         end
 

--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -34,9 +34,7 @@ module Travis
             sh.cmd "sudo mount -o remount,exec /run/user"
             sh.cmd "sudo mkdir -p -m 0755 /nix/"
             sh.cmd "sudo chown $USER /nix/"
-            # Set nix config dir and make config Hydra compatible
-            sh.cmd "sudo mkdir -p -m 0755 /etc/nix"
-            sh.cmd "echo 'build-max-jobs = 4' | sudo tee /etc/nix/nix.conf > /dev/null"
+            sh.cmd "echo 'build-max-jobs = 4' | sudo tee /tmp/nix.conf > /dev/null"
           end
         end
 
@@ -45,7 +43,7 @@ module Travis
 
           sh.fold 'nix.install' do
             sh.cmd "wget --retry-connrefused --waitretry=1 -O /tmp/nix-install https://releases.nixos.org/nix/nix-#{config[:nix]}/install"
-            sh.cmd "yes | sh /tmp/nix-install --daemon"
+            sh.cmd "yes | sh /tmp/nix-install --daemon --nix-extra-conf-file /tmp/nix.conf"
 
             sh.cmd 'source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
           end

--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -32,8 +32,6 @@ module Travis
           if config[:os] == 'linux'
             sh.cmd "sudo mount -o remount,exec /run"
             sh.cmd "sudo mount -o remount,exec /run/user"
-            sh.cmd "sudo mkdir -p -m 0755 /nix/"
-            sh.cmd "sudo chown $USER /nix/"
             sh.cmd "echo 'build-max-jobs = 4' | sudo tee /tmp/nix.conf > /dev/null"
           end
         end

--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -47,7 +47,7 @@ module Travis
 
           sh.fold 'nix.install' do
             sh.cmd "wget --retry-connrefused --waitretry=1 -O /tmp/nix-install https://nixos.org/releases/nix/#{version}/install"
-            sh.cmd "yes | sh /tmp/nix-install"
+            sh.cmd "yes | sh /tmp/nix-install --daemon"
 
             sh.cmd 'source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
           end

--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -9,7 +9,7 @@ module Travis
     class Script
       class Nix < Script
         DEFAULTS = {
-          nix: 'latest'
+          nix: '2.3.6'
         }
 
         def export

--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -43,10 +43,8 @@ module Travis
         def setup
           super
 
-          version = config[:nix] == "latest" ? config[:nix] : "nix-#{config[:nix]}"
-
           sh.fold 'nix.install' do
-            sh.cmd "wget --retry-connrefused --waitretry=1 -O /tmp/nix-install https://nixos.org/releases/nix/#{version}/install"
+            sh.cmd "wget --retry-connrefused --waitretry=1 -O /tmp/nix-install https://releases.nixos.org/nix/nix-#{config[:nix]}/install"
             sh.cmd "yes | sh /tmp/nix-install --daemon"
 
             sh.cmd 'source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'

--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -9,7 +9,7 @@ module Travis
     class Script
       class Nix < Script
         DEFAULTS = {
-          nix: '2.0.4'
+          nix: 'latest'
         }
 
         def export
@@ -43,10 +43,10 @@ module Travis
         def setup
           super
 
-          version = config[:nix]
+          version = config[:nix] == "latest" ? config[:nix] : "nix-#{config[:nix]}"
 
           sh.fold 'nix.install' do
-            sh.cmd "wget --retry-connrefused --waitretry=1 -O /tmp/nix-install https://nixos.org/releases/nix/nix-#{version}/install"
+            sh.cmd "wget --retry-connrefused --waitretry=1 -O /tmp/nix-install https://nixos.org/releases/nix/#{version}/install"
             sh.cmd "yes | sh /tmp/nix-install"
 
             if config[:os] == 'linux'


### PR DESCRIPTION
This gets nix from the `latest` [symlink](https://nixos.org/releases/nix/latest/) by default, so this file doesn't need to be kept in sync with nix releases.