### PR TITLE
Julia: don't put 'juliamnt' and 'julia.dmg' into git clone

### DIFF
--- a/lib/travis/build/script/julia.rb
+++ b/lib/travis/build/script/julia.rb
@@ -59,10 +59,11 @@ module Travis
                        '| tar -C ~/julia -x -z --strip-components=1 -f -'
               sh.cmd 'export PATH="${PATH}:${TRAVIS_HOME}/julia/bin"'
             when 'osx'
-              sh.cmd %Q{curl -A "$CURL_USER_AGENT" -sSf -L --retry 7 -o julia.dmg '#{julia_url}'}
-              sh.cmd 'mkdir juliamnt'
-              sh.cmd 'hdiutil mount -readonly -mountpoint juliamnt julia.dmg'
-              sh.cmd 'cp -a juliamnt/*.app/Contents/Resources/julia ~/'
+              sh.cmd %Q{curl -A "$CURL_USER_AGENT" -sSf -L --retry 7 -o /tmp/julia.dmg '#{julia_url}'}
+              sh.cmd 'sudo hdiutil attach -readonly -mountpoint /Volumes/juliamnt /tmp/julia.dmg'
+              sh.cmd 'cp -a /Volumes/juliamnt/*.app/Contents/Resources/julia ~/'
+              sh.cmd 'sudo hdiutil detach /Volumes/juliamnt'
+              sh.rm '/tmp/julia.dmg'
               sh.cmd 'export PATH="${PATH}:${TRAVIS_HOME}/julia/bin"'
             when 'windows'
               sh.cmd %Q{curl -A "$CURL_USER_AGENT" -sSf -L --retry 7 -o julia-installer.exe '#{julia_url}'}


### PR DESCRIPTION
This can screw up tests if software running in Travis scans its directory recursively.

This is a somewhat more "daring" version of PR #1895; compared to that, it puts the .dmg into the /tmp dir (confirmed to be OK by looking at multiple other scripts in here which all use /tmp), and mount the volume into /Volumes (standard place on macOS, and also what `r.rb` does). Finally, the volume is also detached (and hence unmounted) after use, and the .dmg is removed, so that ideally no trace of this all going on is left for user scripts to observe.

I think this is preferable over PR #1895, except that it's a bigger and hence more risky change that I couldn't really test, so who knows what I screwed up... :/.

Ping @ararslan (sorry for the noise but I figured you should be aware)

Closes #1895