### PR TITLE
Fix Julia "1" Windows installer options

### DIFF
--- a/lib/travis/build/script/julia.rb
+++ b/lib/travis/build/script/julia.rb
@@ -67,7 +67,7 @@ module Travis
             when 'windows'
               sh.cmd %Q{curl -A "$CURL_USER_AGENT" -sSf -L --retry 7 -o julia-installer.exe '#{julia_url}'}
               sh.cmd 'chmod +x julia-installer.exe'
-              if config[:julia] == 'nightly' || Gem::Version.new(config[:julia]) >= Gem::Version.new('1.4')
+              if uses_inno_setup?
                 sh.cmd %Q{powershell -c 'Start-Process -FilePath julia-installer.exe -ArgumentList "/VERYSILENT /DIR=C:\\julia" -NoNewWindow -Wait'}
               else
                 sh.cmd %Q{powershell -c 'Start-Process -FilePath julia-installer.exe -ArgumentList "/S /D=C:\\julia" -NoNewWindow -Wait'}
@@ -189,6 +189,12 @@ module Travis
               sh.failure "Unknown Julia version: #{julia_version}"
             end
             "https://#{url}"
+          end
+
+          def uses_inno_setup?
+            return false unless config[:os] == 'windows'
+            ver = Array(config[:julia]).first.to_s
+            ver == 'nightly' || ver == '1' || Gem::Version.new(ver) >= Gem::Version.new('1.4')
           end
       end
     end


### PR DESCRIPTION
Since the version "1" points to "1.4" now (cf. PR #1878) and "1" < "1.4", this changes the condition to match both "nightly" and "1".