### PR TITLE
Julia: don't pollute package directory with 'juliamnt'

### DIFF
--- a/lib/travis/build/script/julia.rb
+++ b/lib/travis/build/script/julia.rb
@@ -60,9 +60,9 @@ module Travis
               sh.cmd 'export PATH="${PATH}:${TRAVIS_HOME}/julia/bin"'
             when 'osx'
               sh.cmd %Q{curl -A "$CURL_USER_AGENT" -sSf -L --retry 7 -o julia.dmg '#{julia_url}'}
-              sh.cmd 'mkdir juliamnt'
-              sh.cmd 'hdiutil mount -readonly -mountpoint juliamnt julia.dmg'
-              sh.cmd 'cp -a juliamnt/*.app/Contents/Resources/julia ~/'
+              sh.cmd 'mkdir /tmp/juliamnt'
+              sh.cmd 'hdiutil mount -readonly -mountpoint /tmp/juliamnt julia.dmg'
+              sh.cmd 'cp -a /tmp/juliamnt/*.app/Contents/Resources/julia ~/'
               sh.cmd 'export PATH="${PATH}:${TRAVIS_HOME}/julia/bin"'
             when 'windows'
               sh.cmd %Q{curl -A "$CURL_USER_AGENT" -sSf -L --retry 7 -o julia-installer.exe '#{julia_url}'}


### PR DESCRIPTION
This can screw up tests if software running in Travis scans its
directory recursively.

It would actually probably be better to also unmount the image; or in
fact, to use attach/detach instead of mount/unmount (see `r.rb`). But to
minimize risk of breakage, I took this conservative approach instead.

ping @ararslan 