### PR TITLE
Display end of STDERR if `nvm install` fails

### DIFF
--- a/spec/build/script/node_js_spec.rb
+++ b/spec/build/script/node_js_spec.rb
@@ -68,7 +68,7 @@ describe Travis::Build::Script::NodeJs, :sexp do
       context 'when node given is < 1.0' do
         let(:node_js) { '0.8' }
         it 'sends nvm install STDERR to /dev/null' do
-          should include_sexp [:cmd, 'nvm install 0.8 2>/dev/null', echo: true, timing: true]
+          should include_sexp [:cmd, 'nvm install 0.8 2>install.err.log', echo: true, timing: true]
         end
       end
     end


### PR DESCRIPTION
In some cases (e.g., "0.4"), `nvm install` may install `node`
successfully, but the command may fail. In such cases, showing the
end of STDERR is helpful.