### PR TITLE
disown the agent and wait for the pid file to be removed

### DIFF
--- a/lib/travis/build/appliances/agent/agent.rb
+++ b/lib/travis/build/appliances/agent/agent.rb
@@ -12,6 +12,7 @@ def err(*strs)
 end
 
 module Agent
+  PID = '/tmp/travis/agent.pid'
   DIR = '/tmp/travis/events'
   PAUSE = 0.2
 
@@ -34,6 +35,8 @@ module Agent
       puts 'stopped watching'
       sleep PAUSE
       workers.each(&:stop)
+      puts 'removing pid'
+      FileUtils.rm_rf(PID)
     end
 
     private
@@ -69,6 +72,8 @@ module Agent
 
     def stop
       @stop = true
+      sleep(PAUSE)
+      watch
     end
 
     def watch

--- a/lib/travis/build/bash/travis_terminate.bash
+++ b/lib/travis/build/bash/travis_terminate.bash
@@ -39,10 +39,13 @@ _travis_terminate_windows() {
 
 _travis_terminate_agent() {
   [ ! -f /tmp/travis/agent.pid ] && return
-  sleep 1
   pid=$(cat /tmp/travis/agent.pid)
+
   kill "$pid" &>/dev/null
-  wait "$pid"
+  counter=500
+  while test $((counter--)) -ne 0 -a -f /tmp/travis/agent.pid; do
+    sleep 0.1
+  done
 
   [ -z ${TRAVIS_AGENT_DEBUG+x} ] && return
   echo


### PR DESCRIPTION
tested on https://staging.travis-ci.org/svenfuchs/test-2/builds/756074

```
Done. Your build exited with 0.
agent.debug
cat /tmp/travis/agent.log
refreshing token ...
starting workers
starting watcher
[stop] received signal 15
processing /tmp/travis/events/event.1
posting event ...
stopped watching
done posting event.
worker 1 stopped
worker 2 stopped
worker 3 stopped
worker 4 stopped
worker 5 stopped
removing pid
```

the two lines `wait` were debug output in https://github.com/travis-ci/travis-build/pull/1847/files#diff-273db458665b8808ecf6b44ebcb8da3aR46

the log shows that it has sent the signal to the agent, which has then still found and processed the event, and only after that stopped watching, and removed the pid file.