### PR TITLE
Handle `apt.sources` as a Hash

### DIFF
--- a/lib/travis/build/addons/apt.rb
+++ b/lib/travis/build/addons/apt.rb
@@ -226,7 +226,7 @@ module Travis
           end
 
           def config_sources
-            @config_sources ||= Array(config[:sources]).flatten.compact.map do |src|
+            @config_sources ||= Array([config[:sources]]).flatten.compact.map do |src|
               src.is_a?(String) ? { name: src } : src
             end
           rescue TypeError => e

--- a/spec/build/addons/apt_spec.rb
+++ b/spec/build/addons/apt_spec.rb
@@ -275,6 +275,14 @@ describe Travis::Build::Addons::Apt, :sexp do
       it { should include_sexp [:cmd, apt_sources_append_command('foobar'), echo: true, assert: true, timing: true] }
       it { should_not include_sexp [:cmd, apt_sources_append_command(packagecloud['sourceline']), echo: true, assert: true, timing: true] }
       it { should_not include_sexp [:cmd, apt_add_repository_command(deadsnakes['sourceline']), echo: true, assert: true, timing: true] }
+
+      context 'with config gives `sources` as a hash' do
+        let(:apt_config) { { sources: {
+                "sourceline": "deb https://packagecloud.io/chef/stable/ubuntu/ xenial main"
+              } } }
+
+        it { should include_sexp [:cmd, apt_sources_append_command(apt_config[:sources][:sourceline]), echo: true, assert: true, timing: true] }
+      end
     end
   end
 


### PR DESCRIPTION
This 

```yaml
apt:
  sources:
    sourcline: foobarbaz
```
is not documented structure, so it is not strictly required to support it.

Furthermore, `travis-yml` would normalize this incorrect form to something that `travis-build` can handle. So, in the not-so-distant future it would be unnecessary.