### PR TITLE
r.rb: sync the homebrew uninstall script with upstream

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -566,13 +566,14 @@ module Travis
         end
 
         # Uninstalls the preinstalled homebrew
-        # See FAQ: https://docs.brew.sh/FAQ#how-do-i-uninstall-old-versions-of-a-formula
+        # See FAQ: https://docs.brew.sh/FAQ#how-do-i-uninstall-homebrew
         def disable_homebrew
           return unless (config[:os] == 'osx')
-          sh.cmd "curl -fsSOL https://raw.githubusercontent.com/Homebrew/install/master/uninstall"
-          sh.cmd "sudo ruby uninstall --force"
-          sh.cmd "rm uninstall"
+          sh.cmd "curl -fsSOL https://raw.githubusercontent.com/Homebrew/install/master/uninstall.sh"
+          sh.cmd "sudo /bin/bash uninstall.sh --force"
+          sh.cmd "rm uninstall.sh"
           sh.cmd "hash -r"
+          sh.cmd "git config --global --unset protocol.version"
         end
 
         # Abstract out version check


### PR DESCRIPTION
Upstream homebrew has [ported their uninstall script](https://docs.brew.sh/FAQ#how-do-i-uninstall-homebrew) from ruby to bash.

I also added `git config --global --unset protocol.version`. This solves an issue on xcode 10.1 where the image had set `protocol.version 2` however this only works with the homebrew version of git. The macos system git does not support this so we see:

```
$ git clone --depth=50 --branch=master https://github.com/ropensci/xslt.git ropensci/xslt
Cloning into 'ropensci/xslt'...
fatal: unknown value for config 'protocol.version': 2
The command "eval git clone --depth=50 --branch=master https://github.com/ropensci/xslt.git ropensci/xslt " failed. Retrying, 2 of 3.
```

Full log: https://travis-ci.org/github/ropensci/xslt/jobs/675283572