### PR TITLE
use r devel for bioc-devel

### DIFF
--- a/lib/travis/build/script/r.rb
+++ b/lib/travis/build/script/r.rb
@@ -621,8 +621,8 @@ module Travis
           when 'bioc-devel'
             config[:bioc_required] = true
             config[:bioc_use_devel] = true
-            config[:r] = 'release'
-            normalized_r_version('release')
+            config[:r] = 'devel'
+            normalized_r_version('devel')
           when 'bioc-release'
             config[:bioc_required] = true
             config[:bioc_use_devel] = false


### PR DESCRIPTION
This updates Travis to use the appropriate version of R with the Bioconductor release.

Also, R release should be `4.0.3`. I didn't change it but it should be changed. 
Thanks!
@BanzaiMan @jimhester @jeroen 