### PR TITLE
Retry Redis connection

### DIFF
--- a/lib/travis/build/config.rb
+++ b/lib/travis/build/config.rb
@@ -44,10 +44,10 @@ module Travis
             'http://archive.ubuntu.com/ubuntu/'
           )
         },
-        # safe list and alias list are env variables set at the deployment level, pointing to a lists kept in github repository;  
+        # safe list and alias list are env variables set at the deployment level, pointing to a lists kept in github repository;
         # whenever adding a new distribution and relevant new env variable, configure nnew env var to point to that list
         # lists are in form of json file with specified structure
-        apt_package_safelist: { 
+        apt_package_safelist: {
           precise: ENV.fetch('TRAVIS_BUILD_APT_PACKAGE_SAFELIST_PRECISE', ''),
           trusty: ENV.fetch('TRAVIS_BUILD_APT_PACKAGE_SAFELIST_TRUSTY', ''),
           xenial: ENV.fetch('TRAVIS_BUILD_APT_PACKAGE_SAFELIST_XENIAL', ''),
@@ -116,7 +116,12 @@ module Travis
             )
           ).split(',').map { |s| URI.unescape(s.strip) }
         },
-        redis: { url: 'redis://localhost:6379' },
+        redis: {
+          url: 'redis://localhost:6379',
+          reconnect_attempts: 5,
+          reconnect_delay: 1,
+          reconnect_delay_max: 10.0,
+        },
         sentry_dsn: ENV.fetch(
           'TRAVIS_BUILD_SENTRY_DSN', ENV.fetch('SENTRY_DSN', '')
         ),


### PR DESCRIPTION
On the rare occasions that we could not connect to the Redis server,
retry.

These options (https://github.com/redis/redis-rb#reconnections) are passed through to `Redis.new` via

`Travis::Build.redis`
https://github.com/travis-ci/travis-build/blob/3ae9fe1e1cdaa7bf27ae5fd6ee1d847e75607dec/lib/travis/build.rb#L64-L66

and `Travis::RedisPool`
https://github.com/travis-ci/travis-build/blob/3ae9fe1e1cdaa7bf27ae5fd6ee1d847e75607dec/lib/travis/support/redis_pool.rb#L12-L14