### PR TITLE
Update elm integration for 2020

### DIFF
--- a/lib/travis/build/script/elm.rb
+++ b/lib/travis/build/script/elm.rb
@@ -124,16 +124,12 @@ module Travis
             (config[:elm_format] || elm_version_tagged).to_s
           end
 
-          def version_prefix
-            if elm_version =~ /^elm/ || elm_version =~ /^latest-/
-              ""
-            else
-              "latest-"
-            end
-          end
-
           def elm_version_tagged
-            version_prefix + elm_version
+            if elm_version =~ /^(elm|latest-)/
+              elm_version
+            else
+              "latest-#{elm_version}"
+            end
           end
 
           def npm_install_global(package_name, package_version)

--- a/lib/travis/build/script/elm.rb
+++ b/lib/travis/build/script/elm.rb
@@ -3,7 +3,7 @@ module Travis
     class Script
       class Elm < NodeJs
         # Default NodeJS version to install
-        DEFAULT_NODE_VERSION = '13.11.0'
+        DEFAULT_NODE_VERSION = '12'
 
         DEFAULTS = {
           elm: 'latest-0.19.1',

--- a/lib/travis/build/script/elm.rb
+++ b/lib/travis/build/script/elm.rb
@@ -124,8 +124,16 @@ module Travis
             (config[:elm_format] || elm_version_tagged).to_s
           end
 
+          def version_prefix
+            if elm_version =~ /^elm/ || elm_version =~ /^latest-/
+              ""
+            else
+              "latest-"
+            end
+          end
+
           def elm_version_tagged
-            "elm" + elm_version.sub(/^elm/,"")
+            version_prefix + elm_version
           end
 
           def npm_install_global(package_name, package_version)

--- a/lib/travis/build/script/elm.rb
+++ b/lib/travis/build/script/elm.rb
@@ -3,13 +3,13 @@ module Travis
     class Script
       class Elm < NodeJs
         # Default NodeJS version to install
-        DEFAULT_NODE_VERSION = '10.13.0'
+        DEFAULT_NODE_VERSION = '13.11.0'
 
         DEFAULTS = {
           elm: 'elm0.19.0',
         }
 
-        ELM_TEST_REQUIRED_NODE_VERSION = '6.0.0'
+        ELM_TEST_REQUIRED_NODE_VERSION = '8.0.0'
 
         def export
           super

--- a/lib/travis/build/script/elm.rb
+++ b/lib/travis/build/script/elm.rb
@@ -6,7 +6,7 @@ module Travis
         DEFAULT_NODE_VERSION = '13.11.0'
 
         DEFAULTS = {
-          elm: 'elm0.19.0',
+          elm: 'latest-0.19.1',
         }
 
         ELM_TEST_REQUIRED_NODE_VERSION = '8.0.0'

--- a/spec/build/script/elm_spec.rb
+++ b/spec/build/script/elm_spec.rb
@@ -93,18 +93,18 @@ describe Travis::Build::Script::Elm, :sexp do
   context "given 'elm_test: elm0.18.0'" do
     it "sets TRAVIS_ELM_* environment variables correctly" do
       data[:config][:elm_test] = 'elm0.18.0'
-      should include_sexp [:export, ['TRAVIS_ELM_VERSION', 'elm0.19.0']]
+      should include_sexp [:export, ['TRAVIS_ELM_VERSION', 'latest-0.19.1']]
       should include_sexp [:export, ['TRAVIS_ELM_TEST_VERSION', 'elm0.18.0']]
-      should include_sexp [:export, ['TRAVIS_ELM_FORMAT_VERSION', 'elm0.19.0']]
+      should include_sexp [:export, ['TRAVIS_ELM_FORMAT_VERSION', 'latest-0.19.1']]
     end
   end
 
   context "given 'elm_test: latest-0.18.0'" do
     it "sets TRAVIS_ELM_* environment variables correctly" do
       data[:config][:elm_test] = 'latest-0.18.0'
-      should include_sexp [:export, ['TRAVIS_ELM_VERSION', 'elm0.19.0']]
+      should include_sexp [:export, ['TRAVIS_ELM_VERSION', 'latest-0.19.1']]
       should include_sexp [:export, ['TRAVIS_ELM_TEST_VERSION', 'latest-0.18.0']]
-      should include_sexp [:export, ['TRAVIS_ELM_FORMAT_VERSION', 'elm0.19.0']]
+      should include_sexp [:export, ['TRAVIS_ELM_FORMAT_VERSION', 'latest-0.19.1']]
     end
   end
 

--- a/spec/build/script/elm_spec.rb
+++ b/spec/build/script/elm_spec.rb
@@ -22,8 +22,17 @@ describe Travis::Build::Script::Elm, :sexp do
     it "sets TRAVIS_ELM_VERSION to 0.18.0; prefixes TRAVIS_ELM_*_VERSION with 'elm'" do
       data[:config][:elm] = '0.18.0'
       should include_sexp [:export, ['TRAVIS_ELM_VERSION', '0.18.0']]
-      should include_sexp [:export, ['TRAVIS_ELM_TEST_VERSION', 'elm0.18.0']]
-      should include_sexp [:export, ['TRAVIS_ELM_FORMAT_VERSION', 'elm0.18.0']]
+      should include_sexp [:export, ['TRAVIS_ELM_TEST_VERSION', 'latest-0.18.0']]
+      should include_sexp [:export, ['TRAVIS_ELM_FORMAT_VERSION', 'latest-0.18.0']]
+    end
+  end
+
+  context "given 'elm: latest-0.18.0'" do
+    it "sets TRAVIS_ELM_* environment variables to latest-0.18.0" do
+      data[:config][:elm] = 'latest-0.18.0'
+      should include_sexp [:export, ['TRAVIS_ELM_VERSION', 'latest-0.18.0']]
+      should include_sexp [:export, ['TRAVIS_ELM_TEST_VERSION', 'latest-0.18.0']]
+      should include_sexp [:export, ['TRAVIS_ELM_FORMAT_VERSION', 'latest-0.18.0']]
     end
   end
 
@@ -36,6 +45,24 @@ describe Travis::Build::Script::Elm, :sexp do
     end
   end
 
+  context "given 'elm: 0.19.1'" do
+    it "sets TRAVIS_ELM_VERSION to 0.19.1; prefixes TRAVIS_ELM_*_VERSION with 'latest-'" do
+      data[:config][:elm] = '0.19.1'
+      should include_sexp [:export, ['TRAVIS_ELM_VERSION', '0.19.1']]
+      should include_sexp [:export, ['TRAVIS_ELM_TEST_VERSION', 'latest-0.19.1']]
+      should include_sexp [:export, ['TRAVIS_ELM_FORMAT_VERSION', 'latest-0.19.1']]
+    end
+  end
+
+  context "given 'elm: latest-0.19.1'" do
+    it "sets TRAVIS_ELM_* environment variables to latest-0.19.1" do
+      data[:config][:elm] = 'latest-0.19.1'
+      should include_sexp [:export, ['TRAVIS_ELM_VERSION', 'latest-0.19.1']]
+      should include_sexp [:export, ['TRAVIS_ELM_TEST_VERSION', 'latest-0.19.1']]
+      should include_sexp [:export, ['TRAVIS_ELM_FORMAT_VERSION', 'latest-0.19.1']]
+    end
+  end
+
   context "given 'elm: [elm0.18.0]'" do
     it "sets TRAVIS_ELM_* environment variables to elm0.18.0" do
       data[:config][:elm] = ['elm0.18.0']
@@ -45,11 +72,38 @@ describe Travis::Build::Script::Elm, :sexp do
     end
   end
 
+  context "given 'elm: [latest-0.18.0]'" do
+    it "sets TRAVIS_ELM_* environment variables to latest-0.18.0" do
+      data[:config][:elm] = ['latest-0.18.0']
+      should include_sexp [:export, ['TRAVIS_ELM_VERSION', 'latest-0.18.0']]
+      should include_sexp [:export, ['TRAVIS_ELM_TEST_VERSION', 'latest-0.18.0']]
+      should include_sexp [:export, ['TRAVIS_ELM_FORMAT_VERSION', 'latest-0.18.0']]
+    end
+  end
+
+  context "given 'elm: [latest-0.19.1]'" do
+    it "sets TRAVIS_ELM_* environment variables to latest-0.19.1" do
+      data[:config][:elm] = ['latest-0.19.1']
+      should include_sexp [:export, ['TRAVIS_ELM_VERSION', 'latest-0.19.1']]
+      should include_sexp [:export, ['TRAVIS_ELM_TEST_VERSION', 'latest-0.19.1']]
+      should include_sexp [:export, ['TRAVIS_ELM_FORMAT_VERSION', 'latest-0.19.1']]
+    end
+  end
+
   context "given 'elm_test: elm0.18.0'" do
     it "sets TRAVIS_ELM_* environment variables correctly" do
       data[:config][:elm_test] = 'elm0.18.0'
       should include_sexp [:export, ['TRAVIS_ELM_VERSION', 'elm0.19.0']]
       should include_sexp [:export, ['TRAVIS_ELM_TEST_VERSION', 'elm0.18.0']]
+      should include_sexp [:export, ['TRAVIS_ELM_FORMAT_VERSION', 'elm0.19.0']]
+    end
+  end
+
+  context "given 'elm_test: latest-0.18.0'" do
+    it "sets TRAVIS_ELM_* environment variables correctly" do
+      data[:config][:elm_test] = 'latest-0.18.0'
+      should include_sexp [:export, ['TRAVIS_ELM_VERSION', 'elm0.19.0']]
+      should include_sexp [:export, ['TRAVIS_ELM_TEST_VERSION', 'latest-0.18.0']]
       should include_sexp [:export, ['TRAVIS_ELM_FORMAT_VERSION', 'elm0.19.0']]
     end
   end


### PR DESCRIPTION
Two main changes:

* A new patch release of elm has been released (elm `0.19.1`). This pull request uses it by default when `language: elm`.

* The way elm versions are tagged on npm has also changed (see [1](https://www.npmjs.com/package/elm?activeTab=versions), [2](https://www.npmjs.com/package/elm-test?activeTab=versions) and [3](https://www.npmjs.com/package/elm-format?activeTab=versions)) to use tags of the form `latest-0.19.1` instead of `elm0.19.1`. This tagging has been applied retrospectively to versions `0.18.0` onwards (all the versions that travis supports). Notably, the `0.19.1` release has *not* been tagged as `elm0.19.1` which means the [`.travis.yml` config](https://github.com/harrysarson/travis-ci/blob/f249a69f6c7c27f2f02e57033bb1372b5e8d88c8/.travis.yml#L1-L3):

  ```yml
  language: elm
  
  elm: elm0.19.1
  ```

  errors when [run in travis](https://travis-ci.com/github/harrysarson/travis-ci/builds/153320693). This PR updates travis-build to use tags of the form `latest-0.19.1` by default.

---

This PR builds #1718, #1613, #1605 and #934

cc: @avh4, @lukewestby, @stoeffel and @rtfeldman