### PR TITLE
Julia: Update version 1 to point to version 1.5

### DIFF
--- a/lib/travis/build/script/julia.rb
+++ b/lib/travis/build/script/julia.rb
@@ -184,7 +184,7 @@ module Travis
               url = "julialang-s3.julialang.org/bin/#{osarch}/#{$1}/julia-#{$1}-latest-#{ext}"
             when '1'
               # TODO: create a permalink to latest 1.y.z
-              url = "julialang-s3.julialang.org/bin/#{osarch}/1.4/julia-1.4-latest-#{ext}"
+              url = "julialang-s3.julialang.org/bin/#{osarch}/1.5/julia-1.5-latest-#{ext}"
             else
               sh.failure "Unknown Julia version: #{julia_version}"
             end


### PR DESCRIPTION
Julia v1.5.0 was released on Aug. 1, 2020.
This changes the permalink for the version specifier "1", which means the latest 1.y.z.

cc: @ararslan