### PR TITLE
Update repository for crystal to OBS

### DIFF
--- a/lib/travis/build/script/crystal.rb
+++ b/lib/travis/build/script/crystal.rb
@@ -101,9 +101,9 @@ module Travis
             crystal_version ||= "latest"
           end
 
-          # Add repo metadata signign key (shared bintray signing key)
-          sh.cmd %q(sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 379CE192D401AB61)
-          sh.cmd %Q(echo "deb https://dl.bintray.com/crystal/deb all #{crystal_channel}" | sudo tee /etc/apt/sources.list.d/crystal.list)
+          # Add repo metadata signign key
+          sh.cmd %q(curl -fsSL https://download.opensuse.org/repositories/devel:languages:crystal/Debian_10/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/crystal.gpg > /dev/null)
+          sh.cmd %Q(echo "deb http://download.opensuse.org/repositories/devel:/languages:/crystal/Debian_10/ /" | sudo tee /etc/apt/sources.list.d/crystal.list)
 
           sh.cmd 'travis_apt_get_update'
           if crystal_version == "latest"

--- a/spec/build/script/crystal_spec.rb
+++ b/spec/build/script/crystal_spec.rb
@@ -31,7 +31,7 @@ describe Travis::Build::Script::Crystal, :sexp do
   context "versions" do
     it "installs latest linux release by default" do
       data[:config][:os] = "linux"
-      should include_sexp [:cmd, %q(echo "deb https://dl.bintray.com/crystal/deb all stable" | sudo tee /etc/apt/sources.list.d/crystal.list)]
+      should include_sexp [:cmd, %q(echo "deb http://download.opensuse.org/repositories/devel:/languages:/crystal/Debian_10/ /" | sudo tee /etc/apt/sources.list.d/crystal.list)]
       should include_sexp [:cmd, "sudo apt-get install -y crystal"]
     end
 
@@ -43,7 +43,7 @@ describe Travis::Build::Script::Crystal, :sexp do
     it "installs latest stable linux release (with crystal: latest)" do
       data[:config][:os] = "linux"
       data[:config][:crystal] = "latest"
-      should include_sexp [:cmd, %q(echo "deb https://dl.bintray.com/crystal/deb all stable" | sudo tee /etc/apt/sources.list.d/crystal.list)]
+      should include_sexp [:cmd, %q(echo "deb http://download.opensuse.org/repositories/devel:/languages:/crystal/Debian_10/ /" | sudo tee /etc/apt/sources.list.d/crystal.list)]
       should include_sexp [:cmd, "sudo apt-get install -y crystal"]
     end
 
@@ -51,7 +51,7 @@ describe Travis::Build::Script::Crystal, :sexp do
       it "installs latest stable linux release (with crystal: #{channel})" do
         data[:config][:os] = "linux"
         data[:config][:crystal] = channel
-        should include_sexp [:cmd, %Q(echo "deb https://dl.bintray.com/crystal/deb all #{channel}" | sudo tee /etc/apt/sources.list.d/crystal.list)]
+        should include_sexp [:cmd, %Q(echo "deb http://download.opensuse.org/repositories/devel:/languages:/crystal/Debian_10/ /" | sudo tee /etc/apt/sources.list.d/crystal.list)]
         should include_sexp [:cmd, "sudo apt-get install -y crystal"]
       end
 
@@ -59,7 +59,7 @@ describe Travis::Build::Script::Crystal, :sexp do
         it "installs specific channel/version linux release (with crystal: #{channel}/#{version})" do
           data[:config][:os] = "linux"
           data[:config][:crystal] = "#{channel}/#{version}"
-          should include_sexp [:cmd, %Q(echo "deb https://dl.bintray.com/crystal/deb all #{channel}" | sudo tee /etc/apt/sources.list.d/crystal.list)]
+          should include_sexp [:cmd, %Q(echo "deb http://download.opensuse.org/repositories/devel:/languages:/crystal/Debian_10/ /" | sudo tee /etc/apt/sources.list.d/crystal.list)]
           should include_sexp [:cmd, %Q(sudo apt-get install -y crystal="#{version}*")]
         end
       end
@@ -69,7 +69,7 @@ describe Travis::Build::Script::Crystal, :sexp do
       it "installs specific stable version release (with crystal: #{version})" do
         data[:config][:os] = "linux"
         data[:config][:crystal] = version
-        should include_sexp [:cmd, %Q(echo "deb https://dl.bintray.com/crystal/deb all stable" | sudo tee /etc/apt/sources.list.d/crystal.list)]
+        should include_sexp [:cmd, %Q(echo "deb http://download.opensuse.org/repositories/devel:/languages:/crystal/Debian_10/ /" | sudo tee /etc/apt/sources.list.d/crystal.list)]
         should include_sexp [:cmd, %Q(sudo apt-get install -y crystal="#{version}*")]
       end
     end


### PR DESCRIPTION
Crystal uses new package repositories, bintray is no longer available
See https://crystal-lang.org/2021/04/30/new-apt-and-rpm-repositories.html

/cc https://github.com/crystal-lang/crystal/issues/10626