### PR TITLE
Updates sbt-extras version to current master

### DIFF
--- a/lib/travis/build/script/scala.rb
+++ b/lib/travis/build/script/scala.rb
@@ -11,7 +11,7 @@ module Travis
         }
 
         SBT_PATH = '/usr/local/bin/sbt'
-        SBT_SHA  = '4d558c88ae6ae240e7a5eedc0cf33cc9e7bd0e58'
+        SBT_SHA  = '6db3d3d1c38082dd4c49cce9933738d9bff50065'
         SBT_URL  = "https://raw.githubusercontent.com/paulp/sbt-extras/#{SBT_SHA}/sbt"
 
         def configure

--- a/spec/build/script/scala_spec.rb
+++ b/spec/build/script/scala_spec.rb
@@ -4,7 +4,7 @@ describe Travis::Build::Script::Scala, :sexp do
   let(:data)   { payload_for(:push, :scala) }
   let(:script) { described_class.new(data) }
   let(:sbt_path) { '/usr/local/bin/sbt'}
-  let(:sbt_sha) { '4d558c88ae6ae240e7a5eedc0cf33cc9e7bd0e58'}
+  let(:sbt_sha) { '6db3d3d1c38082dd4c49cce9933738d9bff50065'}
   let(:sbt_url) { "https://build.travis-ci.org/files/sbt"}
 
   before do


### PR DESCRIPTION
The old version is broken for sbt versions starting from 1.4.9

See https://travis-ci.community/t/scala-build-broken-for-sbt-1-4-9/11284

Also: https://github.com/scala/scala-dev/issues/765