### PR TITLE
Apply branch-specific Settings env vars last

### DIFF
--- a/lib/travis/build/env/settings.rb
+++ b/lib/travis/build/env/settings.rb
@@ -15,7 +15,9 @@ module Travis
         private
 
           def env_vars
-            data.env_vars.map do |var|
+            branch_specific, default = data.env_vars.partition { |v| v[:branch] == job[:branch]}
+
+            (default + branch_specific).map do |var|
               if var[:branch].to_s.empty? || var[:branch] == job[:branch]
                 [var[:name], var[:value], secure: !var[:public]]
               else


### PR DESCRIPTION
When applying env vars defined in repository settings, be sure to apply
the branch-specific ones after the all-branch ones, so the intended
preferences are respected.