### PR TITLE
r.rb: use ubuntugis-unstable PPA

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -91,7 +91,7 @@ module Travis
                 end
 
                 # Extra PPAs that do not depend on R version
-                sh.cmd 'sudo add-apt-repository -y "ppa:ubuntugis/ppa"'
+                sh.cmd 'sudo add-apt-repository -y "ppa:ubuntugis/ubuntugis-unstable"'
                 sh.cmd 'sudo add-apt-repository -y "ppa:cran/travis"'
 
                 # Update after adding all repositories. Retry several


### PR DESCRIPTION
GDAL 3 and PROJ >= 6 are needed more and more for geospatial R packages. See e.g. [here](https://www.mail-archive.com/r-sig-geo@r-project.org/msg18071.html) for R. Bivand’s recent note on this for the `rgdal` package.

For Bionic (with `dist: bionic` in `.travis.yml`) those versions can _only_ be obtained by adding the ubuntugis-**unstable** [PPA](https://launchpad.net/~ubuntugis/+archive/ubuntu/ubuntugis-unstable). (Moreover they are not available as debian packages for Xenial)

The PPA used on Travis for R package checking is the 'stable' ubuntugis PPA. The 'unstable' PPA, with more recent versions, is actually the recommended one, e.g. [by GRASS](https://grass.osgeo.org/download/linux/), [by QGIS](https://qgis.org/nl/site/forusers/alldownloads.html#debian-ubuntu) and by several r-spatial tutorials for R, such as [this](https://geocompr.github.io/post/2020/installing-r-spatial-ubuntu/) one.

@jeroen @jimhester I'm not familiar with the source code of Travis script, so not 100% sure if this tweak is all that's needed to switch the PPA.

(FYI @robinlovelace)

This topic has some relation to https://travis-ci.community/t/support-for-building-r-project-on-ubuntu-focal-20-04-or-bionic-18-04/9622.