### PR TITLE
Add Rake task to keep `ghc.json` up to date

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,3 +41,5 @@ gem 'travis-config'
 gem 'travis-github_apps', git: gh('travis-ci/travis-github_apps')
 gem 'travis-rollout', git: gh('travis-ci/travis-rollout')
 gem 'travis-support', git: gh('travis-ci/travis-support')
+
+gem "octokit", "~> 4.18"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,9 @@ GEM
     net-http-persistent (3.0.0)
       connection_pool (~> 2.2)
     net-http-pipeline (1.0.1)
+    octokit (4.18.0)
+      faraday (>= 0.9)
+      sawyer (~> 0.8.0, >= 0.5.3)
     optimist (3.0.0)
     parallel (1.12.1)
     parallel_tests (2.23.0)
@@ -157,6 +160,9 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
     sentry-raven (2.7.4)
       faraday (>= 0.7.6, < 1.0)
     simplecov (0.13.0)
@@ -212,6 +218,7 @@ DEPENDENCIES
   metriks-librato_metrics!
   minitar
   mocha
+  octokit (~> 4.18)
   parallel_tests
   pry
   puma
@@ -232,4 +239,4 @@ DEPENDENCIES
   travis-support!
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
The `create_ghc_json_pr` task checks the current GHC versions,
and if updates exists, it creates a PR for maintainers to review.

This new Rake task will create a PR when `ghc.json` needs an update, which causes erroneous PR build failures.

https://github.com/travis-ci/travis-build/pull/1881 was created by running this new Rake task in a debug build.

This task would be added to a cron job, so it runs once a day.

One chore to address: `GITHUB_OAUTH_TOKEN` should belong to a bot, not me.