### PR TITLE
Run command in a way that allows it to set `errexit`

### DIFF
--- a/lib/travis/build/bash/travis_retry.bash
+++ b/lib/travis/build/bash/travis_retry.bash
@@ -5,7 +5,10 @@ travis_retry() {
     [[ "${result}" -ne 0 ]] && {
       echo -e "\\n${ANSI_RED}The command \"${*}\" failed. Retrying, ${count} of 3.${ANSI_RESET}\\n" >&2
     }
-    "${@}" && { result=0 && break; } || result="${?}"
+    # run the command in a way that doesn't disable setting `errexit`
+    "${@}"
+    result="${?}"
+    if [[ $result -eq 0 ]]; then break; fi
     count="$((count + 1))"
     sleep 1
   done


### PR DESCRIPTION
https://travis-ci.community/t/travis-retry-on-windows-does-not-make-the-build-fail