### PR TITLE
Run debug server in the same process

### DIFF
--- a/lib/travis/build/bash/travis_debug.bash
+++ b/lib/travis/build/bash/travis_debug.bash
@@ -14,7 +14,7 @@ travis_debug_warn() {
   echo -e "${ANSI_YELLOW}travis_debug: $1${ANSI_RESET}" 1>&2
 }
 
-main() {
+travis_debug_main() {
   local QUIET TMATE TMATE_MSG
   export TMATE="tmate -S ${TMATE_SOCKET}"
 
@@ -63,4 +63,4 @@ main() {
   fi
 }
 
-main "${@}"
+travis_debug_main "${@}"

--- a/lib/travis/build/script.rb
+++ b/lib/travis/build/script.rb
@@ -237,10 +237,11 @@ module Travis
         def debug
           if debug_build_via_api?
             sh.echo "Debug build initiated by #{data.debug_options[:created_by]}", ansi: :yellow
+            # Virtualenv, for one, doesn't `export` its adjusted PATH, so must run the debug server in the same process
             if debug_quiet?
-              sh.raw "travis_debug --quiet"
+              sh.raw "source travis_debug --quiet"
             else
-              sh.raw "travis_debug"
+              sh.raw "source travis_debug"
             end
 
             sh.newline


### PR DESCRIPTION
Some tools like Virtualenv don't `export` their adjusted envvars.
As a result, the debug console would otherwise have a different
environment than a normal build.

Resolves https://travis-ci.community/t/debug-mode-triggers-python-environmenterror/8343