### PR TITLE
Use HTTPS for fetching sonarcloud CLI

### DIFF
--- a/lib/travis/build/addons/sonarcloud.rb
+++ b/lib/travis/build/addons/sonarcloud.rb
@@ -11,7 +11,7 @@ module Travis
         SCANNER_CLI_VERSION = "3.0.3.778"
         SCANNER_HOME = "${TRAVIS_HOME}/.sonarscanner"
         CACHE_DIR = "${TRAVIS_HOME}/.sonar/cache"
-        SCANNER_CLI_REPO = "http://repo1.maven.org/maven2"
+        SCANNER_CLI_REPO = "https://repo1.maven.org/maven2"
         BUILD_WRAPPER_LINUX = "build-wrapper-linux-x86"
         BUILD_WRAPPER_MACOSX = "build-wrapper-macosx-x86"
 

--- a/spec/build/addons/sonarcloud_spec.rb
+++ b/spec/build/addons/sonarcloud_spec.rb
@@ -12,7 +12,7 @@ describe Travis::Build::Addons::Sonarcloud, :sexp do
   before       { addon.before_before_script }
 
   it_behaves_like 'compiled script' do
-    let(:code) { ['curl -sSLo "${TRAVIS_HOME}/.sonarscanner/sonar-scanner.zip" "http://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/3.0.3.778/sonar-scanner-cli-3.0.3.778.zip"'] }
+    let(:code) { ['curl -sSLo "${TRAVIS_HOME}/.sonarscanner/sonar-scanner.zip" "https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/3.0.3.778/sonar-scanner-cli-3.0.3.778.zip"'] }
   end
 
   describe 'scanner and build wrapper installation' do


### PR DESCRIPTION
The server now requires HTTPS.

<details>
<summary>with HTTPS</summary>
<pre>
$ curl -I https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/3.0.3.778/sonar-scanner-cli-3.0.3.778.zip
HTTP/1.1 200 OK
ETag: "d23419142506d8f9acbeae8d430b0fe0"
Content-Type: application/zip
Last-Modified: Fri, 12 May 2017 16:10:41 GMT
X-Checksum-MD5: d23419142506d8f9acbeae8d430b0fe0
X-Checksum-SHA1: 2070949dc8125ee01d25b76c026f0fa874a3e2dc
Via: 1.1 varnish
Content-Length: 500035
Accept-Ranges: bytes
Date: Wed, 15 Jan 2020 20:03:36 GMT
Via: 1.1 varnish
Age: 804427
Connection: keep-alive
X-Served-By: cache-iad2150-IAD, cache-fty21340-FTY
X-Cache: HIT, HIT
X-Cache-Hits: 1, 1
X-Timer: S1579118616.478236,VS0,VE1
</pre></details>
<details>
<summary>with HTTP</summary>
<pre>
$ curl -I http://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/3.0.3.778/sonar-scanner-cli-3.0.3.778.zip
HTTP/1.1 501 HTTPS Required
Server: Varnish
Content-Type: text/plain
Content-Length: 133
Accept-Ranges: bytes
Date: Wed, 15 Jan 2020 20:05:05 GMT
Via: 1.1 varnish
Connection: close
X-Served-By: cache-fty21357-FTY
X-Cache: MISS
X-Cache-Hits: 0
X-Timer: S1579118705.191576,VS0,VE0
</pre></details>