### PR TITLE
Update sbt-extras in order to use https by default instead of http

### DIFF
--- a/lib/travis/build/script/scala.rb
+++ b/lib/travis/build/script/scala.rb
@@ -11,7 +11,7 @@ module Travis
         }
 
         SBT_PATH = '/usr/local/bin/sbt'
-        SBT_SHA  = '4ad1b8a325f75c1a66f3fd100635da5eb28d9c91'
+        SBT_SHA  = '4d558c88ae6ae240e7a5eedc0cf33cc9e7bd0e58'
         SBT_URL  = "https://raw.githubusercontent.com/paulp/sbt-extras/#{SBT_SHA}/sbt"
 
         def configure

--- a/spec/build/script/scala_spec.rb
+++ b/spec/build/script/scala_spec.rb
@@ -4,7 +4,7 @@ describe Travis::Build::Script::Scala, :sexp do
   let(:data)   { payload_for(:push, :scala) }
   let(:script) { described_class.new(data) }
   let(:sbt_path) { '/usr/local/bin/sbt'}
-  let(:sbt_sha) { '4ad1b8a325f75c1a66f3fd100635da5eb28d9c91'}
+  let(:sbt_sha) { '4d558c88ae6ae240e7a5eedc0cf33cc9e7bd0e58'}
   let(:sbt_url) { "https://build.travis-ci.org/files/sbt"}
 
   before do


### PR DESCRIPTION
Lightbend stopped supporting http for repo.scala-sbt.org
See: https://www.lightbend.com/blog/lightbend-to-require-https-on-repos-starting-august-5-2020