### PR TITLE
fix template file name for mktemp cmd

### DIFF
--- a/lib/travis/build/bash/travis_setup_env.bash
+++ b/lib/travis/build/bash/travis_setup_env.bash
@@ -76,7 +76,7 @@ travis_setup_env() {
   export TRAVIS_TEST_RESULT=
   export TRAVIS_CMD=
 
-  TRAVIS_TMPDIR="$(mktemp -d 2>/dev/null || mktemp -d -t 'travis_tmp')"
+  TRAVIS_TMPDIR="$(mktemp -d 2>/dev/null || mktemp -d -t travis_tmp.XXXX)"
   mkdir -p "${TRAVIS_TMPDIR}"
   export TRAVIS_TMPDIR
 


### PR DESCRIPTION
TEMPLATE must contain at least 3 consecutive `X's in last component. So, updated template name.