### PR TITLE
Allow R packages to install scripts

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -125,6 +125,11 @@ module Travis
 
                 sh.cmd "sudo mkdir -p /usr/local/lib/R/site-library $R_LIBS_USER"
                 sh.cmd 'sudo chmod 2777 /usr/local/lib/R /usr/local/lib/R/site-library $R_LIBS_USER'
+
+                sh.cmd '(R_BIN=$(dirname "$(which Rscript)") && ' \
+                    'sudo chgrp "$(id -g)" "$R_BIN" && ' \
+                    'sudo chmod g+w,o+t "$R_BIN")'
+
               when 'osx'
                 # We want to update, but we don't need the 800+ lines of
                 # output.


### PR DESCRIPTION
Implements option 1 from https://travis-ci.community/t/in-r-version-4-0-0-library-path-not-writable/9744/27?u=native-api.

R has no per-user script directory to complement R_LIBS_USER.
So packages have no option but to install scripts to $R_HOME/bin.
With the `r` Apt package since 4.0, regular users don't have permission
to write there.

The commit allows the current user to create new executables there while
disallowing messing with existing ones.