### PR TITLE
exit on error while travis env setup

### DIFF
--- a/lib/travis/build/bash/travis_setup_env.bash
+++ b/lib/travis/build/bash/travis_setup_env.bash
@@ -1,6 +1,7 @@
 #!/bin/bash
 # shellcheck disable=SC1117
-set -e
+set -o errexit
+
 travis_setup_env() {
   export ANSI_RED="\033[31;1m"
   export ANSI_GREEN="\033[32;1m"

--- a/lib/travis/build/bash/travis_setup_env.bash
+++ b/lib/travis/build/bash/travis_setup_env.bash
@@ -1,5 +1,6 @@
+#!/bin/bash
 # shellcheck disable=SC1117
-
+set -o
 travis_setup_env() {
   export ANSI_RED="\033[31;1m"
   export ANSI_GREEN="\033[32;1m"

--- a/lib/travis/build/bash/travis_setup_env.bash
+++ b/lib/travis/build/bash/travis_setup_env.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 # shellcheck disable=SC1117
-set -o
+set -e
 travis_setup_env() {
   export ANSI_RED="\033[31;1m"
   export ANSI_GREEN="\033[32;1m"


### PR DESCRIPTION
customer pointed out that we don't confirm creation of a directory at https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/bash/travis_setup_env.bash#L80 which causes an error to be thrown and build to fail on Bionic. So, we exit on error for any script on travis env setup.