### PR TITLE
Small fixes for R

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -126,7 +126,7 @@ module Travis
 
                 # R-devel builds available at mac.r-project.org
                 if r_version == 'devel'
-                  r_url = "https://mac.r-project.org/el-capitan/R-devel/R-devel-el-capitan.pkg"
+                  r_url = "https://mac.r-project.org/high-sierra/R-devel/R-devel.pkg"
 
                 # The latest release is the only one available in /bin/macosx
                 elsif r_version == r_latest
@@ -573,7 +573,7 @@ module Travis
           sh.cmd "sudo /bin/bash uninstall.sh --force"
           sh.cmd "rm uninstall.sh"
           sh.cmd "hash -r"
-          sh.cmd "git config --global --unset protocol.version"
+          sh.cmd "git config --global --unset protocol.version || true"
         end
 
         # Abstract out version check
@@ -593,14 +593,14 @@ module Travis
         def normalized_r_version(v=Array(config[:r]).first.to_s)
           case v
           when 'release' then '4.0.0'
-          when 'oldrel' then '3.6.2'
+          when 'oldrel' then '3.6.3'
           when '3.0' then '3.0.3'
           when '3.1' then '3.1.3'
           when '3.2' then '3.2.5'
           when '3.3' then '3.3.3'
           when '3.4' then '3.4.4'
           when '3.5' then '3.5.3'
-          when '3.6' then '3.6.2'
+          when '3.6' then '3.6.3'
           when '4.0' then '4.0.0'
           when 'bioc-devel'
             config[:bioc_required] = true

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -75,7 +75,7 @@ describe Travis::Build::Script::R, :sexp do
   it 'downloads and installs R devel on OS X' do
     data[:config][:os] = 'osx'
     data[:config][:r] = 'devel'
-    should include_sexp [:cmd, %r{^curl.*mac\.r-project\.org/el-capitan/R-devel/R-devel-el-capitan\.pkg},
+    should include_sexp [:cmd, %r{^curl.*mac\.r-project\.org/high-sierra/R-devel/R-devel\.pkg},
                          assert: true, echo: true, retry: true, timing: true]
   end
   it 'downloads and installs gfortran libraries on OS X' do
@@ -253,7 +253,7 @@ describe Travis::Build::Script::R, :sexp do
     }
     it {
       data[:config][:r] = 'oldrel'
-      should eq("cache-#{CACHE_SLUG_EXTRAS}--R-3.6.2")
+      should eq("cache-#{CACHE_SLUG_EXTRAS}--R-3.6.3")
     }
     it {
       data[:config][:r] = '3.1'


### PR DESCRIPTION
Some small tweaks after R 4.0.0 release:
 - Oldrel version is now 3.6.3 (current is 4.0.0)
 - Updated URL for R-devel installer on MacOS
 - Small tweak for spurious failures in `disable_homebrew`