### PR TITLE
Suppress the output

### DIFF
--- a/lib/travis/build/script/node_js.rb
+++ b/lib/travis/build/script/node_js.rb
@@ -160,7 +160,7 @@ module Travis
           end
 
           def npm_disable_spinner
-            sh.cmd 'npm config set spin false || true', echo: false, timing: false
+            sh.cmd 'npm config set spin false --silent || true', echo: false, timing: false
           end
 
           def npm_disable_strict_ssl

--- a/spec/build/script/node_js_spec.rb
+++ b/spec/build/script/node_js_spec.rb
@@ -112,7 +112,7 @@ describe Travis::Build::Script::NodeJs, :sexp do
   end
 
   it 'disables the npm spinner' do
-    should include_sexp [:cmd, 'npm config set spin false || true', assert: true]
+    should include_sexp [:cmd, 'npm config set spin false --silent || true', assert: true]
   end
 
   describe 'if package.json exists' do


### PR DESCRIPTION
NPM v9 doesn't support spin so logs show an error line, this would suppress the error output from the logs.