### PR TITLE
Disable Homebrew autoupdate, too, if the user disabled update

### DIFF
--- a/lib/travis/build/addons/homebrew.rb
+++ b/lib/travis/build/addons/homebrew.rb
@@ -28,6 +28,7 @@ module Travis
               sh.cmd "brew_ruby=#{first_ruby_2_3_plus}"
             end
             update_homebrew if update_homebrew?
+            sh.cmd "export HOMEBREW_NO_AUTO_UPDATE=1" unless update_homebrew?
             install_homebrew_packages
           end
         end


### PR DESCRIPTION
https://travis-ci.community/t/cannot-avoid-brew-update/12033

!! Note that I cannot test this change due to no access to the staging environment.
(Adding an integration test wouldn't help, either, since integration tests are only run in Linux containers while the change is for MacOS.)