### PR TITLE
move setup_bioc to install

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -181,7 +181,6 @@ module Travis
                 config[:r_build_args] = config[:r_build_args] + " --no-manual"
               end
 
-              setup_bioc if needs_bioc?
               setup_pandoc if config[:pandoc]
 
               # Removes preinstalled homebrew
@@ -204,6 +203,8 @@ module Travis
           sh.if '! -e DESCRIPTION' do
             sh.failure "No DESCRIPTION file found, user must supply their own install and script steps"
           end
+
+          setup_bioc if needs_bioc?
 
           sh.fold "R-dependencies" do
             sh.echo 'Installing package dependencies', ansi: :yellow


### PR DESCRIPTION
Hopefully fixes: https://travis-ci.community/t/in-r-version-4-0-0-library-path-not-writable/9744

I think the problem is that `setup_bioc` needs envvars defined inside the `export` block, in particular `$R_LIBS_USER`:

https://github.com/travis-ci/travis-build/blob/b0894327fd9f24d401fc2a2934f4ab50e6f1257b/lib/travis/build/script/r.rb#L47-L55

It looks like travis does not set these variables yet during the `configure` stage, which is leading to permission problems when running `setup_bioc`:

```
Installing Bioconductor
$ Rscript -e 'if (!requireNamespace("BiocManager", quietly=TRUE))  
install.packages("BiocManager")
Warning in install.packages("BiocManager") :
  'lib = "/opt/R/4.0.0/lib/R/library"' is not writable
Error in install.packages("BiocManager") : unable to install packages
Execution halted
```

Note that if `$R_LIBS_USER` would have been set, it will try to install there instead of `/opt/R/4.0.0/lib/R/library`.

I think we can fix it by moving `setup_bioc` down into the `install` step (where we also install remotes, devtools, etc, which all work fine).

@jimhester @native-api 