### PR TITLE
Show envvar changes made by R installation logic

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -120,7 +120,7 @@ module Travis
                 sh.cmd "curl -fLo /tmp/#{r_filename} #{r_url}", retry: true
                 sh.cmd "sudo apt-get install -y gdebi-core"
                 sh.cmd "sudo gdebi --non-interactive /tmp/#{r_filename}"
-                sh.export 'PATH', "/opt/R/#{r_version}/bin:$PATH", echo: false
+                sh.export 'PATH', "/opt/R/#{r_version}/bin:$PATH"
                 sh.rm "/tmp/#{r_filename}"
 
                 sh.cmd "sudo mkdir -p /usr/local/lib/R/site-library $R_LIBS_USER"


### PR DESCRIPTION
Not seeing them makes diagnosing issues like https://travis-ci.community/t/in-r-version-4-0-0-library-path-not-writable/9744 and https://travis-ci.community/t/r-support-failed-on-xenial/9822 impossible