### PR TITLE
Cosmetic adjustments to MATLAB log output

### DIFF
--- a/lib/travis/build/script/matlab.rb
+++ b/lib/travis/build/script/matlab.rb
@@ -29,14 +29,16 @@ module Travis
             sh.echo message, ansi: :green
           end
 
-          # Execute helper script to install runtime dependencies
-          sh.raw "wget -qO- --retry-connrefused #{MATLAB_DEPS_LOCATION}" \
-                 ' | sudo -E bash -s -- $TRAVIS_MATLAB_VERSION'
+          sh.fold 'Setup MATLAB' do
+            # Execute helper script to install runtime dependencies
+            sh.raw "wget -qO- --retry-connrefused #{MATLAB_DEPS_LOCATION}" \
+                  ' | sudo -E bash -s -- $TRAVIS_MATLAB_VERSION'
 
-          # Invoke the ephemeral MATLAB installer that will make a MATLAB available
-          # on the system PATH
-          sh.raw "wget -qO- --retry-connrefused #{MATLAB_INSTALLER_LOCATION}" \
-                 ' | sudo -E bash -s -- --release $TRAVIS_MATLAB_VERSION'
+            # Invoke the ephemeral MATLAB installer that will make a MATLAB available
+            # on the system PATH
+            sh.raw "wget -qO- --retry-connrefused #{MATLAB_INSTALLER_LOCATION}" \
+                  ' | sudo -E bash -s -- --release $TRAVIS_MATLAB_VERSION'
+          end
         end
 
         def script

--- a/lib/travis/build/script/matlab.rb
+++ b/lib/travis/build/script/matlab.rb
@@ -29,7 +29,7 @@ module Travis
             sh.echo message, ansi: :green
           end
 
-          sh.fold 'Setup MATLAB' do
+          sh.fold 'matlab_install' do
             # Execute helper script to install runtime dependencies
             sh.raw "wget -qO- --retry-connrefused #{MATLAB_DEPS_LOCATION}" \
                   ' | sudo -E bash -s -- $TRAVIS_MATLAB_VERSION'

--- a/lib/travis/build/script/matlab.rb
+++ b/lib/travis/build/script/matlab.rb
@@ -7,11 +7,10 @@ module Travis
         MATLAB_START = 'matlab -batch'.freeze
         MATLAB_COMMAND = "assertSuccess(runtests('IncludeSubfolders',true));".freeze
 
-        MATLAB_NOTICE = <<~NOTICE.strip.freeze
-          The MATLAB language is maintained by MathWorks. 
-          If you have any questions or suggestions, please contact MathWorks at
-          continuous-integration@mathworks.com.
-        NOTICE
+        MATLAB_NOTICE = [
+          'The MATLAB language is maintained by MathWorks.',
+          'If you have any questions or suggestions, please contact MathWorks at continuous-integration@mathworks.com.',
+        ]
 
         DEFAULTS = {
           matlab: 'latest'
@@ -26,8 +25,10 @@ module Travis
           super
 
           # Echo support notice
-          sh.echo MATLAB_NOTICE, ansi: :green
-          
+          MATLAB_NOTICE.each do |message|
+            sh.echo message, ansi: :green
+          end
+
           # Execute helper script to install runtime dependencies
           sh.raw "wget -qO- --retry-connrefused #{MATLAB_DEPS_LOCATION}" \
                  ' | sudo -E bash -s -- $TRAVIS_MATLAB_VERSION'
@@ -45,7 +46,7 @@ module Travis
         end
 
         private
-  
+
         def release
           Array(config[:matlab]).first.to_s
         end

--- a/spec/build/script/matlab_spec.rb
+++ b/spec/build/script/matlab_spec.rb
@@ -19,7 +19,9 @@ describe Travis::Build::Script::Matlab, :sexp do
   end
 
   it 'prints the support notice in green' do
-    should include_sexp [:echo, notice, ansi: :green]
+    notice.each do |message|
+      should include_sexp [:echo, message, ansi: :green]
+    end
   end
 
   it 'configures runtime dependencies' do


### PR DESCRIPTION
This PR seeks to correct the formatting inconsistency in the support message for the MATLAB language. 

In addition to that, the log output related to the installation/setup of MATLAB is now collapsable under `matlab_install`

Fellow maintainers: @acampbel @mcafaro
