### PR TITLE
Julia: Updata version 1 to point to version 1.6.

### DIFF
--- a/lib/travis/build/script/julia.rb
+++ b/lib/travis/build/script/julia.rb
@@ -184,7 +184,7 @@ module Travis
               url = "julialang-s3.julialang.org/bin/#{osarch}/#{$1}/julia-#{$1}-latest-#{ext}"
             when '1'
               # TODO: create a permalink to latest 1.y.z
-              url = "julialang-s3.julialang.org/bin/#{osarch}/1.5/julia-1.5-latest-#{ext}"
+              url = "julialang-s3.julialang.org/bin/#{osarch}/1.6/julia-1.6-latest-#{ext}"
             else
               sh.failure "Unknown Julia version: #{julia_version}"
             end


### PR DESCRIPTION
Julia version 1.6 was released on March 24 2021.
This updates the version identifier "1" which points to the latest stable release to point to Julia version 1.6-latest instead of 1.5-latest.