### PR TITLE
`apt update` is now required to install libevent-dev

### DIFF
--- a/lib/travis/build/script/crystal.rb
+++ b/lib/travis/build/script/crystal.rb
@@ -102,6 +102,7 @@ module Travis
         end
 
         def snap_install_crystal(options)
+          sh.cmd 'travis_apt_get_update'
           sh.cmd %Q(sudo apt-get install -y gcc pkg-config git tzdata libpcre3-dev libevent-dev libyaml-dev libgmp-dev libssl-dev libxml2-dev 2>&1 > /dev/null), echo: true
           sh.cmd %Q(sudo snap install crystal --classic #{options}), echo: true
         end


### PR DESCRIPTION
Must be because the metadata in the image is now stale

https://travis-ci.community/t/unable-to-locate-package-libevent-dev/9608