### PR TITLE
Use snap for Crystal latest & add cache support

### DIFF
--- a/lib/travis/build/script/crystal.rb
+++ b/lib/travis/build/script/crystal.rb
@@ -13,9 +13,9 @@ module Travis
             when 'linux'
               validate_version
               if config[:crystal] == 'nightly'
-                snap_install_crystal '--channel=latest/edge'
+                linux_nightly
               else
-                snap_install_crystal '--channel=latest/stable'
+                linux_latest
               end
             when 'osx'
               if config[:crystal] && config[:crystal] != "latest"
@@ -76,12 +76,48 @@ module Travis
           end
         end
 
-        def snap_install_crystal(options)
-          sh.if '"$TRAVIS_DIST" == precise || "$TRAVIS_DIST" == trusty' do
-            sh.failure "Crystal will only be supported on Xenial or later releases"
+        def linux_latest
+          sh.if "-n $(command -v snap)" do
+            snap_install_crystal '--channel=latest/stable'
           end
+          sh.else do
+            apt_install_crystal
+          end
+        end
+
+        def linux_nightly
+          sh.if "-n $(command -v snap)" do
+            snap_install_crystal '--channel=latest/edge'
+          end
+          sh.else do
+            sh.failure "Crystal nightlies will only be supported via snap. Use Xenial or later releases."
+          end
+        end
+
+        def snap_install_crystal(options)
           sh.cmd %Q(sudo apt-get install -y gcc pkg-config git tzdata libpcre3-dev libevent-dev libyaml-dev libgmp-dev libssl-dev libxml2-dev)
           sh.cmd %Q(sudo snap install crystal --classic #{options})
+        end
+
+        def apt_install_crystal
+          version = {
+            url: "https://dist.crystal-lang.org/apt",
+            key: {
+              url: "https://dist.crystal-lang.org/rpm/RPM-GPG-KEY",
+              fingerprint: "5995C83CD754BE448164192909617FD37CC06B54"
+            },
+            package: "crystal"
+          }
+
+          sh.cmd %Q(curl -sSL '#{version[:key][:url]}' > "${TRAVIS_HOME}/crystal_repository_key.asc")
+          sh.if %Q("$(gpg --with-fingerprint "${TRAVIS_HOME}/crystal_repository_key.asc" | grep "Key fingerprint" | cut -d "=" -f2 | tr -d " ")" != "#{version[:key][:fingerprint]}") do
+            sh.failure "The repository key needed to install Crystal did not have the expected fingerprint. Your build was aborted."
+          end
+          sh.cmd %q(sudo sh -c "apt-key add '${TRAVIS_HOME}/crystal_repository_key.asc'")
+
+          sh.cmd %Q(sudo sh -c 'echo "deb #{version[:url]} crystal main" > /etc/apt/sources.list.d/crystal-nightly.list')
+          sh.cmd 'travis_apt_get_update'
+          sh.cmd %Q(sudo apt-get install -y #{version[:package]} libgmp-dev)
         end
 
         def cache_dirs

--- a/lib/travis/build/script/crystal.rb
+++ b/lib/travis/build/script/crystal.rb
@@ -95,7 +95,7 @@ module Travis
         end
 
         def snap_install_crystal(options)
-          sh.cmd %Q(sudo apt-get install -y gcc pkg-config git tzdata libpcre3-dev libevent-dev libyaml-dev libgmp-dev libssl-dev libxml2-dev), echo: true
+          sh.cmd %Q(sudo apt-get install -y gcc pkg-config git tzdata libpcre3-dev libevent-dev libyaml-dev libgmp-dev libssl-dev libxml2-dev 2>&1 > /dev/null), echo: true
           sh.cmd %Q(sudo snap install crystal --classic #{options}), echo: true
         end
 

--- a/lib/travis/build/script/crystal.rb
+++ b/lib/travis/build/script/crystal.rb
@@ -56,6 +56,18 @@ module Travis
           sh.cmd "crystal spec"
         end
 
+        def setup_cache
+          if data.cache?(:shards) && !cache_dirs.empty?
+            sh.fold 'cache.shards' do
+              directory_cache.add cache_dirs
+            end
+          end
+        end
+
+        def cache_slug
+          super << '-crystal'
+        end
+
         private
 
         def validate_version
@@ -70,6 +82,21 @@ module Travis
           end
           sh.cmd %Q(sudo apt-get install -y gcc pkg-config git tzdata libpcre3-dev libevent-dev libyaml-dev libgmp-dev libssl-dev libxml2-dev)
           sh.cmd %Q(sudo snap install crystal --classic #{options})
+        end
+
+        def cache_dirs
+          case config[:os]
+          when 'linux'
+            %W(
+              ${TRAVIS_HOME}/.cache/shards
+            )
+          when 'osx'
+            %W(
+              ${TRAVIS_HOME}/.cache/shards
+            )
+          else
+            []
+          end
         end
       end
     end

--- a/lib/travis/build/script/crystal.rb
+++ b/lib/travis/build/script/crystal.rb
@@ -2,6 +2,9 @@ module Travis
   module Build
     class Script
       class Crystal < Script
+        DEFAULTS = {
+          crystal: 'latest',
+        }
 
         def configure
           super
@@ -12,13 +15,13 @@ module Travis
             case config[:os]
             when 'linux'
               validate_version
-              if config[:crystal] == 'nightly'
+              if crystal_config_version == 'nightly'
                 linux_nightly
               else
                 linux_latest
               end
             when 'osx'
-              if config[:crystal] && config[:crystal] != "latest"
+              if crystal_config_version != "latest"
                 sh.failure %Q(Specifying Crystal version is not yet supported by the macOS environment)
               end
               sh.cmd %q(brew update)
@@ -65,14 +68,18 @@ module Travis
         end
 
         def cache_slug
-          super << '-crystal'
+          super << '-crystal-' << crystal_config_version
         end
 
         private
 
+        def crystal_config_version
+          Array(config[:crystal]).first.to_s
+        end
+
         def validate_version
-          if config[:crystal] != 'latest' && config[:crystal] != 'nightly' && !config[:crystal].nil?
-            sh.failure %Q("#{config[:crystal]}" is an invalid version of Crystal.\nView valid versions of Crystal at https://docs.travis-ci.com/user/languages/crystal/)
+          if crystal_config_version != 'latest' && crystal_config_version != 'nightly'
+            sh.failure %Q("#{crystal_config_version}" is an invalid version of Crystal.\nView valid versions of Crystal at https://docs.travis-ci.com/user/languages/crystal/)
           end
         end
 

--- a/lib/travis/build/script/crystal.rb
+++ b/lib/travis/build/script/crystal.rb
@@ -125,6 +125,7 @@ module Travis
           when 'linux'
             %W(
               ${TRAVIS_HOME}/.cache/shards
+              ${TRAVIS_HOME}/snap/crystal/common/.cache/shards
             )
           when 'osx'
             %W(

--- a/lib/travis/build/script/crystal.rb
+++ b/lib/travis/build/script/crystal.rb
@@ -96,7 +96,7 @@ module Travis
 
         def snap_install_crystal(options)
           sh.cmd %Q(sudo apt-get install -y gcc pkg-config git tzdata libpcre3-dev libevent-dev libyaml-dev libgmp-dev libssl-dev libxml2-dev)
-          sh.cmd %Q(sudo snap install crystal --classic #{options})
+          sh.cmd %Q(sudo snap install crystal --classic #{options}), echo: true
         end
 
         def apt_install_crystal

--- a/lib/travis/build/script/crystal.rb
+++ b/lib/travis/build/script/crystal.rb
@@ -95,7 +95,7 @@ module Travis
         end
 
         def snap_install_crystal(options)
-          sh.cmd %Q(sudo apt-get install -y gcc pkg-config git tzdata libpcre3-dev libevent-dev libyaml-dev libgmp-dev libssl-dev libxml2-dev)
+          sh.cmd %Q(sudo apt-get install -y gcc pkg-config git tzdata libpcre3-dev libevent-dev libyaml-dev libgmp-dev libssl-dev libxml2-dev), echo: true
           sh.cmd %Q(sudo snap install crystal --classic #{options}), echo: true
         end
 

--- a/spec/build/script/crystal_spec.rb
+++ b/spec/build/script/crystal_spec.rb
@@ -23,6 +23,11 @@ describe Travis::Build::Script::Crystal, :sexp do
       echo: true, timing: true]
   end
 
+  describe '#cache_slug' do
+    subject { described_class.new(data).cache_slug }
+    it { is_expected.to eq("cache-#{CACHE_SLUG_EXTRAS}-crystal") }
+  end
+
   context "versions" do
     it "installs latest linux release by default" do
       data[:config][:os] = "linux"

--- a/spec/build/script/crystal_spec.rb
+++ b/spec/build/script/crystal_spec.rb
@@ -25,7 +25,7 @@ describe Travis::Build::Script::Crystal, :sexp do
 
   describe '#cache_slug' do
     subject { described_class.new(data).cache_slug }
-    it { is_expected.to eq("cache-#{CACHE_SLUG_EXTRAS}-crystal") }
+    it { is_expected.to eq("cache-#{CACHE_SLUG_EXTRAS}-crystal-latest") }
   end
 
   context "versions" do

--- a/spec/build/script/crystal_spec.rb
+++ b/spec/build/script/crystal_spec.rb
@@ -34,7 +34,7 @@ describe Travis::Build::Script::Crystal, :sexp do
 
     it "installs latest linux release by default" do
       data[:config][:os] = "linux"
-      expect(with_snap).to include_sexp [:cmd, "sudo snap install crystal --classic --channel=latest/stable"]
+      expect(with_snap).to include_sexp [:cmd, "sudo snap install crystal --classic --channel=latest/stable", {echo: true}]
       expect(without_snap).to include_sexp [:cmd, "sudo apt-get install -y crystal libgmp-dev"]
     end
 
@@ -46,13 +46,13 @@ describe Travis::Build::Script::Crystal, :sexp do
     it "installs latest linux release when explicitly asked for" do
       data[:config][:os] = "linux"
       data[:config][:crystal] = "latest"
-      expect(with_snap).to include_sexp [:cmd, "sudo snap install crystal --classic --channel=latest/stable"]
+      expect(with_snap).to include_sexp [:cmd, "sudo snap install crystal --classic --channel=latest/stable", {echo: true}]
     end
 
     it "installs linux nightly when specified" do
       data[:config][:os] = "linux"
       data[:config][:crystal] = "nightly"
-      expect(with_snap).to include_sexp [:cmd, "sudo snap install crystal --classic --channel=latest/edge"]
+      expect(with_snap).to include_sexp [:cmd, "sudo snap install crystal --classic --channel=latest/edge", {echo: true}]
       expect(without_snap).to include_sexp [:echo, "Crystal nightlies will only be supported via snap. Use Xenial or later releases."]
     end
 

--- a/spec/build/script/crystal_spec.rb
+++ b/spec/build/script/crystal_spec.rb
@@ -26,7 +26,7 @@ describe Travis::Build::Script::Crystal, :sexp do
   context "versions" do
     it "installs latest linux release by default" do
       data[:config][:os] = "linux"
-      should include_sexp [:cmd, "sudo apt-get install -y crystal libgmp-dev"]
+      should include_sexp [:cmd, "sudo snap install crystal --classic --channel=latest/stable"]
     end
 
     it "installs latest macOS release by default" do
@@ -37,13 +37,13 @@ describe Travis::Build::Script::Crystal, :sexp do
     it "installs latest linux release when explicitly asked for" do
       data[:config][:os] = "linux"
       data[:config][:crystal] = "latest"
-      should include_sexp [:cmd, "sudo apt-get install -y crystal libgmp-dev"]
+      should include_sexp [:cmd, "sudo snap install crystal --classic --channel=latest/stable"]
     end
 
     it "installs linux nightly when specified" do
       data[:config][:os] = "linux"
       data[:config][:crystal] = "nightly"
-      should include_sexp [:cmd, "sudo snap install crystal --classic --edge"]
+      should include_sexp [:cmd, "sudo snap install crystal --classic --channel=latest/edge"]
     end
 
     it 'throws a error with a non-release version on macOS' do

--- a/spec/build/script/crystal_spec.rb
+++ b/spec/build/script/crystal_spec.rb
@@ -29,9 +29,13 @@ describe Travis::Build::Script::Crystal, :sexp do
   end
 
   context "versions" do
+    let(:with_snap) { sexp_find(subject, [:if, '-n $(command -v snap)'], [:then]) }
+    let(:without_snap) { sexp_find(subject, [:if, '-n $(command -v snap)'], [:else]) }
+
     it "installs latest linux release by default" do
       data[:config][:os] = "linux"
-      should include_sexp [:cmd, "sudo snap install crystal --classic --channel=latest/stable"]
+      expect(with_snap).to include_sexp [:cmd, "sudo snap install crystal --classic --channel=latest/stable"]
+      expect(without_snap).to include_sexp [:cmd, "sudo apt-get install -y crystal libgmp-dev"]
     end
 
     it "installs latest macOS release by default" do
@@ -42,13 +46,14 @@ describe Travis::Build::Script::Crystal, :sexp do
     it "installs latest linux release when explicitly asked for" do
       data[:config][:os] = "linux"
       data[:config][:crystal] = "latest"
-      should include_sexp [:cmd, "sudo snap install crystal --classic --channel=latest/stable"]
+      expect(with_snap).to include_sexp [:cmd, "sudo snap install crystal --classic --channel=latest/stable"]
     end
 
     it "installs linux nightly when specified" do
       data[:config][:os] = "linux"
       data[:config][:crystal] = "nightly"
-      should include_sexp [:cmd, "sudo snap install crystal --classic --channel=latest/edge"]
+      expect(with_snap).to include_sexp [:cmd, "sudo snap install crystal --classic --channel=latest/edge"]
+      expect(without_snap).to include_sexp [:echo, "Crystal nightlies will only be supported via snap. Use Xenial or later releases."]
     end
 
     it 'throws a error with a non-release version on macOS' do


### PR DESCRIPTION
As a continuation of #1721, this PR make use of snap for latest Crystal release.

~~There was already a condition to avoid running snap in Trusty and Precise. (Although Trusty seems to be supported by snap https://ubuntu.com/blog/snaps-are-now-available-for-ubuntu-14-04-lts-desktop-and-server)~~

~~The condition is left so this is effectively dropping `language: crystal` support for trusty and precise.~~ 

[update: if `snap` is not available crystal latest is installed via apt]

Caching support was also added by:

```
cache: shards

# or 

cache:
  shards: true
```

I am not sure how to test this outside the codebase to double-check everything is in good shape.

I would've wanted to include the crystal/shards version in the cache_slug, and not only the configured version (latest/nightly). But I am not sure if it's possible to capture the output of a command and use that in the cache_slug.