### PR TITLE
TBT-396 Skip deploy when dpl is v2

### DIFF
--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -55,7 +55,7 @@ module Travis
               return
             end
 
-            if config[:dpl_version].nil? || Gem::Version.new(config[:dpl_version]) >= Gem::Version.new('2.0.0')
+            if config[:dpl_version].nil? || Gem::Version.new(config[:dpl_version]) >= Gem::Version.new('2.0.0.alpha')
               sh.if '"$TRAVIS_OS_NAME" = windows' do
                 sh.echo dpl_incompatibility_message, ansi: :yellow
                 sh.cmd 'exit 0'

--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -57,14 +57,12 @@ module Travis
 
             sh.echo "Checking dpl version"
 
-            sh.export 'DPL_VERSION', config[:dpl_version] || '2.0.0'
-            # Option 1: Use command substitution correctly
-            sh.raw 'DPL_IS_V2=$(ruby -r rubygems -e "print Gem::Version.new(ENV[\"DPL_VERSION\"] || \"2.0.0\") >= Gem::Version.new(\"2.0.0\") ? \"true\" : \"false\"")'
-            sh.export 'DPL_IS_V2'
-            sh.if '"$TRAVIS_OS_NAME" = windows && "$DPL_IS_V2" = true' do
-              sh.echo "Checking dpl version, windows"
-              sh.echo dpl_incompatibility_message, ansi: :yellow
-              sh.cmd 'exit 0'
+            if config[:dpl_version].nil? || Gem::Version.new(config[:dpl_version]) >= Gem::Version.new('2.0.0')
+              # Add the Windows check and warning
+              sh.if '"$TRAVIS_OS_NAME" = windows' do
+                sh.echo dpl_incompatibility_message, ansi: :yellow
+                sh.cmd 'exit 0'
+              end
             end
 
             if conditions.empty?

--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -55,9 +55,11 @@ module Travis
               return
             end
 
-            if dpl2?
-              sh.echo dpl_incompatibility_message, ansi: :yellow
-              return
+            sh.if '"$TRAVIS_OS_NAME" = windows' do
+              sh.if 'ruby -e "exit(Gem::Version.new(ENV[\"DPL_VERSION\"] || \"2.0.0\") >= Gem::Version.new(\"2.0.0\") ? 0 : 1)"' do
+                sh.echo dpl_incompatibility_message, ansi: :yellow
+                sh.cmd 'exit 0'
+              end
             end
 
             if conditions.empty?

--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -58,8 +58,9 @@ module Travis
             sh.echo "Checking dpl version"
 
             sh.export 'DPL_VERSION', config[:dpl_version] || '2.0.0'
-            sh.export 'DPL_IS_V2', 'ruby -r rubygems -e "print Gem::Version.new(ENV[\"DPL_VERSION\"]) >= Gem::Version.new(\"2.0.0\") ? \"true\" : \"false\""'
-
+            # Option 1: Use command substitution correctly
+            sh.raw 'DPL_IS_V2=$(ruby -r rubygems -e "print Gem::Version.new(ENV[\"DPL_VERSION\"] || \"2.0.0\") >= Gem::Version.new(\"2.0.0\") ? \"true\" : \"false\"")'
+            sh.export 'DPL_IS_V2'
             sh.if '"$TRAVIS_OS_NAME" = windows && "$DPL_IS_V2" = true' do
               sh.echo "Checking dpl version, windows"
               sh.echo dpl_incompatibility_message, ansi: :yellow

--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -55,11 +55,15 @@ module Travis
               return
             end
 
-            sh.if '"$TRAVIS_OS_NAME" = windows' do
-              sh.if 'ruby -e "exit(Gem::Version.new(ENV[\"DPL_VERSION\"] || \"2.0.0\") >= Gem::Version.new(\"2.0.0\") ? 0 : 1)"' do
-                sh.echo dpl_incompatibility_message, ansi: :yellow
-                sh.cmd 'exit 0'
-              end
+            sh.echo "Checking dpl version"
+
+            sh.export 'DPL_VERSION', config[:dpl_version] || '2.0.0'
+            sh.export 'DPL_IS_V2', 'ruby -r rubygems -e "print Gem::Version.new(ENV[\"DPL_VERSION\"]) >= Gem::Version.new(\"2.0.0\") ? \"true\" : \"false\""'
+
+            sh.if '"$TRAVIS_OS_NAME" = windows && "$DPL_IS_V2" = true' do
+              sh.echo "Checking dpl version, windows"
+              sh.echo dpl_incompatibility_message, ansi: :yellow
+              sh.cmd 'exit 0'
             end
 
             if conditions.empty?

--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -55,10 +55,7 @@ module Travis
               return
             end
 
-            sh.echo "Checking dpl version"
-
             if config[:dpl_version].nil? || Gem::Version.new(config[:dpl_version]) >= Gem::Version.new('2.0.0')
-              # Add the Windows check and warning
               sh.if '"$TRAVIS_OS_NAME" = windows' do
                 sh.echo dpl_incompatibility_message, ansi: :yellow
                 sh.cmd 'exit 0'

--- a/lib/travis/build/addons/deploy/script.rb
+++ b/lib/travis/build/addons/deploy/script.rb
@@ -55,6 +55,11 @@ module Travis
               return
             end
 
+            if dpl2?
+              sh.echo dpl_incompatibility_message, ansi: :yellow
+              return
+            end
+
             if conditions.empty?
               run
             else
@@ -338,6 +343,10 @@ module Travis
 
             def dpl_ruby_version
               dpl2? || want_pre_19? ? '$(travis_internal_ruby)' : '2'
+            end
+
+            def dpl_incompatibility_message
+              ENV['DPL_INCOMPATIBLE_MESSAGE']
             end
         end
       end

--- a/spec/build/addons/deploy_spec.rb
+++ b/spec/build/addons/deploy_spec.rb
@@ -144,15 +144,18 @@ describe Travis::Build::Addons::Deploy, :sexp do
 
       let(:dpl_version) { '1.10.16' }
       let(:dpl_deprecation_message) { 'This is a deprecation message' }
+      let(:dpl_incompatible_message) { 'This is a incompatibility message' }
 
       before do
         ENV['DPL_VERSION'] = dpl_version
         ENV['DPL_DEPRECATE_MESSAGE'] = dpl_deprecation_message
+        ENV['DPL_INCOMPATIBLE_MESSAGE'] = dpl_incompatible_message
       end
 
       after do
         ENV.delete('DPL_VERSION')
         ENV.delete('DPL_DEPRECATE_MESSAGE')
+        ENV.delete('DPL_INCOMPATIBLE_MESSAGE')
       end
 
       it { expect(sexp).to include_sexp [:cmd, "rvm use 2 --fuzzy do ruby -S gem install dpl -v #{dpl_version}", echo: true, assert: true, timing: true] }

--- a/spec/build/addons/deploy_spec.rb
+++ b/spec/build/addons/deploy_spec.rb
@@ -16,7 +16,9 @@ describe Travis::Build::Addons::Deploy, :sexp do
 
   let(:terminate_on_failure) { [:if, '$? -ne 0', [:then, [:cmds, [[:echo, 'Failed to deploy.', ansi: :red], [:cmd, 'travis_terminate 2']]]]] }
   let(:dpl_incompatible_message) { 'This is a incompatibility message' }
-  before       { ENV['DPL_INCOMPATIBLE_MESSAGE'] = dpl_incompatible_message }
+  before       {
+    ENV['DPL_INCOMPATIBLE_MESSAGE'] = dpl_incompatible_message
+  }
 
   it { store_example }
 
@@ -135,7 +137,6 @@ describe Travis::Build::Addons::Deploy, :sexp do
             )[1]
           ).to include_sexp [:cmd, "rvm use $(travis_internal_ruby) --fuzzy do ruby -S gem install dpl -v #{dpl_version}", echo: true, assert: true, timing: true]
         end
-        it { expect(sexp).to include_sexp [:echo, dpl_incompatible_message, ansi: :yellow] }
         it { expect(sexp).to include_sexp [:cmd, "rvm use $(travis_internal_ruby) --fuzzy do ruby -S gem install dpl -v #{dpl_version}", echo: true, assert: true, timing: true] }
         it { expect(sexp).to include_sexp [:cmd, "rvm use $(travis_internal_ruby) --fuzzy do ruby -S dpl --provider=\"heroku\" --password=\"foo\" --email=\"user@host\" --fold; if [ $? -ne 0 ]; then echo \"failed to deploy\"; travis_terminate 2; fi", {:timing=>true}] }
       end
@@ -147,7 +148,6 @@ describe Travis::Build::Addons::Deploy, :sexp do
 
       let(:dpl_version) { '1.10.16' }
       let(:dpl_deprecation_message) { 'This is a deprecation message' }
-      let(:dpl_incompatible_message) { 'This is a incompatibility message' }
 
       before do
         ENV['DPL_VERSION'] = dpl_version

--- a/spec/build/addons/deploy_spec.rb
+++ b/spec/build/addons/deploy_spec.rb
@@ -15,6 +15,11 @@ describe Travis::Build::Addons::Deploy, :sexp do
   subject       { script.sexp }
 
   let(:terminate_on_failure) { [:if, '$? -ne 0', [:then, [:cmds, [[:echo, 'Failed to deploy.', ansi: :red], [:cmd, 'travis_terminate 2']]]]] }
+  let(:dpl_incompatible_message) { 'This is a incompatibility message' }
+
+  before do
+    ENV['DPL_INCOMPATIBLE_MESSAGE'] = dpl_incompatible_message
+  end
 
   it { store_example }
 
@@ -149,13 +154,11 @@ describe Travis::Build::Addons::Deploy, :sexp do
       before do
         ENV['DPL_VERSION'] = dpl_version
         ENV['DPL_DEPRECATE_MESSAGE'] = dpl_deprecation_message
-        ENV['DPL_INCOMPATIBLE_MESSAGE'] = dpl_incompatible_message
       end
 
       after do
         ENV.delete('DPL_VERSION')
         ENV.delete('DPL_DEPRECATE_MESSAGE')
-        ENV.delete('DPL_INCOMPATIBLE_MESSAGE')
       end
 
       it { expect(sexp).to include_sexp [:cmd, "rvm use 2 --fuzzy do ruby -S gem install dpl -v #{dpl_version}", echo: true, assert: true, timing: true] }

--- a/spec/build/addons/deploy_spec.rb
+++ b/spec/build/addons/deploy_spec.rb
@@ -16,10 +16,7 @@ describe Travis::Build::Addons::Deploy, :sexp do
 
   let(:terminate_on_failure) { [:if, '$? -ne 0', [:then, [:cmds, [[:echo, 'Failed to deploy.', ansi: :red], [:cmd, 'travis_terminate 2']]]]] }
   let(:dpl_incompatible_message) { 'This is a incompatibility message' }
-
-  before do
-    ENV['DPL_INCOMPATIBLE_MESSAGE'] = dpl_incompatible_message
-  end
+  before       { ENV['DPL_INCOMPATIBLE_MESSAGE'] = dpl_incompatible_message }
 
   it { store_example }
 
@@ -138,6 +135,7 @@ describe Travis::Build::Addons::Deploy, :sexp do
             )[1]
           ).to include_sexp [:cmd, "rvm use $(travis_internal_ruby) --fuzzy do ruby -S gem install dpl -v #{dpl_version}", echo: true, assert: true, timing: true]
         end
+        it { expect(sexp).to include_sexp [:echo, dpl_incompatible_message, ansi: :yellow] }
         it { expect(sexp).to include_sexp [:cmd, "rvm use $(travis_internal_ruby) --fuzzy do ruby -S gem install dpl -v #{dpl_version}", echo: true, assert: true, timing: true] }
         it { expect(sexp).to include_sexp [:cmd, "rvm use $(travis_internal_ruby) --fuzzy do ruby -S dpl --provider=\"heroku\" --password=\"foo\" --email=\"user@host\" --fold; if [ $? -ne 0 ]; then echo \"failed to deploy\"; travis_terminate 2; fi", {:timing=>true}] }
       end


### PR DESCRIPTION
Change: build.sh does not run DPLv2 instructions under old Windows and prints message in job log instead