### PR TITLE
update bioc-devel r-version to 4.0.2

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -618,8 +618,8 @@ module Travis
           when 'bioc-devel'
             config[:bioc_required] = true
             config[:bioc_use_devel] = true
-            config[:r] = 'devel'
-            normalized_r_version('devel')
+            config[:r] = 'release'
+            normalized_r_version('release')
           when 'bioc-release'
             config[:bioc_required] = true
             config[:bioc_use_devel] = false

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -11,7 +11,7 @@ describe Travis::Build::Script::R, :sexp do
 
   it 'normalizes bioc-devel correctly' do
     data[:config][:r] = 'bioc-devel'
-    should include_sexp [:export, ['TRAVIS_R_VERSION', 'devel']]
+    should include_sexp [:export, ['TRAVIS_R_VERSION', '4.0.2']]
     should include_sexp [:cmd, %r{install.packages\(\"BiocManager"\)},
                          assert: true, echo: true, timing: true, retry: true]
     should include_sexp [:cmd, %r{BiocManager::install\(version = \"devel\"},

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -11,7 +11,7 @@ describe Travis::Build::Script::R, :sexp do
 
   it 'normalizes bioc-devel correctly' do
     data[:config][:r] = 'bioc-devel'
-    should include_sexp [:export, ['TRAVIS_R_VERSION', '4.0.2']]
+    should include_sexp [:export, ['TRAVIS_R_VERSION', '4.0.0']]
     should include_sexp [:cmd, %r{install.packages\(\"BiocManager"\)},
                          assert: true, echo: true, timing: true, retry: true]
     should include_sexp [:cmd, %r{BiocManager::install\(version = \"devel\"},


### PR DESCRIPTION
Based on https://github.com/travis-ci/travis-build/pull/1805

With every Bioconductor release, the lib/travis/build/script/r.rb file has to
change so that the R versions are matching with those that are compatible
with Bioconductor release and devel versions.

Here is the update to that file:
Bioconductor version 3.12 uses R-release (4.0.2).

cc: @jimhester

Reference: https://bioconductor.org/developers/how-to/useDevel/

Best,
Kevin