### PR TITLE
r.rb: skip brew update if disable_homebrew = true

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -120,7 +120,9 @@ module Travis
               when 'osx'
                 # We want to update, but we don't need the 800+ lines of
                 # output.
-                sh.cmd 'brew update >/dev/null', retry: true
+                unless config[:disable_homebrew]
+                  sh.cmd 'brew update >/dev/null', retry: true
+                end
 
                 # R-devel builds available at mac.r-project.org
                 if r_version == 'devel'


### PR DESCRIPTION
With the latest versions of homebrew, `brew update` fails on legacy MacOS. But on these legacy systems we still want to be able to test without homebrew.

Example: https://travis-ci.org/github/r-dbi/RMySQL/jobs/662231478?utm_medium=notification&utm_source=github_status

@jimhester 