### PR TITLE
Support restoring workspace archives from another OS

### DIFF
--- a/lib/travis/build/script/shared/workspace.rb
+++ b/lib/travis/build/script/shared/workspace.rb
@@ -40,7 +40,12 @@ module Travis
         end
 
         def expand
-          sh.cmd "tar -xPzf ${CASHER_DIR}/#{name}-fetch.tgz"
+          archive = "${CASHER_DIR}/#{name}-fetch.tgz"
+          # For any directories where `tar` would directly place files,
+          # create missing ones and give the user permissions for existing ones.
+          # Needed when restoring an archive from another OS with a different filesystem hierarchy.
+          sh.raw "tar -tf \"#{archive}\" | grep -v '/$' | xargs -d '\\n' dirname | sort | uniq | xargs -d '\\n' sudo install -o \"${USER}\" -g \"$(id -gn)\" -d"
+          sh.cmd "tar -xPzf #{archive}"
         end
 
         # for creating workspace

--- a/lib/travis/build/script/shared/workspace.rb
+++ b/lib/travis/build/script/shared/workspace.rb
@@ -46,7 +46,7 @@ module Travis
           # Needed when restoring an archive from another OS with a different filesystem hierarchy.
           sh.raw "tar -tf \"#{archive}\" | grep -v '/$' | xargs -d '\\n' dirname | sort | uniq | "+
                      "xargs -d '\\n' $(if [[ $TRAVIS_OS_NAME != 'windows' ]]; then echo 'sudo'; fi) install -o \"${USER}\" -g \"$(id -gn)\" -d"
-          sh.cmd "tar -xPzf #{archive}"
+          sh.cmd "tar -xPf #{archive}"
         end
 
         # for creating workspace

--- a/lib/travis/build/script/shared/workspace.rb
+++ b/lib/travis/build/script/shared/workspace.rb
@@ -44,7 +44,8 @@ module Travis
           # For any directories where `tar` would directly place files,
           # create missing ones and give the user permissions for existing ones.
           # Needed when restoring an archive from another OS with a different filesystem hierarchy.
-          sh.raw "tar -tf \"#{archive}\" | grep -v '/$' | xargs -d '\\n' dirname | sort | uniq | xargs -d '\\n' sudo install -o \"${USER}\" -g \"$(id -gn)\" -d"
+          sh.raw "tar -tf \"#{archive}\" | grep -v '/$' | xargs -d '\\n' dirname | sort | uniq | "+
+                     "xargs -d '\\n' $(if [[ $TRAVIS_OS_NAME != 'windows' ]]; then echo 'sudo'; fi) install -o \"${USER}\" -g \"$(id -gn)\" -d"
           sh.cmd "tar -xPzf #{archive}"
         end
 

--- a/lib/travis/build/script/shared/workspace.rb
+++ b/lib/travis/build/script/shared/workspace.rb
@@ -41,11 +41,24 @@ module Travis
 
         def expand
           archive = "${CASHER_DIR}/#{name}-fetch.tgz"
-          # For any directories where `tar` would directly place files,
+          # For any root directories that `tar` would be extracting stuff to,
           # create missing ones and give the user permissions for existing ones.
           # Needed when restoring an archive from another OS with a different filesystem hierarchy.
-          sh.raw "tar -tf \"#{archive}\" | grep -v '/$' | xargs -d '\\n' dirname | sort | uniq | "+
-                     "xargs -d '\\n' $(if [[ $TRAVIS_OS_NAME != 'windows' ]]; then echo 'sudo'; fi) install -o \"${USER}\" -g \"$(id -gn)\" -d"
+          sh.raw "tar -tPf \"#{archive}\" | " +
+                     # BSD(OSX) xargs doesn't support `-d` so -0 is the only way to handle paths with spaces.
+                     # BSD awk doesn't support \0 in variables so have to use printf.
+                     # BSD dirname doesn't support multiple arguments; -P 2 reduces time from 30s to 20s on a
+                     # sample archive with ~20k entries, further increase doesn't reduce time.
+                     "awk '{printf(\"%s%c\",$0,0)}' | " +
+                     "xargs -0 $([[ $TRAVIS_OS_NAME =~ (osx|freebsd) ]] && echo '-n 1 -P 2') dirname | " +
+                     "sort | uniq | " +
+                     # Print only lines that don't have the same prefix as a previous one -- to get only root dirs.
+                     # Initial `a` must be an impossible prefix. Since BSD awk doesn't support \0,
+                     # \n is acceptable since `tar -t` delimits entries with \n with no option to change that
+                     "awk 'index($0,a)!=1{a=$0;printf(\"%s%c\",$0,0)} BEGIN{a=\"\\n\"}' | " +
+                     # `install` is more convenient than `mkdir -p` since it can set UID/GID as the same time.
+                     # It only sets UID/GID on the leaf entry
+                     "xargs -0 echo $([[ $TRAVIS_OS_NAME != 'windows' ]] && echo 'sudo') install -o \"${USER}\" -g \"$(id -gn)\" -d"
           sh.cmd "tar -xPf #{archive}"
         end
 


### PR DESCRIPTION
by creating any necessary directory hierarchy on the fly

https://travis-ci.community/t/introducing-workspaces/4249/9

This allows to restore absolute paths regardless of the OS.

Tested the command line on a Travis Python archive in Bionic, OSX Catalina and Windows Git Bash.

---

The stumbling block is currently that it's impossible to extract stuff to `/home` in OSX since it's an automounter mount point.

That could be fixed by altering OSX images:

* remove/comment the `/home` line from `/etc/auto_master` in OSX images; this must be done in the image, or run `sudo launchctl kill HUP system/com.apple.autofsd` after changing it.

`/home` automount point in OSX is only used for mounting a network home dir from a LDAP service, so we don't need it anyway.

---

This may still fail in some unusual setups -- e.g. if root is a readonly filesystem (is this the case with Milti-arch VMs?).