### PR TITLE
Install bioc and requested packages at setup stage

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -189,6 +189,24 @@ module Travis
           end
         end
 
+        def setup
+          super
+
+          setup_bioc if needs_bioc?
+
+          sh.fold "R-packages" do
+            sh.echo 'Installing requested packages', ansi: :yellow
+
+            # Install any declared packages
+            apt_install config[:apt_packages]
+            brew_install config[:brew_packages]
+            r_binary_install config[:r_binary_packages]
+            r_install config[:r_packages]
+            r_install config[:bioc_packages]
+            r_github_install config[:r_github_packages]
+          end
+        end
+
         def announce
           super
           sh.fold 'R-session-info' do
@@ -204,19 +222,8 @@ module Travis
             sh.failure "No DESCRIPTION file found, user must supply their own install and script steps"
           end
 
-          setup_bioc if needs_bioc?
-
           sh.fold "R-dependencies" do
             sh.echo 'Installing package dependencies', ansi: :yellow
-
-            # Install any declared packages
-            apt_install config[:apt_packages]
-            brew_install config[:brew_packages]
-            r_binary_install config[:r_binary_packages]
-            r_install config[:r_packages]
-            r_install config[:bioc_packages]
-            r_github_install config[:r_github_packages]
-
             # Install dependencies for the package we're testing.
             install_deps
           end


### PR DESCRIPTION
This allows the user to override install: without losing this critical part of R build logic.

See https://travis-ci.community/t/in-r-version-4-0-0-library-path-not-writable/9744/22?u=native-api for the user problem that this fixes. I also have trouble checking things out since I cannot get a large part of the logic without a dummy R package or override `install:` which is extremely inconvenient.