### PR TITLE
Test export preserving the value

### DIFF
--- a/spec/shell/generator/bash_spec.rb
+++ b/spec/shell/generator/bash_spec.rb
@@ -141,6 +141,11 @@ describe Travis::Shell::Generator::Bash, :include_node_helpers do
       @sexp = [:export, ['FOO', 'foo'], echo: true, secure: true]
       expect(code).to eql("travis_cmd export\\ FOO\\=foo --echo --display export\\ FOO\\=\\[secure\\] --secure")
     end
+
+    it 'preserves the value as is regardless of syntax' do
+      @sexp=[:export, ['foo', '$bar "baz blah" `xyz zy`']]
+      expect(code).to eql('export foo=$bar "baz blah" `xyz zy`')
+    end
   end
 
   describe :file do


### PR DESCRIPTION
Follow-up of https://github.com/travis-ci/travis-build/pull/1865#issuecomment-596645499.

Adds a test for the current behavior when Bash special characters are present in the value.

[x] Document the behavior: https://github.com/travis-ci/docs-travis-ci-com/pull/2720.

As per https://github.com/travis-ci/docs-travis-ci-com/pull/2720#issue-387098928, no functional changes are needed.