### PR TITLE
Update macOS R-devel travis config for testing 4.0.0

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -126,7 +126,7 @@ module Travis
 
                 # R-devel builds available at mac.r-project.org
                 if r_version == 'devel'
-                  r_url = "https://mac.r-project.org/el-capitan/R-devel/R-devel-el-capitan.pkg"
+                  r_url = "http://mac.r-project.org/high-sierra/R-4.0-branch/R-4.0-branch.pkg"
 
                 # The latest release is the only one available in /bin/macosx
                 elsif r_version == r_latest

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -556,12 +556,18 @@ module Travis
             sh.cmd 'curl -fLo /tmp/gfortran.tar.bz2 http://r.research.att.com/libs/gfortran-4.8.2-darwin13.tar.bz2', retry: true
             sh.cmd 'sudo tar fvxz /tmp/gfortran.tar.bz2 -C /'
             sh.rm '/tmp/gfortran.tar.bz2'
-          else
+          elsif r_version_less_than('3.7')
             sh.cmd "curl -fLo /tmp/gfortran61.dmg #{repos[:CRAN]}/contrib/extra/macOS/gfortran-6.1-ElCapitan.dmg", retry: true
             sh.cmd 'sudo hdiutil attach /tmp/gfortran61.dmg -mountpoint /Volumes/gfortran'
             sh.cmd 'sudo installer -pkg "/Volumes/gfortran/gfortran-6.1-ElCapitan/gfortran.pkg" -target /'
             sh.cmd 'sudo hdiutil detach /Volumes/gfortran'
             sh.rm '/tmp/gfortran61.dmg'
+          else
+            sh.cmd "curl -fLo /tmp/gfortran82.dmg https://github.com/fxcoudert/gfortran-for-macOS/releases/download/8.2/gfortran-8.2-Mojave.dmg", retry: true
+            sh.cmd 'sudo hdiutil attach /tmp/gfortran82.dmg -mountpoint /Volumes/gfortran'
+            sh.cmd 'sudo installer -pkg "/Volumes/gfortran/gfortran-8.2-Mojave/gfortran.pkg" -target /'
+            sh.cmd 'sudo hdiutil detach /Volumes/gfortran'
+            sh.rm '/tmp/gfortran82.dmg'
           end
         end
 

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -126,7 +126,7 @@ module Travis
 
                 # R-devel builds available at mac.r-project.org
                 if r_version == 'devel'
-                  r_url = "http://mac.r-project.org/high-sierra/R-4.0-branch/R-4.0-branch.pkg"
+                  r_url = "https://mac.r-project.org/high-sierra/R-4.0-branch/R-4.0-branch.pkg"
 
                 # The latest release is the only one available in /bin/macosx
                 elsif r_version == r_latest

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -126,7 +126,7 @@ module Travis
 
                 # R-devel builds available at mac.r-project.org
                 if r_version == 'devel'
-                  r_url = "https://mac.r-project.org/high-sierra/R-4.0-branch/R-4.0-branch.pkg"
+                  r_url = "https://mac.r-project.org/high-sierra/R-devel/R-devel.pkg"
 
                 # The latest release is the only one available in /bin/macosx
                 elsif r_version == r_latest

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -75,7 +75,7 @@ describe Travis::Build::Script::R, :sexp do
   it 'downloads and installs R devel on OS X' do
     data[:config][:os] = 'osx'
     data[:config][:r] = 'devel'
-    should include_sexp [:cmd, %r{^curl.*mac\.r-project\.org/el-capitan/R-devel/R-devel-el-capitan\.pkg},
+    should include_sexp [:cmd, %r{^curl.*mac\.r-project\.org/high-sierra/R-4.0-branch/R-4.0-branch\.pkg},
                          assert: true, echo: true, retry: true, timing: true]
   end
   it 'downloads and installs gfortran libraries on OS X' do
@@ -91,6 +91,14 @@ describe Travis::Build::Script::R, :sexp do
     data[:config][:r] = 'release'
     data[:config][:fortran] = true
     should include_sexp [:cmd, %r{^curl.*\/tmp\/gfortran61.dmg https?:\/\/.*\/macOS\/gfortran-6.1-ElCapitan.dmg},
+                         assert: true, echo: true, retry: true, timing: true]
+  end
+  
+  it 'downloads and installs Coudert gfortran on OS X for R 3.4' do
+    data[:config][:os] = 'osx'
+    data[:config][:r] = 'devel'
+    data[:config][:fortran] = true
+    should include_sexp [:cmd, %r{^curl.*\/tmp\/gfortran82.dmg https?:\/\/.*\/download\/8.2\/gfortran-8.2-Mojave.dmg},
                          assert: true, echo: true, retry: true, timing: true]
   end
 

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -75,7 +75,7 @@ describe Travis::Build::Script::R, :sexp do
   it 'downloads and installs R devel on OS X' do
     data[:config][:os] = 'osx'
     data[:config][:r] = 'devel'
-    should include_sexp [:cmd, %r{^curl.*mac\.r-project\.org/high-sierra/R-4.0-branch/R-4.0-branch\.pkg},
+    should include_sexp [:cmd, %r{^curl.*mac\.r-project\.org/high-sierra/R-devel/R-devel\.pkg},
                          assert: true, echo: true, retry: true, timing: true]
   end
   it 'downloads and installs gfortran libraries on OS X' do


### PR DESCRIPTION
This PR updates the toolchain to use:

- gfortran 8.2
   - https://github.com/fxcoudert/gfortran-for-macOS/releases/download/8.2/gfortran-8.2-Mojave.dmg
- New r-devel package endpoint for R 4.0.0 
   - http://mac.r-project.org/high-sierra/R-4.0-branch/R-4.0-branch.pkg

As noted in:

https://stat.ethz.ch/pipermail/r-sig-mac/2020-April/013289.html

And addressed further in:

https://stat.ethz.ch/pipermail/r-sig-mac/2020-April/013311.html

----

What wasn't done is implement a pull of binaries available here:

http://mac.r-project.org/libs-4/

Note:  There is a machine-readable list in http://mac.r-project.org/libs-4/INDEX

Would this be appreciated?