### PR TITLE
Download R builds from https://github.com/rstudio/r-builds

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -119,7 +119,7 @@ module Travis
                 os_version = "$(lsb_release -rs | tr -d '.')"
                 r_url = "https://cdn.rstudio.com/r/ubuntu-#{os_version}/pkgs/#{r_filename}"
                 sh.cmd "curl -fLo /tmp/#{r_filename} #{r_url}", retry: true
-                sh.cmd "sudo apt-get install gdebi-core"
+                sh.cmd "sudo apt-get install -y gdebi-core"
                 sh.cmd "sudo gdebi r-#{r_version}_1_amd64.deb"
                 sh.export 'PATH', "/opt/R/#{r_version}/bin:$PATH", echo: false
                 sh.rm "/tmp/#{r_filename}"

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -113,7 +113,7 @@ module Travis
                   "#{optional_apt_pkgs}", retry: true
 
                 r_filename = "r-#{r_version}_1_amd64.deb"
-                os_version = "$(lsb_release -ds | perl -a -e '$F[1] =~ tr/[.]//d; print $F[1]')"
+                os_version = "$(lsb_release -rs | tr -d '.')"
                 r_url = "https://cdn.rstudio.com/r/ubuntu-#{os_version}/pkgs/#{r_filename}"
                 sh.cmd "curl -fLo /tmp/#{r_filename} #{r_url}", retry: true
                 sh.cmd "sudo apt-get install gdebi-core"

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -112,12 +112,13 @@ module Travis
                   'cdbs qpdf texinfo libssh2-1-dev devscripts '\
                   "#{optional_apt_pkgs}", retry: true
 
-                r_filename = "R-#{r_version}-$(lsb_release -cs).xz"
-                r_url = "https://travis-ci.rstudio.org/#{r_filename}"
+                r_filename = "r-#{r_version}_1_amd64.deb"
+                os_version = "$(lsb_release -ds | perl -a -e '$F[1] =~ tr/[.]//d; print $F[1]')"
+                r_url = "https://cdn.rstudio.com/r/ubuntu-#{os_version}/pkgs/#{r_filename}"
                 sh.cmd "curl -fLo /tmp/#{r_filename} #{r_url}", retry: true
-                sh.cmd "tar xJf /tmp/#{r_filename} -C ~"
-                sh.export 'PATH', "${TRAVIS_HOME}/R-bin/bin:$PATH", echo: false
-                sh.export 'LD_LIBRARY_PATH', "${TRAVIS_HOME}/R-bin/lib:$LD_LIBRARY_PATH", echo: false
+                sh.cmd "sudo apt-get install gdebi-core"
+                sh.cmd "sudo gdebi r-#{r_version}_1_amd64.deb"
+                sh.export 'PATH', "/opt/R/#{r_version}/bin:$PATH", echo: false
                 sh.rm "/tmp/#{r_filename}"
 
                 sh.cmd "sudo mkdir -p /usr/local/lib/R/site-library $R_LIBS_USER"

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -120,7 +120,7 @@ module Travis
                 r_url = "https://cdn.rstudio.com/r/ubuntu-#{os_version}/pkgs/#{r_filename}"
                 sh.cmd "curl -fLo /tmp/#{r_filename} #{r_url}", retry: true
                 sh.cmd "sudo apt-get install -y gdebi-core"
-                sh.cmd "sudo gdebi r-#{r_version}_1_amd64.deb"
+                sh.cmd "sudo gdebi --non-interactive r-#{r_version}_1_amd64.deb"
                 sh.export 'PATH', "/opt/R/#{r_version}/bin:$PATH", echo: false
                 sh.rm "/tmp/#{r_filename}"
 

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -67,6 +67,9 @@ module Travis
               sh.echo 'Installing R', ansi: :yellow
               case config[:os]
               when 'linux'
+              if config[:arch] == 'arm64'
+                sh.failure 'ARM architecture not supported'
+              end
                 # This key is added implicitly by the marutter PPA below
                 #sh.cmd 'apt-key adv --keyserver ha.pool.sks-keyservers.net '\
                   #'--recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9', sudo: true

--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -120,7 +120,7 @@ module Travis
                 r_url = "https://cdn.rstudio.com/r/ubuntu-#{os_version}/pkgs/#{r_filename}"
                 sh.cmd "curl -fLo /tmp/#{r_filename} #{r_url}", retry: true
                 sh.cmd "sudo apt-get install -y gdebi-core"
-                sh.cmd "sudo gdebi --non-interactive r-#{r_version}_1_amd64.deb"
+                sh.cmd "sudo gdebi --non-interactive /tmp/#{r_filename}"
                 sh.export 'PATH', "/opt/R/#{r_version}/bin:$PATH", echo: false
                 sh.rm "/tmp/#{r_filename}"
 

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -50,7 +50,7 @@ describe Travis::Build::Script::R, :sexp do
   end
 
   it 'downloads and installs latest R' do
-    should include_sexp [:cmd, %r{^curl.*https://travis-ci\.rstudio\.org/R-4\.0\.0-\$\(lsb_release -cs\)\.xz},
+    should include_sexp [:cmd, %r{^curl.*https://cdn.rstudio.com/r/ubuntu-.*/pkgs/r-4\.0\.0_1_amd64\.deb},
                          assert: true, echo: true, retry: true, timing: true]
   end
 
@@ -104,19 +104,19 @@ describe Travis::Build::Script::R, :sexp do
 
   it 'downloads and installs R 3.1' do
     data[:config][:r] = '3.1'
-    should include_sexp [:cmd, %r{^curl.*https://travis-ci\.rstudio\.org/R-3\.1\.3-\$\(lsb_release -cs\)\.xz},
+    should include_sexp [:cmd, %r{^curl.*https://cdn.rstudio.com/r/ubuntu-.*/pkgs/r-3\.1\.3_1_amd64\.deb},
                          assert: true, echo: true, retry: true, timing: true]
   end
 
   it 'downloads and installs R 3.2' do
     data[:config][:r] = '3.2'
-    should include_sexp [:cmd, %r{^curl.*https://travis-ci\.rstudio\.org/R-3\.2\.5-\$\(lsb_release -cs\)\.xz},
+    should include_sexp [:cmd, %r{^curl.*https://cdn.rstudio.com/r/ubuntu-.*/pkgs/r-3\.2\.5_1_amd64\.deb},
                          assert: true, echo: true, retry: true, timing: true]
   end
 
   it 'downloads and installs R devel' do
     data[:config][:r] = 'devel'
-    should include_sexp [:cmd, %r{^curl.*https://travis-ci\.rstudio\.org/R-devel-\$\(lsb_release -cs\)\.xz},
+    should include_sexp [:cmd, %r{^curl.*https://cdn.rstudio.com/r/ubuntu-.*/pkgs/r-devel_1_amd64\.deb},
                          assert: true, echo: true, retry: true, timing: true]
   end
 


### PR DESCRIPTION
This changes the installation script to use the R builds available at
https://github.com/rstudio/r-builds rather than the custom travis
specific builds we used previously.

This will reduce the maintenance needed specifically for travis.