### PR TITLE
tweaks for language-r

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -67,9 +67,13 @@ module Travis
               sh.echo 'Installing R', ansi: :yellow
               case config[:os]
               when 'linux'
-              if config[:arch] == 'arm64'
-                sh.failure 'ARM architecture not supported'
-              end
+                if config[:arch] == 'arm64'
+                  sh.failure 'ARM architecture not supported'
+                end
+                if config[:dist] == 'trusty'
+                  sh.failure '"dist: trusty" is no longer supported for "language: r"'
+                end
+
                 # This key is added implicitly by the marutter PPA below
                 #sh.cmd 'apt-key adv --keyserver ha.pool.sks-keyservers.net '\
                   #'--recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9', sudo: true
@@ -89,11 +93,6 @@ module Travis
                 # Extra PPAs that do not depend on R version
                 sh.cmd 'sudo add-apt-repository -y "ppa:ubuntugis/ppa"'
                 sh.cmd 'sudo add-apt-repository -y "ppa:cran/travis"'
-
-                # Both c2d4u and c2d4u3.5 depend on this ppa for ffmpeg
-                sh.if "$(lsb_release -cs) = 'trusty'" do
-                  sh.cmd 'sudo add-apt-repository -y "ppa:kirillshkrogalev/ffmpeg-next"'
-                end
 
                 # Update after adding all repositories. Retry several
                 # times to work around flaky connection to Launchpad PPAs.
@@ -608,7 +607,7 @@ module Travis
 
         def normalized_r_version(v=Array(config[:r]).first.to_s)
           case v
-          when 'release' then '4.0.0'
+          when 'release' then '4.0.2'
           when 'oldrel' then '3.6.3'
           when '3.0' then '3.0.3'
           when '3.1' then '3.1.3'
@@ -617,7 +616,7 @@ module Travis
           when '3.4' then '3.4.4'
           when '3.5' then '3.5.3'
           when '3.6' then '3.6.3'
-          when '4.0' then '4.0.0'
+          when '4.0' then '4.0.2'
           when 'bioc-devel'
             config[:bioc_required] = true
             config[:bioc_use_devel] = true

--- a/spec/build/script/r_spec.rb
+++ b/spec/build/script/r_spec.rb
@@ -11,7 +11,7 @@ describe Travis::Build::Script::R, :sexp do
 
   it 'normalizes bioc-devel correctly' do
     data[:config][:r] = 'bioc-devel'
-    should include_sexp [:export, ['TRAVIS_R_VERSION', '4.0.0']]
+    should include_sexp [:export, ['TRAVIS_R_VERSION', '4.0.2']]
     should include_sexp [:cmd, %r{install.packages\(\"BiocManager"\)},
                          assert: true, echo: true, timing: true, retry: true]
     should include_sexp [:cmd, %r{BiocManager::install\(version = \"devel\"},
@@ -22,7 +22,7 @@ describe Travis::Build::Script::R, :sexp do
     data[:config][:r] = 'bioc-release'
     should include_sexp [:cmd, %r{install.packages\(\"BiocManager"\)},
                          assert: true, echo: true, timing: true, retry: true]
-    should include_sexp [:export, ['TRAVIS_R_VERSION', '4.0.0']]
+    should include_sexp [:export, ['TRAVIS_R_VERSION', '4.0.2']]
   end
 
   it 'r_packages works with a single package set' do
@@ -50,7 +50,7 @@ describe Travis::Build::Script::R, :sexp do
   end
 
   it 'downloads and installs latest R' do
-    should include_sexp [:cmd, %r{^curl.*https://cdn.rstudio.com/r/ubuntu-.*/pkgs/r-4\.0\.0_1_amd64\.deb},
+    should include_sexp [:cmd, %r{^curl.*https://cdn.rstudio.com/r/ubuntu-.*/pkgs/r-4\.0\.2_1_amd64\.deb},
                          assert: true, echo: true, retry: true, timing: true]
   end
 
@@ -257,7 +257,7 @@ describe Travis::Build::Script::R, :sexp do
     }
     it {
       data[:config][:r] = 'release'
-      should eq("cache-#{CACHE_SLUG_EXTRAS}--R-4.0.0")
+      should eq("cache-#{CACHE_SLUG_EXTRAS}--R-4.0.2")
     }
     it {
       data[:config][:r] = 'oldrel'


### PR DESCRIPTION
As a consequence of https://github.com/travis-ci/travis-build/pull/1941, we have dropped support for trusty (the new cdn does not provide R binaries for trusty). This error makes that more obvious for people that are still using `dist: trusty`.

