### PR TITLE
nix: upgrade 2.0.4 -> 2.3.4

### DIFF
--- a/lib/travis/build/script/nix.rb
+++ b/lib/travis/build/script/nix.rb
@@ -9,7 +9,7 @@ module Travis
     class Script
       class Nix < Script
         DEFAULTS = {
-          nix: '2.0.4'
+          nix: '2.3.4'
         }
 
         def export


### PR DESCRIPTION
The current nix version does not have builtins like `fromTOML`
and in general lacks behind what we use in stable.

see https://github.com/nix-community/NUR/pull/217